### PR TITLE
Fixing issue 152

### DIFF
--- a/tlcc_enclave/enclave/ledger.cpp
+++ b/tlcc_enclave/enclave/ledger.cpp
@@ -675,8 +675,8 @@ int parse_endorser_transaction(
                         }
                         LOG_DEBUG("Ledger: \t\t\t \\-> key = %s", key.c_str());
                         // note prototype does not support deletes
-                        std::string val((const char*)kvrwset.writes[0].value->bytes,
-                            kvrwset.writes[0].value->size);
+                        std::string val((const char*)kvrwset.writes[i].value->bytes,
+                            kvrwset.writes[i].value->size);
                         version_t version = {tx_version->block_num, tx_version->tx_num};
                         updates->insert(kvs_item_t(key, kvs_value_t(val, version)));
 


### PR DESCRIPTION
This commit fixes the issue that some read-write set validations at tlcc
failed. In particular, this was the case when multiple writes are in one
transaction.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>