### PR TITLE
Add "Contributions Welcome" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,13 +436,14 @@ By running the following command you can generate the documentation.
 Found a bug? Need help to fix an issue? You have a great idea for a new feature? Talk to us! You can reach us on
 [RocketChat](https://chat.hyperledger.org/) in #private-data-objects. 
 
-For more information on how to contribute to Fabric Private Chaincode please see our [contribution](CONTRIBUTING.md)
-section.
-
 We also have a weekly meeting every Tuesday at 3 pm GMT on [Zoom](https://zoom.us/my/hyperledger.community.3). Please
 see the Hyperledger [community calendar](https://wiki.hyperledger.org/display/HYP/Calendar+of+Public+Meetings) for
 details.
 
+## Contributions Welcome
+
+For more information on how to contribute to Fabric Private Chaincode please see our [contribution](CONTRIBUTING.md)
+section.
 
 ## References
 


### PR DESCRIPTION
In order to make the "how to contribute" information more prominent, this commit creates a section with a link to the CONTRIBUTING guide.

Fixes Issue #178 