### PR TITLE
Integration test fixes

### DIFF
--- a/fabric/bin/lib/common_utils.sh
+++ b/fabric/bin/lib/common_utils.sh
@@ -52,3 +52,25 @@ function para() {
 try() {
     "$@" || die "test failed: $*"
 }
+
+# Try function which returns the response string
+try_r() {
+    echo "$@"
+    result=$("$@" 2>&1) || die "test failed: $*"
+    echo $result
+    export RESPONSE=$(echo $result | awk -F "\"" '{print $5}' | awk -F "\\" '{print $1}' | base64 -d)
+    say $RESPONSE
+}
+
+# Check the Response returned to validate expected Response
+check_result() {
+    if [[ "$1" == "$2" ]]; then
+        export RESULT=PASSED
+	gecho $RESULT
+    else
+        export RESULT=FAILED
+	recho $RESULT
+        export FAILURES=$(($FAILURES+1))
+    fi
+}
+

--- a/fabric/bin/lib/common_utils.sh
+++ b/fabric/bin/lib/common_utils.sh
@@ -62,6 +62,9 @@ try_r() {
     say $RESPONSE
 }
 
+RESULT=PASSED
+FAILURES=0
+
 # Check the Response returned to validate expected Response
 check_result() {
     if [[ "$1" == "$2" ]]; then

--- a/fabric/bin/lib/common_utils.sh
+++ b/fabric/bin/lib/common_utils.sh
@@ -22,6 +22,10 @@ function becho () {
     echo "${cbld}${cblu}" $@ "${crst}" >&2
 }
 
+function gecho () {
+    echo "${cbld}${cgrn}" $@ "${crst}" >&2
+}
+
 # Common reporting functions: say, yell & die
 #-----------------------------------------
 # say is stdout, yell is stderr

--- a/integration/auction_test.sh
+++ b/integration/auction_test.sh
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+#set -x
 SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 FPC_TOP_DIR="${SCRIPTDIR}/.."
 FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
@@ -14,6 +15,8 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
 CC_ID=auction_test
+RESULT=PASSED
+failures=0
 
 #this is the path that will be used for the docker build of the chaincode enclave
 ENCLAVE_SO_PATH=examples/auction/_build/lib/
@@ -22,7 +25,30 @@ CC_VERS=0
 num_rounds=3
 num_clients=10
 
+# Try function which returns the response string
+try_r() {
+    echo "$@" 
+    export RESPONSE=""
+    "$@" 2>&1 | tee -a /tmp/response.txt || die "test failed: $*"
+    export RESPONSE=$(cat /tmp/response.txt | awk -F "\"" '{print $5}' | awk -F "\\" '{print $1}' | base64 -d)
+    say $RESPONSE
+    rm /tmp/response.txt
+}
+
+# Check the Response returned to validate expected Response
+check_result() {
+    if [[ "$1" == "$2" ]]; then
+        export RESULT=PASSED
+	gecho $RESULT
+    else
+        export RESULT=FAILED
+	recho $RESULT
+        export failures=$((failures+1))
+    fi
+}
+
 auction_test() {
+
     # install, init, and register (auction) chaincode
     try ${PEER_CMD} chaincode install -l fpc-c -n ${CC_ID} -v ${CC_VERS} -p ${ENCLAVE_SO_PATH}
     sleep 3
@@ -36,19 +62,65 @@ auction_test() {
     say "invoke submit"
     try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"submit\",\"MyAuction\", \"JohnnyCash0\", \"0\"]", ""]}' --waitForEvent
 
-    for (( i=1; i<=$num_rounds; i++ ))
+    # Scenario 1
+    becho ">>>> Close and evaluate non existing auction. Response should be AUCTION_NOT_EXISTING"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction\"]",""]}' --waitForEvent
+    check_result $RESPONSE "AUCTION_NOT_EXISTING"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"eval\",\"MyAuction\"]", ""]}'  # Don't do --waitForEvent, so potentially there is some parallelism here ..
+    check_result $RESPONSE "AUCTION_NOT_EXISTING"
+
+    # Scenario 2
+    becho ">>>> Create an auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction1\"]", ""]}' --waitForEvent
+    check_result $RESPONSE "OK" 
+    becho ">>>> Create two equivalent bids. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"submit\",\"MyAuction1\", \"JohnnyCash0\", \"2\"]", ""]}' # Don't do --waitForEvent, so potentially there is some parallelism here ..
+    check_result $RESPONSE "OK" 
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"submit\",\"MyAuction1\", \"JohnnyCash1\", \"2\"]", ""]}' # Don't do --waitForEvent, so potentially there is some parallelism here ..
+    check_result $RESPONSE "OK" 
+    becho ">>>> Close auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction1\"]",""]}' --waitForEvent
+    check_result $RESPONSE "OK" 
+    becho ">>>> Submit a bid on a closed auction. Response should be AUCTION_ALREADY_CLOSED"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction1\"]",""]}' --waitForEvent
+    check_result $RESPONSE "AUCTION_ALREADY_CLOSED"; 
+    becho ">>>> Evaluate auction. Response should be DRAW"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"eval\",\"MyAuction1\"]", ""]}'  # Don't do --waitForEvent, so potentially there is some parallelism here ..
+    check_result $RESPONSE "DRAW" 
+
+    # Scenario 3
+    becho ">>>> Create an auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction2\"]", ""]}' --waitForEvent
+    check_result $RESPONSE "OK" 
+    for (( i=0; i<=$num_rounds; i++ ))
     do
