### PR TITLE
Fixing Issue #42

### DIFF
--- a/ecc/vscc/ecc_validation_logic.go
+++ b/ecc/vscc/ecc_validation_logic.go
@@ -190,6 +190,10 @@ func (vscc *VSCCECC) checkEnclaveEndorsement(cis *peer.ChaincodeInvocationSpec, 
 
 		// range query reads
 		for _, rqi := range ns.KvRwSet.RangeQueriesInfo {
+			if rqi.GetRawReads() == nil {
+				// no raw reads available in this range query
+				continue
+			}
 			for _, qr := range rqi.GetRawReads().KvReads {
 				k := sgx_utils.TransformToSGX(qr.Key, sgx_utils.SEP)
 				readKeys = append(readKeys, k)

--- a/integration/auction_test.sh
+++ b/integration/auction_test.sh
@@ -93,9 +93,9 @@ auction_test() {
     check_result "NO_BIDS"
 
     # Code below is used to test bug in issue #42
-    #becho ">>>> Create a new auction. Response should be OK"
-    #try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"create", "Args": ["MyAuction4"]}' --waitForEvent
-    #check_result "OK"
+    becho ">>>> Create a new auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"create", "Args": ["MyAuction4"]}' --waitForEvent
+    check_result "OK"
 }
 
 # 1. prepare


### PR DESCRIPTION
This commit fixes the problem of ecc-vscc crashes when processing
a transaction containing an empty range queries result. This may
happen, for instance, when an auction evaluation is invoked but
no bids are submitted. In detail, a range query is performed but
does not contain any raw reads.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>