### PR TITLE
Fix concurrency issue in registry

### DIFF
--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -76,9 +76,9 @@ func NewRegistry() *Registry {
 
 func (r *Registry) Register(stubs *Stubs) int {
 	r.Lock()
+	defer r.Unlock()
 	r.index++
 	r.internal[r.index] = stubs
-	r.Unlock()
 	return r.index
 }
 


### PR DESCRIPTION
In cases of high load the evaluation of r.index took place after it was incremented by another invocation.
This led to two invocations using the same index and finally a crash.

Now the lock is released after the evaluation of r.index.