+        becho ">>>> Submit unique bid. Response should be OK"
         b="$(($i%$num_clients))"
-        try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"submit\",\"MyAuction\", \"JohnnyCash'$b'\", \"'$b'\"]", ""]}' # Don't do --waitForEvent, so potentially there is some parallelism here ..
+        try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"submit\",\"MyAuction2\", \"JohnnyCash'$b'\", \"'$b'\"]", ""]}' # Don't do --waitForEvent, so potentially there is some parallelism here ..
+        check_result $RESPONSE "OK" 
     done
+    becho ">>>> Close auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction2\"]",""]}' --waitForEvent
+    check_result $RESPONSE "OK"
+    becho ">>>> Evaluate auction. Auction Result should be printed out"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"eval\",\"MyAuction2\"]", ""]}'  # Don't do --waitForEvent, so potentially there is some parallelism here ..
 
-    try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction\"]",""]}' --waitForEvent
-
-    say "invoke eval"
-    for (( i=1; i<=1; i++ ))
-    do
-        try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"eval\",\"MyAuction\"]", ""]}'  # Don't do --waitForEvent, so potentially there is some parallelism here ..
-    done
+    # Scenario 4
+    becho ">>>> Create a new auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction3\"]", ""]}' --waitForEvent
+    check_result $RESPONSE "OK"
+    becho  ">>>> Create a duplicate auction. Response should be AUCTION_ALREADY_EXISTING"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction3\"]", ""]}' --waitForEvent
+    check_result $RESPONSE "AUCTION_ALREADY_EXISTING"
+    becho ">>>> Close auction and evaluate. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction3\"]",""]}' --waitForEvent
+    check_result $RESPONSE "OK"
+    becho ">>>> Close an already closed auction. Response should be AUCTION_ALREADY_CLOSED"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"close\",\"MyAuction3\"]",""]}' --waitForEvent
+    check_result $RESPONSE "AUCTION_ALREADY_CLOSED"
+    becho ">>>> Evaluate auction. Response should be NO_BIDS"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"eval\",\"MyAuction3\"]", ""]}'  # Don't do --waitForEvent, so potentially there is some parallelism here ..
+    check_result $RESPONSE "NO_BIDS"
 }
 
 # 1. prepare
@@ -60,7 +132,6 @@ docker_clean ${CC_ID}
 
 trap ledger_shutdown EXIT
 
-
 para
 say "Run auction test"
 
@@ -68,12 +139,16 @@ say "- setup ledger"
 ledger_init
 
 say "- auction test"
-auction_test 
+auction_test
 
 say "- shutdown ledger"
 ledger_shutdown
 
 para
-yell "Auction test PASSED"
-
+if [[ "$failures" == 0 ]]; then
+    yell "Auction test PASSED"
+else
+    yell "Auction test had ${failures} failures"
+fi
 exit 0
+

--- a/integration/auction_test.sh
+++ b/integration/auction_test.sh
@@ -15,8 +15,8 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
 CC_ID=auction_test
