### PR TITLE
improved error handling in sgxcclib

### DIFF
--- a/common/enclave/common.cpp
+++ b/common/enclave/common.cpp
@@ -83,35 +83,6 @@ int ecall_create_report(
     return SGX_SUCCESS;
 }
 
-int ecall_get_target_info(sgx_target_info_t* target)
-{
-    if (!target)
-    {
-        LOG_ERROR("Enclave: Invalid input");
-        return SGX_ERROR_INVALID_PARAMETER;
-    }
-
-    // create a report and extract target_info
-    sgx_report_t temp_report;
-    memset(&temp_report, 0, sizeof(temp_report));
-    memset(target, 0, sizeof(sgx_target_info_t));
-
-    sgx_status_t ret = sgx_create_report(NULL, NULL, &temp_report);
-    if (ret != SGX_SUCCESS)
-    {
-        LOG_ERROR("Enclave: Error while creating report");
-        return ret;
-    }
-
-    // target info size is 512
-    memcpy(&target->mr_enclave, &temp_report.body.mr_enclave, sizeof(sgx_measurement_t));
-    memcpy(&target->attributes, &temp_report.body.attributes, sizeof(sgx_attributes_t));
-    memcpy(&target->misc_select, &temp_report.body.misc_select, sizeof(sgx_misc_select_t));
-
-    LOG_DEBUG("Enc: TargetInfo created!");
-    return SGX_SUCCESS;
-}
-
 // returns enclave pk in Big Endian format
 int ecall_get_pk(uint8_t* pubkey)
 {

--- a/common/enclave/common.edl
+++ b/common/enclave/common.edl
@@ -16,8 +16,6 @@ enclave {
                 [out] sgx_report_t *report,
                 [out, size=64] uint8_t *pubkey);
 
-        public int ecall_get_target_info([in, out] sgx_target_info_t *target_info);
-
         public int ecall_get_pk([out, size=64] uint8_t *pubkey);
     };
 

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -17,6 +17,7 @@ DOCKER_CONTAINER_ID?=$$(docker ps | grep -- ${NET_ID}-${PEER_ID}-$(CC_NAME)- | a
 # the following are the required docker build parameters
 DOCKER_IMAGE ?= $$(docker images | grep -- ${NET_ID}-${PEER_ID}-$(CC_NAME)- | awk '{print $$1;}')
 DOCKER_BOILERPLATE_ECC_IMAGE ?= $(PROJECT_NAME)/boilerplate-ecc
+INSTALLED_DOCKER_BOILERPLATE_ECC_IMAGE ?= $$(docker images | grep -- ${DOCKER_BOILERPLATE_ECC_IMAGE} | awk '{print $$1;}')
 DOCKER_ENCLAVE_SO_PATH ?= $(ENCLAVE_SO_PATH)
 
 all: build
@@ -86,3 +87,4 @@ docker-stop:
 
 docker-clean: docker-stop
 	-if [ ! -z "$(DOCKER_IMAGE)" ]; then docker rmi -f $(DOCKER_IMAGE); fi
+	-if [ ! -z "$(INSTALLED_DOCKER_BOILERPLATE_ECC_IMAGE)" ]; then echo "Remove boilerplate image"; docker rmi $(INSTALLED_DOCKER_BOILERPLATE_ECC_IMAGE); fi

--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -253,7 +253,7 @@ func get_state_by_partial_composite_key(comp_key *C.char, values *C.uint8_t, max
 // Stub interface
 type Stub interface {
 	// Return quote and enclave PK in DER-encoded PKIX format
-	GetRemoteAttestationReport(spid []byte) ([]byte, []byte, error)
+	GetRemoteAttestationReport(spid []byte, sig_rl []byte, sig_rl_size uint) ([]byte, []byte, error)
 	// Return report and enclave PK in DER-encoded PKIX format
 	GetLocalAttestationReport(targetInfo []byte) ([]byte, []byte, error)
 	// Init chaincode
@@ -287,11 +287,22 @@ func NewEnclave() Stub {
 
 // GetRemoteAttestationReport - calls the enclave for attestation, takes SPID as input
 // and returns a quote and enclaves public key
-func (e *StubImpl) GetRemoteAttestationReport(spid []byte) ([]byte, []byte, error) {
-	// quote
-	quote_size := C.sgxcc_get_quote_size()
-	quotePtr := C.malloc(C.ulong(quote_size))
-	defer C.free(quotePtr)
+func (e *StubImpl) GetRemoteAttestationReport(spid []byte, sig_rl []byte, sig_rl_size uint) ([]byte, []byte, error) {
+	//sig_rl
+	var sig_rlPtr unsafe.Pointer
+	if sig_rl == nil {
+		sig_rlPtr = unsafe.Pointer(sig_rlPtr)
+	} else {
+		sig_rlPtr = C.CBytes(sig_rl)
+		defer C.free(sig_rlPtr)
+	}
+
+	// quote size
+	quoteSize := C.uint32_t(0)
+	ret := C.sgxcc_get_quote_size((*C.uint8_t)(sig_rlPtr), C.uint(sig_rl_size), (*C.uint32_t)(unsafe.Pointer(&quoteSize)))
+	if ret != 0 {
+		return nil, nil, fmt.Errorf("C.sgxcc_get_quote_size failed. Reason: %d", int(ret))
+	}
 
 	// pubkey
 	pubkeyPtr := C.malloc(PUB_KEY_SIZE)
@@ -301,11 +312,17 @@ func (e *StubImpl) GetRemoteAttestationReport(spid []byte) ([]byte, []byte, erro
 	spidPtr := C.CBytes(spid)
 	defer C.free(spidPtr)
 
+	// prepare quote space
+	quotePtr := C.malloc(C.ulong(quoteSize))
+	defer C.free(quotePtr)
+
 	e.sem.Acquire(context.Background(), 1)
 	// call enclave
-	// TODO read error
-	C.sgxcc_get_remote_attestation_report(e.eid, (*C.quote_t)(quotePtr), quote_size,
-		(*C.ec256_public_t)(pubkeyPtr), (*C.spid_t)(spidPtr))
+	ret = C.sgxcc_get_remote_attestation_report(e.eid, (*C.quote_t)(quotePtr), C.uint32_t(quoteSize),
+		(*C.ec256_public_t)(pubkeyPtr), (*C.spid_t)(spidPtr), (*C.uint8_t)(sig_rlPtr), C.uint32_t(sig_rl_size))
+	if ret != 0 {
+		return nil, nil, fmt.Errorf("C.sgxcc_get_remote_attestation_report failed. Reason: %d", int(ret))
+	}
 
 	e.sem.Release(1)
 
@@ -315,7 +332,7 @@ func (e *StubImpl) GetRemoteAttestationReport(spid []byte) ([]byte, []byte, erro
 		return nil, nil, err
 	}
 
-	return C.GoBytes(quotePtr, C.int(quote_size)), pk, nil
+	return C.GoBytes(quotePtr, C.int(quoteSize)), pk, nil
 }
 
 // GetLocalAttestationReport - calls the enclave for attestation, takes SPID as input
@@ -352,8 +369,7 @@ func (e *StubImpl) Init(args []byte, shimStub shim.ChaincodeStubInterface, tlccS
 	defer C.free(signaturePtr)
 
 	e.sem.Acquire(context.Background(), 1)
-	// invoke enclave
-	// TODO read error
+	// invoke (init) enclave
 	ret := C.sgxcc_init(e.eid,
 		argsPtr,
 		(*C.uint8_t)(responsePtr), C.uint32_t(MAX_RESPONSET_SIZE), &responseLenOut,
@@ -403,7 +419,6 @@ func (e *StubImpl) Invoke(args []byte, pk []byte, shimStub shim.ChaincodeStubInt
 
 	e.sem.Acquire(context.Background(), 1)
 	// invoke enclave
-	// TODO read error
 	ret := C.sgxcc_invoke(e.eid,
 		argsPtr,
 		pkPtr,
@@ -430,9 +445,11 @@ func (e *StubImpl) GetPublicKey() ([]byte, error) {
 
 	e.sem.Acquire(context.Background(), 1)
 	// call enclave
-	// TODO read error
-	C.sgxcc_get_pk(e.eid, (*C.ec256_public_t)(pubkeyPtr))
+	ret := C.sgxcc_get_pk(e.eid, (*C.ec256_public_t)(pubkeyPtr))
 	e.sem.Release(1)
+	if ret != 0 {
+		return nil, fmt.Errorf("C.sgxcc_get_pk failed. Reason: %d", int(ret))
+	}
 
 	// convert sgx format to DER-encoded PKIX format
 	return crypto.MarshalEnclavePk(C.GoBytes(pubkeyPtr, C.int(PUB_KEY_SIZE)))
@@ -441,7 +458,6 @@ func (e *StubImpl) GetPublicKey() ([]byte, error) {
 // Create starts a new enclave instance
 func (e *StubImpl) Create(enclaveLibFile string) error {
 	var eid C.enclave_id_t
-	// todo read error
 	e.sem.Acquire(context.Background(), 1)
 	if ret := C.sgxcc_create_enclave(&eid, C.CString(enclaveLibFile)); ret != 0 {
 		return fmt.Errorf("Can not create enclave (lib %s): Reason: %d", enclaveLibFile, ret)
@@ -457,7 +473,10 @@ func (e *StubImpl) GetTargetInfo() ([]byte, error) {
 	defer C.free(targetInfoPtr)
 
 	e.sem.Acquire(context.Background(), 1)
-	C.sgxcc_get_target_info(e.eid, (*C.target_info_t)(targetInfoPtr))
+	ret := C.sgxcc_get_target_info(e.eid, (*C.target_info_t)(targetInfoPtr))
+	if ret != 0 {
+		return nil, fmt.Errorf("C.sgxcc_get_target_info failed. Reason: %d", int(ret))
+	}
 	e.sem.Release(1)
 
 	return C.GoBytes(targetInfoPtr, TARGET_INFO_SIZE), nil
@@ -493,8 +512,10 @@ func (e *StubImpl) Bind(report, pk []byte) error {
 
 // Destroy kills the current enclave instance
 func (e *StubImpl) Destroy() error {
-	// todo read error
-	C.sgxcc_destroy_enclave(e.eid)
+	ret := C.sgxcc_destroy_enclave(e.eid)
+	if ret != 0 {
+		return fmt.Errorf("C.sgxcc_destroy_enclave failed. Reason: %d", int(ret))
+	}
 	return nil
 }
 

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright 2019 Intel Corporation
  * Copyright IBM Corp. All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
@@ -24,12 +25,44 @@
 #define RED "\x1B[31m"
 #define CYN "\x1B[36m"
 
-#define LOG_ERROR(fmt, ...) golog(CYN "ERROR" RED fmt NRM "\n", ##__VA_ARGS__)
+//TODO: separate logging in sgxcclib
 
 // Prototypes of CGo functions implemented in ecc/enclave/enclave_stub.go
-
 // - logging
 extern void golog(const char* format, ...);
+
+#include <stdio.h>
+#include <stdarg.h>
+
+#define BUF_SIZE 1024
+#define LARGE_BUF_SIZE (BUF_SIZE*2)
+void LOG_ERROR(const char* fmt, ...) {
+    //create message
+    char msg[BUF_SIZE];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, BUF_SIZE, fmt, ap);
+    va_end(ap);
+    //color the message
+    char colored_msg[LARGE_BUF_SIZE];
+    snprintf(colored_msg, LARGE_BUF_SIZE, RED "ERROR: %s" NRM "\n", msg);
+    //dump message
+    golog(colored_msg);
+}
+
+void LOG_DEBUG(const char* fmt, ...) {
+    //create message
+    char msg[BUF_SIZE];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, BUF_SIZE, fmt, ap);
+    va_end(ap);
+    //color the message
+    char colored_msg[LARGE_BUF_SIZE];
+    snprintf(colored_msg, LARGE_BUF_SIZE, CYN "DEBUG: %s" NRM "\n", msg);
+    //dump message
+    golog(colored_msg);
+}
 
 // - creator access
 extern void get_creator_name(
@@ -55,7 +88,7 @@ int sgxcc_create_enclave(sgx_enclave_id_t* eid, const char* enclave_file)
     if (access(enclave_file, F_OK) == -1)
     {
         LOG_ERROR("Lib: enclave file does not exist! %s", enclave_file);
-        return -1;
+        return SGX_ERROR_UNEXPECTED;
     }
 
     sgx_launch_token_t token = {0};
@@ -68,15 +101,13 @@ int sgxcc_create_enclave(sgx_enclave_id_t* eid, const char* enclave_file)
         return ret;
     }
 
-    int enclave_ret = -1;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     ret = ecall_init(*eid, &enclave_ret);
     if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: Unable to initialize enclave. reason: %d", ret);
-        return ret;
     }
-
-    return SGX_SUCCESS;
+    return enclave_ret;
 }
 
 int sgxcc_destroy_enclave(enclave_id_t eid)
@@ -85,48 +116,59 @@ int sgxcc_destroy_enclave(enclave_id_t eid)
     if (ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: Error: %d", ret);
-        return ret;
     }
-    return SGX_SUCCESS;
+    return ret;
 }
 
-uint32_t sgxcc_get_quote_size()
+int sgxcc_get_quote_size(uint8_t *p_sig_rl, uint32_t sig_rl_size, uint32_t *p_quote_size)
 {
-    uint32_t needed_quote_size = 0;
-    sgx_calc_quote_size(NULL, 0, &needed_quote_size);
-    return needed_quote_size;
+    *p_quote_size = 0;
+    if(sig_rl_size > 0 && p_sig_rl == NULL) {
+        LOG_ERROR("Lib: Error: sigrlsize not zero but null sig_rl");
+        return SGX_ERROR_UNEXPECTED;
+    }
+    if(p_quote_size == NULL) {
+        LOG_ERROR("Lib: Error: pquotesize is null");
+        return SGX_ERROR_UNEXPECTED;
+    }
+
+    sgx_status_t ret = sgx_calc_quote_size(p_sig_rl, sig_rl_size, p_quote_size);
+    if(ret != SGX_SUCCESS) {
+        LOG_ERROR("Lib: Error: %d", ret);
+    }
+
+    return (int)ret;
 }
 
-int sgxcc_get_target_info(enclave_id_t eid, target_info_t* target_info)
+int sgxcc_get_target_info(enclave_id_t eid, target_info_t* p_target_info)
 {
-    int enclave_ret;
-    int ret = ecall_get_target_info(eid, &enclave_ret, (sgx_target_info_t*)target_info);
+    int ret = sgx_get_target_info(eid, (sgx_target_info_t*)p_target_info);
     if (ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - ecall_get_target_info: %d", ret);
     }
+
     return ret;
 }
 
 int sgxcc_get_local_attestation_report(
     enclave_id_t eid, target_info_t* target_info, report_t* report, ec256_public_t* pubkey)
 {
-    int enclave_ret;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     int ret = ecall_create_report(eid, &enclave_ret, (sgx_target_info_t*)target_info,
         (sgx_report_t*)report, (uint8_t*)pubkey);
-    if (ret != SGX_SUCCESS)
+    if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - ecall_create_report: %d", ret);
-        return ret;
     }
-    return ret;
+    return enclave_ret;
 }
 
 int sgxcc_bind(enclave_id_t eid, report_t* report, ec256_public_t* pubkey)
 {
-    int enclave_ret;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     int ret = ecall_bind_tlcc(eid, &enclave_ret, (sgx_report_t*)report, (uint8_t*)pubkey);
-    if (ret != SGX_SUCCESS)
+    if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - ecall_bind_tlcc: %d", ret);
     }
@@ -134,7 +176,7 @@ int sgxcc_bind(enclave_id_t eid, report_t* report, ec256_public_t* pubkey)
 }
 
 int sgxcc_get_remote_attestation_report(
-    enclave_id_t eid, quote_t* quote, uint32_t quote_size, ec256_public_t* pubkey, spid_t* spid)
+    enclave_id_t eid, quote_t* quote, uint32_t quote_size, ec256_public_t* pubkey, spid_t* spid, uint8_t *p_sig_rl, uint32_t sig_rl_size)
 {
     sgx_target_info_t qe_target_info = {0};
     sgx_epid_group_id_t gid = {0};
@@ -148,49 +190,50 @@ int sgxcc_get_remote_attestation_report(
     }
 
     // get report from enclave
-    int enclave_ret = -1;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     ret = ecall_create_report(eid, &enclave_ret, &qe_target_info, &report, (uint8_t*)pubkey);
-    if (ret != SGX_SUCCESS)
+    if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
+        LOG_ERROR("Lib: ERROR - ecall_create_report: %d", ret);
+        return enclave_ret;
+    }
+
+    uint32_t required_quote_size = 0;
+    ret = sgxcc_get_quote_size(p_sig_rl, sig_rl_size, &required_quote_size);
+    if(ret != SGX_SUCCESS)
+    {
+        LOG_ERROR("Lib: ERROR - get quote size, %d", ret);
         return ret;
     }
-
-    int32_t needed = sgxcc_get_quote_size();
-    if (quote_size < needed)
+    if (quote_size < required_quote_size)
     {
-        LOG_ERROR("Lib: ERROR - quote size to small needed: %i but have %i", needed, quote_size);
+        LOG_ERROR("Lib: ERROR - quote size too small. Required %u have %u", required_quote_size, quote_size);
         return SGX_ERROR_OUT_OF_MEMORY;
     }
-
-    // TODO: retrieve SigRL from IAS instead of just passing NULL below ...
 
     ret = sgx_get_quote(&report, SGX_QUOTE_SIGN_TYPE,
         (sgx_spid_t*)spid,  // spid
         NULL,               // nonce
-        NULL,               // sig_rl
-        0,                  // sig_rl_size
+        p_sig_rl,           // sig_rl
+        sig_rl_size,        // sig_rl_size
         NULL,               // p_qe_report
         (sgx_quote_t*)quote, quote_size);
 
     if (ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - sgx_get_quote: %d", ret);
-        return ret;
     }
-
     return ret;
 }
 
 int sgxcc_get_pk(enclave_id_t eid, ec256_public_t* pubkey)
 {
-    int enclave_ret;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     int ret = ecall_get_pk(eid, &enclave_ret, (uint8_t*)pubkey);
-    if (ret != SGX_SUCCESS)
+    if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - ecall_get_pk: %d", ret);
-        return ret;
     }
-
     return enclave_ret;
 }
 
@@ -202,18 +245,16 @@ int sgxcc_init(enclave_id_t eid,
     ec256_signature_t* signature,
     void* ctx)
 {
-    int enclave_ret;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     int ret = ecall_cc_init(eid, &enclave_ret,
         encoded_args,                                 // args (encoded and potentially encrypted)
         response, response_len_in, response_len_out,  // response
         (sgx_ec256_signature_t*)signature,            // signature
         ctx);                                         // context for callback
-    if (ret != SGX_SUCCESS)
+    if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - invoke: %d", ret);
-        return ret;
     }
-
     return enclave_ret;
 }
 
@@ -226,20 +267,30 @@ int sgxcc_invoke(enclave_id_t eid,
     ec256_signature_t* signature,
     void* ctx)
 {
-    int enclave_ret;
+    int enclave_ret = SGX_ERROR_UNEXPECTED;
     int ret = ecall_cc_invoke(eid, &enclave_ret,
         encoded_args,  // args  (encoded and potentially encrypted)
         pk,            // client pk used for args encryption, if null no encryption used
         response, response_len_in, response_len_out,  // response
         (sgx_ec256_signature_t*)signature,            // signature
         ctx);                                         // context for callback
-    if (ret != SGX_SUCCESS)
+    if (ret != SGX_SUCCESS || enclave_ret != SGX_SUCCESS)
     {
         LOG_ERROR("Lib: ERROR - invoke: %d", ret);
-        return ret;
     }
 
     return enclave_ret;
+}
+
+int sgxcc_get_egid(unsigned int* p_egid) {
+    sgx_target_info_t target_info = {0};
+    int ret = sgx_init_quote(&target_info, (sgx_epid_group_id_t*)p_egid);
+    if (ret != SGX_SUCCESS)
+    {
+        LOG_ERROR("Lib: ERROR - sgx_get_egid: %d", ret);
+    }
+    LOG_DEBUG("EGID: %u", *p_egid);
+    return ret;
 }
 
 /* OCall functions */

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -145,7 +145,7 @@ int sgxcc_get_target_info(enclave_id_t eid, target_info_t* p_target_info)
     int ret = sgx_get_target_info(eid, (sgx_target_info_t*)p_target_info);
     if (ret != SGX_SUCCESS)
     {
-        LOG_ERROR("Lib: ERROR - ecall_get_target_info: %d", ret);
+        LOG_ERROR("Lib: ERROR - sgx_get_target_info: %d", ret);
     }
 
     return ret;

--- a/ecc_enclave/sgxcclib/sgxcclib.h
+++ b/ecc_enclave/sgxcclib/sgxcclib.h
@@ -17,13 +17,13 @@ int sgxcc_create_enclave(enclave_id_t* eid, const char* enclave_file);
 
 int sgxcc_destroy_enclave(enclave_id_t eid);
 
-uint32_t sgxcc_get_quote_size(void);
+int sgxcc_get_quote_size(uint8_t *p_sig_rl, uint32_t sig_rl_size, uint32_t *p_quote_size);
 
 int sgxcc_get_local_attestation_report(
     enclave_id_t eid, target_info_t* target_info, report_t* report, ec256_public_t* pubkey);
 
 int sgxcc_get_remote_attestation_report(
-    enclave_id_t eid, quote_t* quote, uint32_t quote_size, ec256_public_t* pubkey, spid_t* spid);
+    enclave_id_t eid, quote_t* quote, uint32_t quote_size, ec256_public_t* pubkey, spid_t* spid, uint8_t *p_sig_rl, uint32_t sig_rl_size);
 
 int sgxcc_get_target_info(enclave_id_t eid, target_info_t* target_info);
 
@@ -50,6 +50,8 @@ int sgxcc_invoke(enclave_id_t eid,
     void* ctx);
 
 int sgxcc_get_pk(enclave_id_t eid, ec256_public_t* pubkey);
+
+int sgxcc_get_egid(unsigned int* p_egid);
 
 #ifdef __cplusplus
 }

--- a/tlcc_enclave/trusted_ledger/trusted_ledger.c
+++ b/tlcc_enclave/trusted_ledger/trusted_ledger.c
@@ -65,10 +65,10 @@ uint32_t tlcc_get_quote_size()
     return needed_quote_size;
 }
 
-int tlcc_get_target_info(enclave_id_t eid, target_info_t* target_info)
+int tlcc_get_target_info(enclave_id_t eid, target_info_t* p_target_info)
 {
     int enclave_ret = -1;
-    int ret = ecall_get_target_info(eid, &enclave_ret, (sgx_target_info_t*)target_info);
+    int ret = sgx_get_target_info(eid, (sgx_target_info_t*)p_target_info);
     if (ret != SGX_SUCCESS)
     {
         PERR("Lib: ERROR - ecall_target_info: %s", ret);


### PR DESCRIPTION
This addresses issue #87 . Additionally
* improved (but not complete) handling of sig_rl
* removed ecall for get_target, use the sgx function instead
* improved log functions in sgxcclib (next: move these in a separate package/source file)

Note: linter/indentation checks might fail. This is addressed in separate PR