### PR TITLE
Fix for accidentally merged buggy PR #78

### DIFF
--- a/ercc/attestation/ias_test.go
+++ b/ercc/attestation/ias_test.go
@@ -77,7 +77,8 @@ var _ = Describe("Ias", func() {
 
 				ias := attestation.NewIASWithMock(ts.URL, ts.Client())
 				_, err = ias.RequestAttestationReport(apiKey, []byte(quote))
-				Expect(err).To(MatchError("report does not contain submitted quote"))
+				Expect(err).To(HaveOccurred())
+				Expect(strings.HasPrefix(err.Error(), "report does not contain submitted quote")).To(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
the removal of dot-import uncovered a bug in the report verification (which for whatever reason got skipped in the dot-import version) where the prefix test was done the wrong way around.  Besides fixing, i've also added some comments on rational for tests (which was not obvious on first sight of the code) and added a bit more debugging ...

PS: If i would have followed michael's law i would have discovered issue before merging but i guess i assumed marcus did end-to-end test for the dot-removal (i've only tested that this makes ercc tests working) and marcus probably assumed i tested ...