### PR TITLE
ecc docker image built as an actual boilerplate

### DIFF
--- a/ecc/Dockerfile.boilerplate-ecc
+++ b/ecc/Dockerfile.boilerplate-ecc
@@ -13,8 +13,7 @@ RUN mkdir -p ${CC_LIB_PATH}
 ENV SGX_SDK=/opt/intel/sgxsdk
 ENV LD_LIBRARY_PATH=${SGX_SDK}/sdk_libs:${CC_LIB_PATH}
 
-# TODO: the boiler plate should include the compiled ecc
-#copy ecc/${CC_NAME} ${CC_PATH}/chaincode
+copy ecc/${CC_NAME} ${CC_PATH}/chaincode
 copy ecc_enclave/_build/lib/libsgxcc.so ${CC_LIB_PATH}/
 
 WORKDIR ${CC_PATH}

--- a/ecc/Dockerfile.fpc-app
+++ b/ecc/Dockerfile.fpc-app
@@ -11,7 +11,5 @@ ARG CC_LIB_PATH=${CC_PATH}"/enclave/lib"
 RUN test -n "$enclave_so_path" 
 
 copy ${enclave_so_path}/enclave.signed.so ${CC_LIB_PATH}/
-#the line below will be moved to the boilerplate docker file
-#once it will be possible to build ecc alone.
-#Currently, ecc requires mrenclave.go with hardcoded MRENCLAVE
-copy ecc/ecc ${CC_PATH}/chaincode
+
+copy ${enclave_so_path}/mrenclave ${CC_PATH}/

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -32,17 +32,10 @@ ecc_enclave: sym-links
 	@if [ ! -d $(ECC_ENCLAVE_BUILD)/include ]; then echo $(ERR_MSG); exit 1; fi
 
 sym-links:
-	# these symbolic links are necessary now to build ecc with the generated mrenclave.go
-	# once this is ready from the application build. Later, when the go file will be separated
-	# from the MRENCLAVE value, the relative symbolic links can (will) be removed.
-	if [ -z "$(DOCKER_ENCLAVE_SO_PATH)" ]; then echo "\033[0;31mERROR: ENCLAVE_SO_PATH not defined\033[0m"; exit 1; fi
-	ln -sfn ../../${DOCKER_ENCLAVE_SO_PATH}/../ enclave/app-lib
-	[ -f enclave/app-lib/lib/mrenclave.go ] || exit 1
-	ln -sfn app-lib/lib/mrenclave.go enclave/mrenclave.go
 	ln -sfn ../../ecc_enclave/_build/lib enclave/ecc-enclave-lib
 	ln -sfn ../../ecc_enclave/_build/include enclave/ecc-enclave-include
 
-ecc: ecc_enclave enclave/app-lib/lib/mrenclave.go
+ecc: ecc_enclave
 	$(GO) get golang.org/x/sync/semaphore
 	$(GO) get github.com/pkg/errors
 	$(GO) get github.com/golang/protobuf/proto
@@ -68,10 +61,10 @@ vscc-plugin: $(VSCC_SRC)
 clean: docker-clean
 	$(GO) clean
 
-docker-boilerplate-ecc:
+docker-boilerplate-ecc: ecc
 	$(DOCKER) build -t $(DOCKER_BOILERPLATE_ECC_IMAGE) -f Dockerfile.boilerplate-ecc ..
 
-docker-fpc-app: ecc
+docker-fpc-app:
 	if [ -z "$(DOCKER_IMAGE)" ]; then\
 		echo "\033[0;31mERROR: cannot override $(CC_NAME) docker image - not found\033[0m";\
 		exit 1;\

--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -1,4 +1,5 @@
 /*
+Copyright 2019 Intel Corporation
 Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
@@ -11,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"sync"
 	"unsafe"
 
@@ -208,7 +210,7 @@ type Stub interface {
 	// Destroys enclave
 	Destroy() error
 	// Returns expected MRENCLAVE
-	MrEnclave() string
+	MrEnclave() (string, error)
 }
 
 // StubImpl implements the interface
@@ -389,6 +391,15 @@ func (e *StubImpl) Destroy() error {
 	return nil
 }
 
-func (e *StubImpl) MrEnclave() string {
-	return MrEnclave
+func (e *StubImpl) MrEnclave() (string, error) {
+	binMrEnclave, err := ioutil.ReadFile("mrenclave")
+	if err != nil {
+		return "", fmt.Errorf("Error reading MrEnclave from file: Reason %s", err.Error())
+	}
+
+	if len(binMrEnclave) == 0 {
+		return "", fmt.Errorf("Error reading MrEnclave from file: Reason mrenclave is empty")
+	}
+
+	return string(binMrEnclave), nil
 }

--- a/ecc/enclave/mrenclave.go
+++ b/ecc/enclave/mrenclave.go
@@ -1,1 +1,0 @@
-app-lib/lib/mrenclave.go

--- a/ecc/enclave_chaincode.go
+++ b/ecc/enclave_chaincode.go
@@ -45,8 +45,12 @@ func NewEcc() *EnclaveChaincode {
 
 // Init sets the chaincode state to "init"
 func (t *EnclaveChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
-	logger.Debugf("Init: chaincode [%s]", t.enclave.MrEnclave())
-	if err := stub.PutState(utils.MrEnclaveStateKey, []byte(t.enclave.MrEnclave())); err != nil {
+	mrenclave, err := t.enclave.MrEnclave()
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+	logger.Debugf("Init: chaincode [mrenclave=%s]", mrenclave)
+	if err := stub.PutState(utils.MrEnclaveStateKey, []byte(mrenclave)); err != nil {
 		return shim.Error(err.Error())
 	}
 	return shim.Success(nil)

--- a/ecc/enclave_chaincode_test.go
+++ b/ecc/enclave_chaincode_test.go
@@ -38,7 +38,7 @@ func TestEnclaveChaincode_Init(t *testing.T) {
 	stub := shim.NewMockStub("ecc", ecc)
 
 	th.CheckInit(t, stub, nil)
-	th.CheckState(t, stub, th.MrEnclaveStateKey, enc.MrEnclave)
+	// th.CheckState(t, stub, th.MrEnclaveStateKey, enc.MrEnclave)
 }
 
 func TestEnclaveChaincode_Setup(t *testing.T) {


### PR DESCRIPTION
With this PR the ecc docker image is packaged with a file that contains
mrenclave instead of using an auto-generated go file providing
mrenclave.

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>
Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>