### PR TITLE
Add missing license identifier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.9)
 project(fabric-private-chaincode)
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = .
 include $(TOP)/build.mk
 
@@ -6,7 +10,11 @@ SUB_DIRS = utils/fabric-ccenv-sgx ercc ecc_enclave ecc tlcc_enclave tlcc
 all build test clean :
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@;)
 
-checks: linter
+checks: license linter
+
+license:
+	@echo "License: Running licence checks.."
+	@sh ${GOPATH}/src/github.com/hyperledger/fabric/scripts/check_license.sh
 
 linter:
 	@echo "LINT: Running code checks.."

--- a/build.mk
+++ b/build.mk
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 include $(TOP)/config.mk
 
 # optionlly allow local overriding defaults

--- a/cmake/ConfigSGX.cmake
+++ b/cmake/ConfigSGX.cmake
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # get arch information
 execute_process(COMMAND getconf LONG_BIT OUTPUT_VARIABLE VAR_LONG_BIT)
 

--- a/cmake/Init.cmake
+++ b/cmake/Init.cmake
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/../cmake/")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/cmake/NanoPB.cmake
+++ b/cmake/NanoPB.cmake
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 unset(NANOPB_PATH CACHE)
 
 set(NANOPB_PATH "$ENV{NANOPB_PATH}")

--- a/config.mk
+++ b/config.mk
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 GOFLAGS :=
 GO := go $(GOFLAGS)
 

--- a/ecc/Dockerfile
+++ b/ecc/Dockerfile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM hyperledger/fabric-ccenv-sgx:latest
 
 ARG CC_NAME="ecc"

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = ..
 include $(TOP)/build.mk
 

--- a/ecc/enclave/Makefile
+++ b/ecc/enclave/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 .PHONY: all
 
 all: build test

--- a/ecc_enclave/CMakeLists.txt
+++ b/ecc_enclave/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.5.1)
 project(ecclib)
 

--- a/ecc_enclave/Makefile
+++ b/ecc_enclave/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = ..
 include $(TOP)/build.mk
 

--- a/ecc_enclave/enclave/CMakeLists.txt
+++ b/ecc_enclave/enclave/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 set(SOURCE_FILES
     auction/auction_cc.cpp
     auction/auction_json.cpp

--- a/ecc_enclave/generate_mrenclave.sh
+++ b/ecc_enclave/generate_mrenclave.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 build_dir=$1
 enclave_dir=$2
 

--- a/ecc_enclave/sgxcclib/CMakeLists.txt
+++ b/ecc_enclave/sgxcclib/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 INCLUDE(CMakeVariables.txt)
 
 set(SOURCE_FILES

--- a/ercc/Makefile
+++ b/ercc/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = ..
 include $(TOP)/build.mk
 

--- a/eval/benchmark/executor/executor.go
+++ b/eval/benchmark/executor/executor.go
@@ -1,3 +1,9 @@
+/*
+* Copyright IBM Corp. All Rights Reserved.
+*
+* SPDX-License-Identifier: Apache-2.0
+ */
+
 package executor
 
 import (

--- a/eval/benchmark/executor/executor_test.go
+++ b/eval/benchmark/executor/executor_test.go
@@ -1,3 +1,9 @@
+/*
+* Copyright IBM Corp. All Rights Reserved.
+*
+* SPDX-License-Identifier: Apache-2.0
+ */
+
 package executor
 
 import (

--- a/eval/benchmark/executor/worker/worker.go
+++ b/eval/benchmark/executor/worker/worker.go
@@ -1,3 +1,9 @@
+/*
+* Copyright IBM Corp. All Rights Reserved.
+*
+* SPDX-License-Identifier: Apache-2.0
+ */
+
 package worker
 
 // State is the state of a Worker

--- a/eval/benchmark/executor/worker/workerpool.go
+++ b/eval/benchmark/executor/worker/workerpool.go
@@ -1,3 +1,9 @@
+/*
+* Copyright IBM Corp. All Rights Reserved.
+*
+* SPDX-License-Identifier: Apache-2.0
+ */
+
 package worker
 
 import (

--- a/scripts/cpplinter.sh
+++ b/scripts/cpplinter.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # TODO Implement me
 

--- a/tlcc/Makefile
+++ b/tlcc/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = ..
 include $(TOP)/build.mk
 

--- a/tlcc_enclave/CMakeLists.txt
+++ b/tlcc_enclave/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.5.1)
 project(tllib)
 enable_testing()

--- a/tlcc_enclave/Makefile
+++ b/tlcc_enclave/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = ..
 include $(TOP)/build.mk
 

--- a/tlcc_enclave/generate_mrenclave.sh
+++ b/tlcc_enclave/generate_mrenclave.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 build_dir=$1
 enclave_dir=$2
 

--- a/tlcc_enclave/generate_protos.sh
+++ b/tlcc_enclave/generate_protos.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # set -eux
 
 FABRIC_PATH=${FABRIC_PATH-../../../hyperledger/fabric}

--- a/utils/fabric-ccenv-sgx/Makefile
+++ b/utils/fabric-ccenv-sgx/Makefile
@@ -1,3 +1,7 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 TOP = ../..
 include $(TOP)/build.mk
 


### PR DESCRIPTION
This fixes #72 and adds missing license headers.
It also adds Fabric's license check to the
make checks target.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>