-RESULT=PASSED
-FAILURES=0
+# RESULT=PASSED
+# FAILURES=0
 
 #this is the path that will be used for the docker build of the chaincode enclave
 ENCLAVE_SO_PATH=examples/auction/_build/lib/
@@ -51,7 +51,7 @@ auction_test() {
     becho ">>>> Create an auction. Response should be OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction1\"]", ""]}' --waitForEvent
     # check_result $RESPONSE "OK" 
-    check_result $RESPONSE "TEST" 
+    check_result $RESPONSE "OK" 
     becho ">>>> Create two equivalent bids. Response should be OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"submit\",\"MyAuction1\", \"JohnnyCash0\", \"2\"]", ""]}' # Don't do --waitForEvent, so potentially there is some parallelism here ..
     check_result $RESPONSE "OK" 
@@ -101,9 +101,11 @@ auction_test() {
     becho ">>>> Evaluate auction. Response should be NO_BIDS"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args":["[\"eval\",\"MyAuction3\"]", ""]}'  # Don't do --waitForEvent, so potentially there is some parallelism here ..
     check_result $RESPONSE "NO_BIDS"
-    becho ">>>> Create a new auction. Response should be OK"
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction4\"]", ""]}' --waitForEvent
-    check_result $RESPONSE "OK"
+
+    # Code below is used to test bug in issue #42
+    #becho ">>>> Create a new auction. Response should be OK"
+    #try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"create\",\"MyAuction4\"]", ""]}' --waitForEvent
+    #check_result $RESPONSE "OK"
 }
 
 # 1. prepare

--- a/integration/auction_test.sh
+++ b/integration/auction_test.sh
@@ -15,8 +15,6 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
 CC_ID=auction_test
-# RESULT=PASSED
-# FAILURES=0
 
 #this is the path that will be used for the docker build of the chaincode enclave
 ENCLAVE_SO_PATH=examples/auction/_build/lib/

--- a/integration/deployment_test.sh
+++ b/integration/deployment_test.sh
@@ -17,41 +17,44 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
 CC_VERS=0
+FAILURES=0
 
 run_test() {
-    # install, init, and register (auction) chaincode
+    # install, init, and register auction chaincode
     try ${PEER_CMD} chaincode install -l fpc-c -n auction_test -v ${CC_VERS} -p examples/auction/_build/lib
-
-    try ${PEER_CMD} chaincode install -l golang -n example02 -v ${CC_VERS} -p github.com/hyperledger/fabric/examples/chaincode/go/example02/cmd
+    sleep 3
 
     try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -v ${CC_VERS} -c '{"args":["My Auction"]}' -V ecc-vscc
     sleep 3
-
-    try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args": ["[\"create\",\"MyAuction\"]", ""]}' --waitForEvent
-
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -v ${CC_VERS} -c '{"args":["init", "bob", "100", "alice", "200"]}'
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args": ["[\"create\",\"MyAuction\"]", ""]}' --waitForEvent
+    check_result "OK"
     sleep 3
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "bob"]}' --waitForEvent
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "alice"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args":["[\"submit\",\"MyAuction\", \"JohnnyCash0\", \"0\"]", ""]}' --waitForEvent
+    check_result "OK"
+    sleep 3
 
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["invoke", "bob", "alice", "99"]}' --waitForEvent
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "bob"]}' --waitForEvent
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "alice"]}' --waitForEvent
-    # check_result $RESPONSE "echo-$i"
-
+    # install, init, and register echo chaincode
     try ${PEER_CMD} chaincode install -l fpc-c -n echo_test -v ${CC_VERS} -p examples/echo/_build/lib
     sleep 3
-
+    
     try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n echo_test -v ${CC_VERS} -c '{"args":[]}' -V ecc-vscc
     sleep 3
 
-    # create auction
-    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args": ["[\"create\",\"MyAuction\"]", ""]}' --waitForEvent
-    check_result $RESPONSE "OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n echo_test -c '{"Args": ["[\"moin\"]", ""]}' --waitForEvent
-    check_result $RESPONSE "moin"
+    check_result "moin"
+    sleep 3
 
