### PR TITLE
Code checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,15 @@
+TOP = .
+include $(TOP)/build.mk
+
 SUB_DIRS = utils/fabric-ccenv-sgx ercc ecc_enclave ecc tlcc_enclave tlcc
 
-all clean test:
+all build test clean :
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@;)
+
+checks: linter
+
+linter:
+	@echo "LINT: Running code checks.."
+	@./scripts/golinter.sh
+	@./scripts/cpplinter.sh
+

--- a/build.mk
+++ b/build.mk
@@ -4,11 +4,11 @@ include $(TOP)/config.mk
 -include $(TOP)/config.override.mk
 
 .PHONY: all
-#all: build check test integration
-all: build test
+#all: build checks test integration
+all: build checks test
 
 .PHONY: build
-#.PHONY: check
+.PHONY: checks
 .PHONY: test
 #.PHONY: integration
 .PHONY: clean

--- a/ecc/crypto/ecdsa.go
+++ b/ecc/crypto/ecdsa.go
@@ -113,7 +113,7 @@ func EnclavePk2ECDSAPK(input []byte) (*ecdsa.PublicKey, error) {
 		return nil, fmt.Errorf("Public key not valid (Point not on curve)")
 	}
 
-	return &ecdsa.PublicKey{curve, x, y}, nil
+	return &ecdsa.PublicKey{Curve: curve, X: x, Y: y}, nil
 }
 
 // MarshallEnclavePk converts sgx format Big endian to DER-encoded PKIX format

--- a/ecc/crypto/enc_test.go
+++ b/ecc/crypto/enc_test.go
@@ -32,13 +32,12 @@ func TestDH(t *testing.T) {
 	enclavePriv, err := ecdsa.GenerateKey(p256, rand.Reader)
 	enclavePub, ok := enclavePriv.Public().(*ecdsa.PublicKey)
 	if !ok {
-		panic("error: cast")
+		t.Error("cannot cast ecdsa pub key", err)
 	}
 
 	priv, pub, err := GenKeyPair()
 	if err != nil {
-		fmt.Errorf("Can not gen key pair")
-		t.FailNow()
+		t.Error("cannot generate key pair", err)
 	}
 	pubBytes := make([]byte, 0)
 	pubBytes = append(pubBytes, pub.X.Bytes()...)

--- a/ercc/attestation/ias.go
+++ b/ercc/attestation/ias.go
@@ -25,10 +25,11 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
 )
 
 // intel verification key

