### PR TITLE
Load SPID as text (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ could a mismatch between provided SPID and api key as specified below).
 Place your ias api key and your SPID in the ``ias`` folder as follows:
 
     echo 'YOUR_API_KEY' > ${GOPATH}/src/github.com/hyperledger-labs/fabric-private-chaincode/config/ias/api_key.txt
-    echo 'YOURSPID' | xxd -r -p > ${GOPATH}/src/github.com/hyperledger-labs/fabric-private-chaincode/config/ias/spid.txt
+    echo 'YOUR_SPID' > ${GOPATH}/src/github.com/hyperledger-labs/fabric-private-chaincode/config/ias/spid.txt
 
 
 ### Get NanoPB

--- a/ercc/attestation/ias_credentials/decoration.go
+++ b/ercc/attestation/ias_credentials/decoration.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/hyperledger/fabric/core/config"
 	"github.com/hyperledger/fabric/core/handlers/decoration"
@@ -67,7 +69,22 @@ func readSPIDFromFile(spidFile string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return bytes, nil
+
+	return hexSPID2bytes(string(bytes))
+}
+
+func hexSPID2bytes(input string) ([]byte, error) {
+	spidString := strings.TrimSpace(input)
+	spid, err := hex.DecodeString(spidString)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(spid) != 16 {
+		return nil, fmt.Errorf("Cannot parse SPID: wrong size")
+	}
+
+	return spid, nil
 }
 
 func readFile(file string) ([]byte, error) {


### PR DESCRIPTION
This PR allows to store SPID as text format and performs conversion to
binary format within ercc.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>