### PR TITLE
upgrade to fabric v1.4.2 & config upgrade from old release-1.3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ deploying and running an example chaincode.
 
 * CMake 3.5.1 or higher
 * Go 1.11.x or higher
-* Hyperledger Fabric v1.4.1 https://github.com/hyperledger/fabric
+* Hyperledger Fabric v1.4.2 https://github.com/hyperledger/fabric
 
     If you are new to Fabric, we recommend the Fabric documentation as your starting point. You should start with
     [installing](https://hyperledger-fabric.readthedocs.io/en/release-1.4/prereqs.html) Fabric dependencies and setting

--- a/fabric/0001-sgx-enable-invoked-docker-containers-iff-either-dev-.patch
+++ b/fabric/0001-sgx-enable-invoked-docker-containers-iff-either-dev-.patch
@@ -15,8 +15,8 @@ index 2a709ed0b..53717139c 100644
 @@ -16,6 +16,7 @@ import (
  	"fmt"
  	"io"
- 	"regexp"
 +	"os"
+ 	"regexp"
  	"strconv"
  	"strings"
  	"time"
@@ -28,13 +28,13 @@ index 2a709ed0b..53717139c 100644
 +	// Check whether sgx driver (and which version) exists
 +	hasSGX := false
 +	sgxDeviceName := ""
-+	for _, name := range []string{ "/dev/sgx", "/dev/isgx" } {
++	for _, name := range []string{"/dev/sgx", "/dev/isgx"} {
 +		if _, err := os.Stat(name); err == nil {
 +			hasSGX = true
-+			sgxDeviceName=name
++			sgxDeviceName = name
 +			break
 +		}
-+        }
++	}
 +
 +	config := &docker.HostConfig{
  		CapAdd:  viper.GetStringSlice(dockerKey("CapAdd")),

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -18,9 +18,9 @@ your [development environment](https://hyperledger-fabric.readthedocs.io/en/rele
 
 ## Patch and Build
 
-Clone fabric and checkout the 1.4.1 release.
+Clone fabric and checkout the 1.4.2 release.
 
-    $ git clone --branch v1.4.1 https://github.com/hyperledger/fabric.git $GOPATH/src/github.com/hyperledger/fabric
+    $ git clone --branch v1.4.2 https://github.com/hyperledger/fabric.git $GOPATH/src/github.com/hyperledger/fabric
     $ cd $GOPATH/src/github.com/hyperledger/fabric
     $ git am ../../hyperledger-labs/fabric-private-chaincode/fabric/*.patch
 

--- a/fabric/sgxconfig/configtx.yaml
+++ b/fabric/sgxconfig/configtx.yaml
@@ -1,6 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 ---
 ################################################################################
@@ -48,6 +49,11 @@ Organizations:
                 Type: Signature
                 Rule: "OR('SampleOrg.admin')"
 
+        # OrdererEndpoints is a list of all orderers this org runs which clients
+        # and peers may to connect to to push transactions and receive blocks respectively.
+        OrdererEndpoints:
+            - "127.0.0.1:7050"
+
         # AnchorPeers defines the location of peers which can be used for
         # cross-org gossip communication. Note, this value is only encoded in
         # the genesis block in the Application section context.
@@ -79,13 +85,13 @@ Capabilities:
     # supported by both.
     # Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        # V1.3 for Channel is a catchall flag for behavior which has been
-        # determined to be desired for all orderers and peers running at the v1.3.x
+        # V1.4.2 for Channel is a catchall flag for behavior which has been
+        # determined to be desired for all orderers and peers running at the v1.4.2
         # level, but which would be incompatible with orderers and peers from
         # prior releases.
-        # Prior to enabling V1.3 channel capabilities, ensure that all
-        # orderers and peers on a channel are at v1.3.0 or later.
-        V1_3: true
+        # Prior to enabling V1.4.2 channel capabilities, ensure that all
+        # orderers and peers on a channel are at v1.4.2 or later.
+        V1_4_2: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
     # used with prior release peers.
@@ -102,9 +108,12 @@ Capabilities:
     # used with prior release orderers.
     # Set the value of the capability to true to require it.
     Application: &ApplicationCapabilities
+        # V1.4.2 for Application enables the new non-backwards compatible
+        # features and fixes of fabric v1.4.2
+        V1_4_2: true
         # V1.3 for Application enables the new non-backwards compatible
         # features and fixes of fabric v1.3.
-        V1_3: true
+        V1_3: false
         # V1.2 for Application enables the new non-backwards compatible
         # features and fixes of fabric v1.2 (note, this need not be set if
         # later version capabilities are set)
@@ -229,12 +238,13 @@ Orderer: &OrdererDefaults
     # Available types are "solo" and "kafka".
     OrdererType: solo
 
-    # Addresses here is a nonexhaustive list of orderers the peers and clients can
-    # connect to. Adding/removing nodes from this list has no impact on their
-    # participation in ordering.
-    # NOTE: In the solo case, this should be a one-item list.
+    # Addresses used to be the list of orderer addresses that clients and peers
+    # could connect to.  However, this does not allow clients to associate orderer
+    # addresses and orderer organizations which can be useful for things such
+    # as TLS validation.  The preferred way to specify orderer addresses is now
+    # to include the OrdererEndpoints item in your org definition
     Addresses:
-        - 127.0.0.1:7050
+        # - 127.0.0.1:7050
 
     # Batch Timeout: The amount of time to wait before creating a batch.
     BatchTimeout: 2s
@@ -249,7 +259,7 @@ Orderer: &OrdererDefaults
 
         # Max Message Count: The maximum number of messages to permit in a
         # batch.  No block will contain more than this number of messages.
-        MaxMessageCount: 10
+        MaxMessageCount: 500
 
         # Absolute Max Bytes: The absolute maximum number of bytes allowed for
         # the serialized messages in a batch. The maximum block size is this value
@@ -271,7 +281,7 @@ Orderer: &OrdererDefaults
         # will contain only that message.  Because messages may be larger than
         # preferred max bytes (up to AbsoluteMaxBytes), some batches may exceed
         # the preferred max bytes, but will always contain exactly one transaction.
-        PreferredMaxBytes: 512 KB
+        PreferredMaxBytes: 2 MB
 
     # Max Channels is the maximum number of channels to allow on the ordering
     # network. When set to 0, this implies no maximum number of channels.
@@ -285,6 +295,53 @@ Orderer: &OrdererDefaults
             - kafka0:9092
             - kafka1:9092
             - kafka2:9092
+
+    # EtcdRaft defines configuration which must be set when the "etcdraft"
+    # orderertype is chosen.
+    EtcdRaft:
+        # The set of Raft replicas for this network. For the etcd/raft-based
+        # implementation, we expect every replica to also be an OSN. Therefore,
+        # a subset of the host:port items enumerated in this list should be
+        # replicated under the Orderer.Addresses key above.
+        Consenters:
+            - Host: raft0.example.com
+              Port: 7050
+              ClientTLSCert: path/to/ClientTLSCert0
+              ServerTLSCert: path/to/ServerTLSCert0
+            - Host: raft1.example.com
+              Port: 7050
+              ClientTLSCert: path/to/ClientTLSCert1
+              ServerTLSCert: path/to/ServerTLSCert1
+            - Host: raft2.example.com
+              Port: 7050
+              ClientTLSCert: path/to/ClientTLSCert2
+              ServerTLSCert: path/to/ServerTLSCert2
+
+        # Options to be specified for all the etcd/raft nodes. The values here
+        # are the defaults for all new channels and can be modified on a
+        # per-channel basis via configuration updates.
+        Options:
+            # TickInterval is the time interval between two Node.Tick invocations.
+            TickInterval: 500ms
+
+            # ElectionTick is the number of Node.Tick invocations that must pass
+            # between elections. That is, if a follower does not receive any
+            # message from the leader of current term before ElectionTick has
+            # elapsed, it will become candidate and start an election.
+            # ElectionTick must be greater than HeartbeatTick.
+            ElectionTick: 10
+
+            # HeartbeatTick is the number of Node.Tick invocations that must
+            # pass between heartbeats. That is, a leader sends heartbeat
+            # messages to maintain its leadership every HeartbeatTick ticks.
+            HeartbeatTick: 1
+
+            # MaxInflightBlocks limits the max number of in-flight append messages
+            # during optimistic replication phase.
+            MaxInflightBlocks: 5
+
+            # SnapshotIntervalSize defines number of bytes per which a snapshot is taken
+            SnapshotIntervalSize: 20 MB
 
     # Organizations lists the orgs participating on the orderer side of the
     # network.
@@ -491,3 +548,36 @@ Profiles:
             <<: *ApplicationDefaults
             Organizations:
                 - *SampleOrg
+
+    # SampleDevModeEtcdRaft defines a configuration that differs from the
+    # SampleDevModeSolo one only in that it uses the etcd/raft-based orderer.
+    SampleDevModeEtcdRaft:
+        <<: *ChannelDefaults
+        Orderer:
+            <<: *OrdererDefaults
+            OrdererType: etcdraft
+            Organizations:
+                - <<: *SampleOrg
+                  Policies:
+                      <<: *SampleOrgPolicies
+                      Admins:
+                          Type: Signature
+                          Rule: "OR('SampleOrg.member')"
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+                - <<: *SampleOrg
+                  Policies:
+                      <<: *SampleOrgPolicies
+                      Admins:
+                          Type: Signature
+                          Rule: "OR('SampleOrg.member')"
+        Consortiums:
+            SampleConsortium:
+                Organizations:
+                    - <<: *SampleOrg
+                      Policies:
+                          <<: *SampleOrgPolicies
+                          Admins:
+                              Type: Signature
+                              Rule: "OR('SampleOrg.member')"

--- a/fabric/sgxconfig/core.yaml
+++ b/fabric/sgxconfig/core.yaml
@@ -1,6 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 ###############################################################################
 #
@@ -195,6 +196,34 @@ peer:
             reconcileSleepInterval: 1m
             # reconciliationEnabled is a flag that indicates whether private data reconciliation is enable or not.
             reconciliationEnabled: true
+            # skipPullingInvalidTransactionsDuringCommit is a flag that indicates whether pulling of invalid
+            # transaction's private data from other peers need to be skipped during the commit time and pulled
+            # only through reconciler.
+            skipPullingInvalidTransactionsDuringCommit: false
+
+        # Gossip state transfer related configuration
+        state:
+            # indicates whenever state transfer is enabled or not
+            # default value is true, i.e. state transfer is active
+            # and takes care to sync up missing blocks allowing
+            # lagging peer to catch up to speed with rest network
+            enabled: true
+            # checkInterval interval to check whether peer is lagging behind enough to
+            # request blocks via state transfer from another peer.
+            checkInterval: 10s
+            # responseTimeout amount of time to wait for state transfer response from
+            # other peers
+            responseTimeout: 3s
+            # batchSize the number of blocks to request via state transfer from another peer
+            batchSize: 10
+            # blockBufferSize reflect the maximum distance between lowest and
+            # highest block sequence number state buffer to avoid holes.
+            # In order to ensure absence of the holes actual buffer size
+            # is twice of this distance
+            blockBufferSize: 100
+            # maxRetries maximum number of re-tries to ask
+            # for single state transfer request
+            maxRetries: 3
 
     # TLS Settings
     # Note that peer-chaincode connections through chaincodeListenAddress is
@@ -585,7 +614,7 @@ ledger:
        # This username must have read and write authority on CouchDB
        username:
        # The password is recommended to pass as an environment variable
-       # during start up (eg LEDGER_COUCHDBCONFIG_PASSWORD).
+       # during start up (eg CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD).
        # If it is stored here, the file must be access control protected
        # to prevent unintended users from discovering the password.
        password:

--- a/fabric/sgxconfig/orderer.yaml
+++ b/fabric/sgxconfig/orderer.yaml
@@ -1,6 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 ---
 ################################################################################
@@ -51,32 +52,30 @@ General:
     # Cluster settings for ordering service nodes that communicate with other ordering service nodes
     # such as Raft based ordering service.
     Cluster:
+        # SendBufferSize is the maximum number of messages in the egress buffer.
+        # Consensus messages are dropped if the buffer is full, and transaction
+        # messages are waiting for space to be freed.
+        SendBufferSize: 10
         # ClientCertificate governs the file location of the client TLS certificate
         # used to establish mutual TLS connections with other ordering service nodes.
         ClientCertificate:
         # ClientPrivateKey governs the file location of the private key of the client TLS certificate.
         ClientPrivateKey:
-        # DialTimeout governs the maximum duration of time after which connection
-        # attempts are considered as failed.
-        DialTimeout: 5s
-        # RPCTimeout governs the maximum duration of time after which RPC
-        # attempts are considered as failed.
-        RPCTimeout: 7s
-        # RootCAs governs the file locations of certificates of the Certificate Authorities
-        # which authorize connections to remote ordering service nodes.
-        RootCAs:
-          - tls/ca.crt
-        # ReplicationBuffersSize is the maximum number of bytes that can be allocated
-        # for each in-memory buffer used for block replication from other cluster nodes.
-        # Each channel has its own memory buffer.
-        ReplicationBufferSize: 20971520 # 20MB
-        # PullTimeout is the maximum duration the ordering node will wait for a block
-        # to be received before it aborts.
-        ReplicationPullTimeout: 5s
-        # ReplicationRetryTimeout is the maximum duration the ordering node will wait
-        # between 2 consecutive attempts.
-        ReplicationRetryTimeout: 5s
+        # The below 4 properties should be either set together, or be unset together.
+        # If they are set, then the orderer node uses a separate listener for intra-cluster
+        # communication. If they are unset, then the general orderer listener is used.
+        # This is useful if you want to use a different TLS server certificates on the
+        # client-facing and the intra-cluster listeners.
 
+        # ListenPort defines the port on which the cluster listens to connections.
+        ListenPort:
+        # ListenAddress defines the IP on which to listen to intra-cluster communication.
+        ListenAddress:
+        # ServerCertificate defines the file location of the server TLS certificate used for intra-cluster
+        # communication.
+        ServerCertificate:
+        # ServerPrivateKey defines the file location of the private key of the TLS certificate.
+        ServerPrivateKey:
     # Genesis method: The method by which the genesis block for the orderer
     # system channel is specified. Available options are "provisional", "file":
     #  - provisional: Utilizes a genesis profile, specified by GenesisProfile,
@@ -327,7 +326,7 @@ Operations:
         ClientAuthRequired: false
 
         # Paths to PEM encoded ca certificates to trust for client authentication
-        RootCAs: []
+        ClientRootCAs: []
 
 ################################################################################
 #

--- a/integration/config/configtx.yaml
+++ b/integration/config/configtx.yaml
@@ -2,6 +2,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 ---
 ################################################################################
@@ -49,6 +50,11 @@ Organizations:
                 Type: Signature
                 Rule: "OR('SampleOrg.admin')"
 
+        # OrdererEndpoints is a list of all orderers this org runs which clients
+        # and peers may to connect to to push transactions and receive blocks respectively.
+        OrdererEndpoints:
+            - "127.0.0.1:7050"
+
         # AnchorPeers defines the location of peers which can be used for
         # cross-org gossip communication. Note, this value is only encoded in
         # the genesis block in the Application section context.
@@ -80,13 +86,13 @@ Capabilities:
     # supported by both.
     # Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        # V1.3 for Channel is a catchall flag for behavior which has been
-        # determined to be desired for all orderers and peers running at the v1.3.x
+        # V1.4.2 for Channel is a catchall flag for behavior which has been
+        # determined to be desired for all orderers and peers running at the v1.4.2
         # level, but which would be incompatible with orderers and peers from
         # prior releases.
-        # Prior to enabling V1.3 channel capabilities, ensure that all
-        # orderers and peers on a channel are at v1.3.0 or later.
-        V1_3: true
+        # Prior to enabling V1.4.2 channel capabilities, ensure that all
+        # orderers and peers on a channel are at v1.4.2 or later.
+        V1_4_2: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
     # used with prior release peers.
@@ -103,9 +109,12 @@ Capabilities:
     # used with prior release orderers.
     # Set the value of the capability to true to require it.
     Application: &ApplicationCapabilities
+        # V1.4.2 for Application enables the new non-backwards compatible
+        # features and fixes of fabric v1.4.2
+        V1_4_2: true
         # V1.3 for Application enables the new non-backwards compatible
         # features and fixes of fabric v1.3.
-        V1_3: true
+        V1_3: false
         # V1.2 for Application enables the new non-backwards compatible
         # features and fixes of fabric v1.2 (note, this need not be set if
         # later version capabilities are set)
@@ -230,12 +239,13 @@ Orderer: &OrdererDefaults
     # Available types are "solo" and "kafka".
     OrdererType: solo
 
-    # Addresses here is a nonexhaustive list of orderers the peers and clients can
-    # connect to. Adding/removing nodes from this list has no impact on their
-    # participation in ordering.
-    # NOTE: In the solo case, this should be a one-item list.
+    # Addresses used to be the list of orderer addresses that clients and peers
+    # could connect to.  However, this does not allow clients to associate orderer
+    # addresses and orderer organizations which can be useful for things such
+    # as TLS validation.  The preferred way to specify orderer addresses is now
+    # to include the OrdererEndpoints item in your org definition
     Addresses:
-        - 127.0.0.1:7050
+        # - 127.0.0.1:7050
 
     # Batch Timeout: The amount of time to wait before creating a batch.
     BatchTimeout: 2s
@@ -250,7 +260,7 @@ Orderer: &OrdererDefaults
 
         # Max Message Count: The maximum number of messages to permit in a
         # batch.  No block will contain more than this number of messages.
-        MaxMessageCount: 10
+        MaxMessageCount: 500
 
         # Absolute Max Bytes: The absolute maximum number of bytes allowed for
         # the serialized messages in a batch. The maximum block size is this value
@@ -272,7 +282,7 @@ Orderer: &OrdererDefaults
         # will contain only that message.  Because messages may be larger than
         # preferred max bytes (up to AbsoluteMaxBytes), some batches may exceed
         # the preferred max bytes, but will always contain exactly one transaction.
-        PreferredMaxBytes: 512 KB
+        PreferredMaxBytes: 2 MB
 
     # Max Channels is the maximum number of channels to allow on the ordering
     # network. When set to 0, this implies no maximum number of channels.
@@ -286,6 +296,53 @@ Orderer: &OrdererDefaults
             - kafka0:9092
             - kafka1:9092
             - kafka2:9092
+
+    # EtcdRaft defines configuration which must be set when the "etcdraft"
+    # orderertype is chosen.
+    EtcdRaft:
+        # The set of Raft replicas for this network. For the etcd/raft-based
+        # implementation, we expect every replica to also be an OSN. Therefore,
+        # a subset of the host:port items enumerated in this list should be
+        # replicated under the Orderer.Addresses key above.
+        Consenters:
+            - Host: raft0.example.com
+              Port: 7050
+              ClientTLSCert: path/to/ClientTLSCert0
+              ServerTLSCert: path/to/ServerTLSCert0
+            - Host: raft1.example.com
+              Port: 7050
+              ClientTLSCert: path/to/ClientTLSCert1
+              ServerTLSCert: path/to/ServerTLSCert1
+            - Host: raft2.example.com
+              Port: 7050
+              ClientTLSCert: path/to/ClientTLSCert2
+              ServerTLSCert: path/to/ServerTLSCert2
+
+        # Options to be specified for all the etcd/raft nodes. The values here
+        # are the defaults for all new channels and can be modified on a
+        # per-channel basis via configuration updates.
+        Options:
+            # TickInterval is the time interval between two Node.Tick invocations.
+            TickInterval: 500ms
+
+            # ElectionTick is the number of Node.Tick invocations that must pass
+            # between elections. That is, if a follower does not receive any
+            # message from the leader of current term before ElectionTick has
+            # elapsed, it will become candidate and start an election.
+            # ElectionTick must be greater than HeartbeatTick.
+            ElectionTick: 10
+
+            # HeartbeatTick is the number of Node.Tick invocations that must
+            # pass between heartbeats. That is, a leader sends heartbeat
+            # messages to maintain its leadership every HeartbeatTick ticks.
+            HeartbeatTick: 1
+
+            # MaxInflightBlocks limits the max number of in-flight append messages
+            # during optimistic replication phase.
+            MaxInflightBlocks: 5
+
+            # SnapshotIntervalSize defines number of bytes per which a snapshot is taken
+            SnapshotIntervalSize: 20 MB
 
     # Organizations lists the orgs participating on the orderer side of the
     # network.
@@ -492,3 +549,36 @@ Profiles:
             <<: *ApplicationDefaults
             Organizations:
                 - *SampleOrg
+
+    # SampleDevModeEtcdRaft defines a configuration that differs from the
+    # SampleDevModeSolo one only in that it uses the etcd/raft-based orderer.
+    SampleDevModeEtcdRaft:
+        <<: *ChannelDefaults
+        Orderer:
+            <<: *OrdererDefaults
+            OrdererType: etcdraft
+            Organizations:
+                - <<: *SampleOrg
+                  Policies:
+                      <<: *SampleOrgPolicies
+                      Admins:
+                          Type: Signature
+                          Rule: "OR('SampleOrg.member')"
+        Application:
+            <<: *ApplicationDefaults
+            Organizations:
+                - <<: *SampleOrg
+                  Policies:
+                      <<: *SampleOrgPolicies
+                      Admins:
+                          Type: Signature
+                          Rule: "OR('SampleOrg.member')"
+        Consortiums:
+            SampleConsortium:
+                Organizations:
+                    - <<: *SampleOrg
+                      Policies:
+                          <<: *SampleOrgPolicies
+                          Admins:
+                              Type: Signature
+                              Rule: "OR('SampleOrg.member')"

--- a/integration/config/core.yaml
+++ b/integration/config/core.yaml
@@ -2,6 +2,7 @@
 # Copyright Intel Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 ###############################################################################
 #
@@ -196,6 +197,34 @@ peer:
             reconcileSleepInterval: 1m
             # reconciliationEnabled is a flag that indicates whether private data reconciliation is enable or not.
             reconciliationEnabled: true
+            # skipPullingInvalidTransactionsDuringCommit is a flag that indicates whether pulling of invalid
+            # transaction's private data from other peers need to be skipped during the commit time and pulled
+            # only through reconciler.
+            skipPullingInvalidTransactionsDuringCommit: false
+
+        # Gossip state transfer related configuration
+        state:
+            # indicates whenever state transfer is enabled or not
+            # default value is true, i.e. state transfer is active
+            # and takes care to sync up missing blocks allowing
+            # lagging peer to catch up to speed with rest network
+            enabled: true
+            # checkInterval interval to check whether peer is lagging behind enough to
+            # request blocks via state transfer from another peer.
+            checkInterval: 10s
+            # responseTimeout amount of time to wait for state transfer response from
+            # other peers
+            responseTimeout: 3s
+            # batchSize the number of blocks to request via state transfer from another peer
+            batchSize: 10
+            # blockBufferSize reflect the maximum distance between lowest and
+            # highest block sequence number state buffer to avoid holes.
+            # In order to ensure absence of the holes actual buffer size
+            # is twice of this distance
+            blockBufferSize: 100
+            # maxRetries maximum number of re-tries to ask
+            # for single state transfer request
+            maxRetries: 3
 
     # TLS Settings
     # Note that peer-chaincode connections through chaincodeListenAddress is
@@ -586,7 +615,7 @@ ledger:
        # This username must have read and write authority on CouchDB
        username:
        # The password is recommended to pass as an environment variable
-       # during start up (eg LEDGER_COUCHDBCONFIG_PASSWORD).
+       # during start up (eg CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD).
        # If it is stored here, the file must be access control protected
        # to prevent unintended users from discovering the password.
        password:

--- a/integration/config/orderer.yaml
+++ b/integration/config/orderer.yaml
@@ -2,6 +2,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
 
 ---
 ################################################################################
@@ -52,32 +53,30 @@ General:
     # Cluster settings for ordering service nodes that communicate with other ordering service nodes
     # such as Raft based ordering service.
     Cluster:
+        # SendBufferSize is the maximum number of messages in the egress buffer.
+        # Consensus messages are dropped if the buffer is full, and transaction
+        # messages are waiting for space to be freed.
+        SendBufferSize: 10
         # ClientCertificate governs the file location of the client TLS certificate
         # used to establish mutual TLS connections with other ordering service nodes.
         ClientCertificate:
         # ClientPrivateKey governs the file location of the private key of the client TLS certificate.
         ClientPrivateKey:
-        # DialTimeout governs the maximum duration of time after which connection
-        # attempts are considered as failed.
-        DialTimeout: 5s
-        # RPCTimeout governs the maximum duration of time after which RPC
-        # attempts are considered as failed.
-        RPCTimeout: 7s
-        # RootCAs governs the file locations of certificates of the Certificate Authorities
-        # which authorize connections to remote ordering service nodes.
-        RootCAs:
-          - tls/ca.crt
-        # ReplicationBuffersSize is the maximum number of bytes that can be allocated
-        # for each in-memory buffer used for block replication from other cluster nodes.
-        # Each channel has its own memory buffer.
-        ReplicationBufferSize: 20971520 # 20MB
-        # PullTimeout is the maximum duration the ordering node will wait for a block
-        # to be received before it aborts.
-        ReplicationPullTimeout: 5s
-        # ReplicationRetryTimeout is the maximum duration the ordering node will wait
-        # between 2 consecutive attempts.
-        ReplicationRetryTimeout: 5s
+        # The below 4 properties should be either set together, or be unset together.
+        # If they are set, then the orderer node uses a separate listener for intra-cluster
+        # communication. If they are unset, then the general orderer listener is used.
+        # This is useful if you want to use a different TLS server certificates on the
+        # client-facing and the intra-cluster listeners.
 
+        # ListenPort defines the port on which the cluster listens to connections.
+        ListenPort:
+        # ListenAddress defines the IP on which to listen to intra-cluster communication.
+        ListenAddress:
+        # ServerCertificate defines the file location of the server TLS certificate used for intra-cluster
+        # communication.
+        ServerCertificate:
+        # ServerPrivateKey defines the file location of the private key of the TLS certificate.
+        ServerPrivateKey:
     # Genesis method: The method by which the genesis block for the orderer
     # system channel is specified. Available options are "provisional", "file":
     #  - provisional: Utilizes a genesis profile, specified by GenesisProfile,
@@ -328,7 +327,7 @@ Operations:
         ClientAuthRequired: false
 
         # Paths to PEM encoded ca certificates to trust for client authentication
-        RootCAs: []
+        ClientRootCAs: []
 
 ################################################################################
 #


### PR DESCRIPTION
looking at some configtx options i realized that we still were using older 1.3 configs. Given that the comments in these yaml files are really the main documentation for available parameters in these files (at least i couldn't find anything detailed in the normal docu ...) i thought i upgraded them to current version.  Belatedly i also noticed that i was using the latest released version of config which happens to be 1.4.2 and the configs for that do not run with 1.4.1.  But keeping track with latest released version seems to make anyway sense, so i've tested with 1.4.2 -- works fine .. -- and updated also docu to refer to 1.4.2 ... 

Signed-off-by: Michael Steiner <michael.steiner@intel.com>