### PR TITLE
fix make docker step

### DIFF
--- a/ecc/Dockerfile
+++ b/ecc/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p ${CC_LIB_PATH}
 ENV SGX_SDK=/opt/intel/sgxsdk
 ENV LD_LIBRARY_PATH=${SGX_SDK}/sdk_libs:${CC_LIB_PATH}
 
-copy ${CC_NAME} ${CC_PATH}/chaincode
-copy enclave/lib/*.so ${CC_LIB_PATH}/
+copy ecc/${CC_NAME} ${CC_PATH}/chaincode
+copy ecc_enclave/_build/lib/*.so ${CC_LIB_PATH}/
 
 WORKDIR ${CC_PATH}

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -43,7 +43,7 @@ stress:
 .PHONY: debug
 debug:
 	$(LD_LIBRARY_PATH) $(GO) test -c
-	$(LD_LIBRARY_PATH) sgx-gdb ecc.test -d $GOROOT
+	$(LD_LIBRARY_PATH) sgx-gdb ecc.test -d $(GOROOT)
 
 clean: docker-clean
 	$(GO) clean
@@ -52,7 +52,7 @@ clean: docker-clean
 #	rm enclave/mrenclave.go
 
 docker:
-	$(DOCKER) build -t $(DOCKER_IMAGE) .
+	$(DOCKER) build -t $(DOCKER_IMAGE) -f Dockerfile ..
 
 docker-run:
 	$(DOCKER) run \


### PR DESCRIPTION
This fixes PR #52  -- thanks Michael for suggesting it.
The 'make docker' fails due to the symbolic links in ecc/enclave.
Additionally, the 'make debug' contains an incorrect reference to an environment variable.

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>