--- a/ercc/attestation/ias_test.go
+++ b/ercc/attestation/ias_test.go
@@ -24,6 +24,7 @@ import (
 const enclavePK = `MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE9lPD9QkW9oxWlFvwABrmseYAVvoBvvmTt3jzV0sdASR2KDDQPvz8EcyqfomEOTwSz7E+mISktMxYqofRr+4Yw==`
 const enclavePkHash = `qpEqqBaEkNz9bTO77QK8+CLbvaEN1NATs7ajRTzq70k=`
 const quote = `AgAAAG4NAAAEAAQAAAAAACVC+Q1jMSwdovbiGHbw44nMDb+CvAvF0FJF/38NWjOqAgIC/wEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAJiu1hyR8lijfGjtSUMpdpVkfse75gCMwRGwoSZQ6+uRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD3TvjLWa36sT/kCIRYXhtYoRQ61x2u48Q16bzoq8w6egAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAIAAFXdt6ObnofTxKVhK9Eafot/LsUGgr4546W34JUey7aqo9b6mpeP3X6W/DMIc1JbIXpFd5+mHWP+R7swgSEYNg+RUVbjkZ38nOJHzIl0E7Dgxs8X8iilH+hxpcPiYQphpIcBS5NUCmDn6Wsz/I+Dbpbt3e2G74WFPLHqDn+JHva5vtaYHd7cAfmPIhZZXXMCQJ8um5Jcer4L16VOugt8LEE0i3FqLb0khMYUHmEsqWuh1Fss5bNUuRDqotz6XTBq0uQ+nCfzv9ZsT2CDihsuQTzgU0BiZZuf06Aw9NQdywg+vTZoqyWw0Ca/jsAt+OpbQeQzDoH3HAvnaRvRByozHqKQ1Z83vVny2DQPVwWm6hxIEUCDVE2A/fkbo+UjR12fD8XWUw3xXfd6Dob9N2gBAAB1NRKH8uhAp94KvF/EF76xtBOYnlpAkbv4pYsmJfWkt0CtKtt/lvMQqkmZwSi8LQ93XBiAdVEKt255ycfFxcmAHPFPrjwHMb0/5wKNXa9vyBlgJ63tU/8U1JxujZ6QdS05xiQbKb+l2y6Nm++iw1Ba7BBJgQR+xDBud/VMjjLI3/nMlA9JTpVw9sSTsWdqHzA4bJm2P7fxkxL4wUYe6w+1uWGnT8XFwuJOfw1bUKZWlGZCOe8iLiPmDOmKUegpiLy0wY73gk+5bJhq1L8b4EXJMoSVoS4JgzYajh8oEBaUheiR4ze8sD9KuF0y+dfQklcMKdONyXMcI8QcZfj19iQy2FvXY8Ca0AoBkQMk4bn49e19ePChDUhrk7ynGGy5d9Wo8g3aNZLNWol5LuwCduTYv83xbHeKDkEsvk23m5NiXlVnDo6Pwu+32w57sX4K4CcojQZvJRYfFUuRCoN05TY0oJ0qvvZ1pAEAQAuBfOucbX6QZZ4qPcMR`
+const apiKey = "dummyAPiKey"
 
 // TODO: below might have to be fixed for changes related to new IAS auth method (issue #47, PR #49).
 // However, i have no idea where NewIASCredentialProviderFromConfig comes from and
@@ -31,7 +32,6 @@ const quote = `AgAAAG4NAAAEAAQAAAAAACVC+Q1jMSwdovbiGHbw44nMDb+CvAvF0FJF/38NWjOqA
 func TestRequestAttestationReport(t *testing.T) {
 
 	ias := NewIAS()
-	credis, _ := NewIASCredentialProviderFromConfig()
 	verifier := VerifierImpl{}
 
 	quoteAsBytes, err := base64.StdEncoding.DecodeString(quote)
@@ -40,15 +40,8 @@ func TestRequestAttestationReport(t *testing.T) {
 		t.Errorf(jsonResp)
 	}
 
-	// get ercc client cert for IAS
-	cert, err := credis.GetIASClientCert()
-	if err != nil {
-		jsonResp := "{\"Error\":\" Can not retrieve IAS client cert from ledger: " + err.Error() + " \"}"
-		t.Errorf(jsonResp)
-	}
-
 	// send quote to intel for verification
-	attestationReport, err := ias.RequestAttestationReport(cert, quoteAsBytes)
+	attestationReport, err := ias.RequestAttestationReport(apiKey, quoteAsBytes)
 	if err != nil {
 		jsonResp := "{\"Error\":\" Error while retrieving attestation report: " + err.Error() + "\"}"
 		t.Errorf(jsonResp)

--- a/ercc/ercc_test.go
+++ b/ercc/ercc_test.go
@@ -43,7 +43,7 @@ func TestEnclaveRegistry_Init(t *testing.T) {
 func TestEnclaveRegistry_Register(t *testing.T) {
 	ercc := NewTestErcc()
 	stub := shim.NewMockStub("ercc", ercc)
-	stub.Decorations["apiKey"] = []byte(mock.MOCK_ApiKey)
+	stub.Decorations["apiKey"] = mock.MOCK_API_KEY[:]
 
 	// Init
 	th.CheckInit(t, stub, [][]byte{})
@@ -56,7 +56,7 @@ func TestEnclaveRegistry_Register(t *testing.T) {
 func TestEnclaveRegistry_GetAttestationReport(t *testing.T) {
 	ercc := NewTestErcc()
 	stub := shim.NewMockStub("ercc", ercc)
-	stub.Decorations["apiKey"] = []byte(mock.MOCK_ApiKey)
+	stub.Decorations["apiKey"] = mock.MOCK_API_KEY[:]
 
 	// Init
 	th.CheckInit(t, stub, [][]byte{})

--- a/scripts/cpplinter.sh
+++ b/scripts/cpplinter.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# TODO Implement me
+

--- a/scripts/golinter.sh
+++ b/scripts/golinter.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright Greg Haskins All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+# place the Go build cache directory into the default build tree if it exists
+#if [ -d "${GOPATH}/src/github.com/hyperledger/fabric/.build" ]; then
+#    export GOCACHE="${GOPATH}/src/github.com/hyperledger/fabric/.build/go-cache"
+#fi
+
+# install goimports if not present
+go get golang.org/x/tools/cmd/goimports
+
+fabric_dir="$(cd "$(dirname "$0")/.." && pwd)"
+source_dirs=$(go list -f '{{.Dir}}' ./... | sed s,"${fabric_dir}".,,g | cut -f 1 -d / | sort -u)
+
+echo "Checking with gofmt"
+OUTPUT="$(gofmt -l -s ${source_dirs})"
+if [ -n "$OUTPUT" ]; then
+    echo "The following files contain gofmt errors"
+    echo "$OUTPUT"
+    echo "The gofmt command 'gofmt -l -s -w' must be run for these files"
+    exit 1
+fi
+
+echo "Checking with goimports"
+OUTPUT="$(goimports -l ${source_dirs} | grep -Ev '(^|/)testdata/' || true)"
+if [ -n "$OUTPUT" ]; then
+    echo "The following files contain goimports errors"
+    echo $OUTPUT
+    echo "The goimports command 'goimports -l -w' must be run for these files"
+    exit 1
+fi
+
+# Now that context is part of the standard library, we should use it
+# consistently. The only place where the legacy golang.org version should be
+# referenced is in the generated protos.
+echo "Checking for golang.org/x/net/context"
+context_whitelist=(
+    "^github.com/hyperledger/fabric/protos(:|/.*:)"
+    "^github.com/hyperledger/fabric/orderer/common/broadcast/mock:"
+    "^github.com/hyperledger/fabric/common/grpclogging/fakes:"
+    "^github.com/hyperledger/fabric/common/grpclogging/testpb:"
+    "^github.com/hyperledger/fabric/common/grpcmetrics/fakes:"
+    "^github.com/hyperledger/fabric/common/grpcmetrics/testpb:"
+)
+TEMPLATE='{{with $d := .}}{{range $d.Imports}}{{ printf "%s:%s " $d.ImportPath . }}{{end}}{{end}}'
+OUTPUT="$(go list -f "$TEMPLATE" ./... | grep -Ev $(IFS='|' ; echo "${context_whitelist[*]}") | grep 'golang.org/x/net/context' | cut -f1 -d:)"
+if [ -n "$OUTPUT" ]; then
+    echo "The following packages import golang.org/x/net/context instead of context"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo "Checking with go vet"
+PRINTFUNCS="Print,Printf,Info,Infof,Warning,Warningf,Error,Errorf,Critical,Criticalf,Sprint,Sprintf,Log,Logf,Panic,Panicf,Fatal,Fatalf,Notice,Noticef,Wrap,Wrapf,WithMessage"
+OUTPUT="$(go vet -all -printfuncs $PRINTFUNCS ./...)"
+if [ -n "$OUTPUT" ]; then
+    echo "The following files contain go vet errors"
+    echo $OUTPUT
+    exit 1
+fi

--- a/tlcc_enclave/generate_protos.sh
+++ b/tlcc_enclave/generate_protos.sh
@@ -2,7 +2,7 @@
 
 # set -eux
 
-FABRIC_PATH=${FABRIC_PATH-~/fabric}
+FABRIC_PATH=${FABRIC_PATH-../../../hyperledger/fabric}
 NANOPB_PATH=${NANOPB_PATH-~/nanopb}
 
 PROTOC_OPTS="--plugin=protoc-gen-nanopb=$NANOPB_PATH/generator/protoc-gen-nanopb"


### PR DESCRIPTION
This addresses #55 and adds Fabric's go linter to the project. 

Moreover, proper code checks for c/cpp components are needed as well. @bvavala suggested using clang-format for this as PDO also uses it. I think we should adopt the coding c/cpp coding standards used in PDO as this would exchanging code among much cleaner. WDYT?

Note that another PR is required to fix the issues detected by the checks, that is, when running `make check` on the current code it may fail.