-    try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args":["[\"submit\",\"MyAuction\", \"JohnnyCash0\", \"0\"]", ""]}' --waitForEvent
+    # install, init, and register fabric example02 chaincode
+    try ${PEER_CMD} chaincode install -l golang -n example02 -v ${CC_VERS} -p github.com/hyperledger/fabric/examples/chaincode/go/example02/cmd
+    sleep 3
+    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -v ${CC_VERS} -c '{"args":["init", "bob", "100", "alice", "200"]}'
+    sleep 3
+
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "bob"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "alice"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["invoke", "bob", "alice", "99"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "bob"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "alice"]}' --waitForEvent
 }
 
 # 1. prepare
@@ -85,6 +88,10 @@ say "- shutdown ledger"
 ledger_shutdown
 
 para
-yell "Test PASSED"
-
+if [[ "$FAILURES" == 0 ]]; then
+    yell "Deployement test PASSED"
+else
+    yell "Deployement test had ${FAILURES} failures"
+fi
 exit 0
+

--- a/integration/deployment_test.sh
+++ b/integration/deployment_test.sh
@@ -31,8 +31,13 @@ run_test() {
 
     try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -v ${CC_VERS} -c '{"args":["init", "bob", "100", "alice", "200"]}'
     sleep 3
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "bob"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "alice"]}' --waitForEvent
 
-    try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["invoke", "bob", "alice", "99"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["invoke", "bob", "alice", "99"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "bob"]}' --waitForEvent
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n example02 -c '{"args": ["query", "alice"]}' --waitForEvent
+    # check_result $RESPONSE "echo-$i"
 
     try ${PEER_CMD} chaincode install -l fpc-c -n echo_test -v ${CC_VERS} -p examples/echo/_build/lib
     sleep 3
@@ -40,7 +45,11 @@ run_test() {
     try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n echo_test -v ${CC_VERS} -c '{"args":[]}' -V ecc-vscc
     sleep 3
 
-    try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n echo_test -c '{"Args": ["[\"moin\"]", ""]}' --waitForEvent
+    # create auction
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args": ["[\"create\",\"MyAuction\"]", ""]}' --waitForEvent
+    check_result $RESPONSE "OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n echo_test -c '{"Args": ["[\"moin\"]", ""]}' --waitForEvent
+    check_result $RESPONSE "moin"
 
     try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args":["[\"submit\",\"MyAuction\", \"JohnnyCash0\", \"0\"]", ""]}' --waitForEvent
 }

--- a/integration/echo_test.sh
+++ b/integration/echo_test.sh
@@ -33,7 +33,8 @@ echo_test() {
     for (( i=1; i<=$num_rounds; i++ ))
     do
         # echos
-        try ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"echo-'$i'\"]", ""]}' --waitForEvent
+        try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"echo-'$i'\"]", ""]}' --waitForEvent
+ 	check_result $RESPONSE "echo-$i"
     done
 }
 
@@ -60,6 +61,10 @@ say "- shutdown ledger"
 ledger_shutdown
 
 para
-yell "Echo test PASSED"
+if [[ "$FAILURES" == 0 ]]; then
+    yell "Echo test PASSED"
+else
+    yell "Echo test had ${FAILURES} failures"
+fi
 
 exit 0

--- a/integration/echo_test.sh
+++ b/integration/echo_test.sh
@@ -20,6 +20,7 @@ ENCLAVE_SO_PATH=examples/echo/_build/lib/
 
 CC_VERS=0
 num_rounds=10
+FAILURES=0
 
 echo_test() {
     # install, init, and register (auction) chaincode
@@ -34,8 +35,8 @@ echo_test() {
     do
         # echos
         try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Args": ["[\"echo-'$i'\"]", ""]}' --waitForEvent
- 	check_result $RESPONSE "echo-$i"
-    done
+        check_result "echo-$i"
+     done
 }
 
 # 1. prepare
@@ -66,5 +67,5 @@ if [[ "$FAILURES" == 0 ]]; then
 else
     yell "Echo test had ${FAILURES} failures"
 fi
-
 exit 0
+


### PR DESCRIPTION
Addressing Issue 104: 
I have improved the auction test to check all error codes and scenarios.  I added the code to extract out the actual response payload from the info returned from the peer, and a function to be able to test on the response code.  

I track how many failures occur and report at the end.

Ultimately, we will have a better integration test, but this will work for now.  I am pushing the code for auction first and will upgrade echo next.

I also added a green text function to the fabric utilities.
