### PR TITLE
Auction chaincode testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ godeps: gotools
 	$(GO) get github.com/golang/protobuf/proto
 	$(GO) get github.com/onsi/ginkgo
 	$(GO) get github.com/onsi/gomega
+	$(GO) get github.com/gin-contrib/cors
+	$(GO) get github.com/gin-gonic/gin
 
 plugins:
 	$(foreach DIR, $(PLUGINS), $(MAKE) -C $(DIR) build || exit;)

--- a/demo/chaincode/golang/auction.go
+++ b/demo/chaincode/golang/auction.go
@@ -1,0 +1,265 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package golang
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+const auctionKeyPrefix = "auction_"
+const auctionStatusKeyPostfix = "_status"
+const bidKeyPrefix = "bid_"
+
+func storeAuctionStatus(stub shim.ChaincodeStubInterface, auctionId int, status *AuctionStatus) error {
+	statusJson, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("json error: %s", err)
+	}
+
+	key := auctionKeyPrefix + string(auctionId) + auctionStatusKeyPostfix
+	err = stub.PutState(key, statusJson)
+	if err != nil {
+		return fmt.Errorf("putState error: %s", err)
+	}
+
+	return nil
+}
+
+func fetchAuctionStatus(stub shim.ChaincodeStubInterface, auctionId int) (*AuctionStatus, error) {
+	key := auctionKeyPrefix + string(auctionId) + auctionStatusKeyPostfix
+	auctionStatusJson, err := stub.GetState(key)
+	if err != nil {
+		return nil, fmt.Errorf("getState error: %s", err)
+	}
+
+	if auctionStatusJson == nil {
+		return nil, fmt.Errorf("auction status with id %d does not exist", auctionId)
+	}
+
+	var auctionStatus AuctionStatus
+	err = json.Unmarshal(auctionStatusJson, &auctionStatus)
+	if err != nil {
+		return nil, fmt.Errorf("json error: %s", err)
+	}
+
+	return &auctionStatus, nil
+}
+
+func fetchAuctionDetails(stub shim.ChaincodeStubInterface, auctionId int) (*Auction, error) {
+	key := auctionKeyPrefix + string(auctionId)
+	auctionJson, err := stub.GetState(key)
+	if err != nil {
+		return nil, fmt.Errorf("getState error: %s", err)
+	}
+
+	if auctionJson == nil {
+		return nil, fmt.Errorf("auction details with id %d does not exist", auctionId)
+	}
+
+	var auction Auction
+	err = json.Unmarshal(auctionJson, &auction)
+	return &auction, nil
+}
+
+func createAuction(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	// hardcoded auction id
+	request := &AuctionRequest{1}
+
+	// static state from input
+	var auction Auction
+	err := json.Unmarshal([]byte(args[0]), &auction)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	// assign owner
+	auction.Owner = &Principle{[]byte("auctioneeer@org4"), "auctioneeer"}
+
+	auctionJson, err := json.Marshal(auction)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	key := auctionKeyPrefix + string(request.AuctionId)
+	err = stub.PutState(key, auctionJson)
+	if err != nil {
+		return shim.Error("PutState error: " + err.Error())
+	}
+
+	// dynamic state
+	auctionStatus := &AuctionStatus{"clock", 1, true}
+	err = storeAuctionStatus(stub, request.AuctionId, auctionStatus)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	status := &Status{0, "OK"}
+
+	return shim.Success(buildReturnJson(status, request))
+}
+
+func getAuctionDetails(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var request AuctionRequest
+	err := json.Unmarshal([]byte(args[0]), &request)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	auction, err := fetchAuctionDetails(stub, request.AuctionId)
+	if err != nil {
+		status := &Status{-1, err.Error()}
+		return shim.Success(buildReturnJson(status, nil))
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, auction))
+}
+
+func getAuctionStatus(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var request AuctionRequest
+	err := json.Unmarshal([]byte(args[0]), &request)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	auctionStatus, err := fetchAuctionStatus(stub, request.AuctionId)
+	if err != nil {
+		status := &Status{-1, err.Error()}
+		return shim.Success(buildReturnJson(status, nil))
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, auctionStatus))
+}
+
+func submitClockBid(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	bidId := "1"
+	err := stub.PutState(bidKeyPrefix+bidId, []byte(args[0]))
+	if err != nil {
+		return shim.Error("PutState error: " + err.Error())
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, nil))
+}
+
+func endRound(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var request AuctionRequest
+	err := json.Unmarshal([]byte(args[0]), &request)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	auctionStatus, err := fetchAuctionStatus(stub, request.AuctionId)
+	if err != nil {
+		status := &Status{-1, err.Error()}
+		return shim.Success(buildReturnJson(status, nil))
+	}
+
+	auctionStatus.RoundActive = false
+
+	err = storeAuctionStatus(stub, request.AuctionId, auctionStatus)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, nil))
+}
+
+func startNextRound(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var request AuctionRequest
+	err := json.Unmarshal([]byte(args[0]), &request)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	auctionStatus, err := fetchAuctionStatus(stub, request.AuctionId)
+	if err != nil {
+		status := &Status{-1, err.Error()}
+		// TODO discuss if this is a shim error os success?
+		return shim.Success(buildReturnJson(status, nil))
+	}
+
+	auctionStatus.ClockRound = auctionStatus.ClockRound + 1
+	auctionStatus.RoundActive = true
+
+	err = storeAuctionStatus(stub, request.AuctionId, auctionStatus)
+	if err != nil {
+		return shim.Error(err.Error())
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, nil))
+}
+
+func getRoundInfo(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var request RoundRequest
+	err := json.Unmarshal([]byte(args[0]), &request)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	auction, err := fetchAuctionDetails(stub, request.AuctionId)
+	if err != nil {
+		status := &Status{-1, err.Error()}
+		return shim.Success(buildReturnJson(status, nil))
+	}
+
+	// gather information for round
+	auctionStatus, err := fetchAuctionStatus(stub, request.AuctionId)
+	if err != nil {
+		status := &Status{-1, err.Error()}
+		// TODO discuss if this is a shim error os success?
+		return shim.Success(buildReturnJson(status, nil))
+	}
+
+	var prices []Price
+	for _, territory := range auction.Territories {
+		prices = append(prices, Price{
+			TerritoryId: territory.Id,
+			MinPrice:    territory.MinPrice,
+			ClockPrice:  int(float64(territory.MinPrice) * (1 + float64(auction.ClockPriceIncrementPercentage)/100.0)),
+		})
+	}
+
+	response := &RoundInfo{
+		Prices: prices,
+		Active: auctionStatus.RoundActive,
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, response))
+}
+
+func getBidderRoundResults(stub shim.ChaincodeStubInterface, args []string) pb.Response {
+	var request RoundRequest
+	err := json.Unmarshal([]byte(args[0]), &request)
+	if err != nil {
+		return shim.Error("json error: " + err.Error())
+	}
+
+	results := []Result{{
+		TerritoryId:       1,
+		PostedPrice:       50,
+		ExcessDemand:      1000,
+		ProcessedLicenses: 40,
+	}}
+
+	response := &BidderRoundResult{
+		Result:                 results,
+		FutureEligibility:      31,
+		RequiredFutureActivity: 5187,
+	}
+
+	status := &Status{0, "OK"}
+	return shim.Success(buildReturnJson(status, response))
+}

--- a/demo/chaincode/golang/chaincode.go
+++ b/demo/chaincode/golang/chaincode.go
@@ -1,0 +1,68 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package golang
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hyperledger-labs/fabric-private-chaincode/utils"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+var logger = shim.NewLogger("MockAuction")
+
+type MockAuction struct {
+	dispatcher map[string]func(shim.ChaincodeStubInterface, []string) pb.Response
+}
+
+// Init initializes the chaincode
+func (t *MockAuction) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+func (t *MockAuction) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	function, args := stub.GetFunctionAndParameters()
+	logger.Info(fmt.Sprintf("invoke: `%s` with args: %s\n", function, args))
+
+	action, exists := t.dispatcher[function]
+	if !exists {
+		return shim.Error("Invalid invoke function name")
+	}
+
+	response := action(stub, args)
+	logger.Info(fmt.Sprintf("Response: %s\n", response.Payload))
+
+	if response.Status != shim.OK {
+		// if we have an error return
+		return response
+	}
+
+	// otherwise, wrap response in a ecc compatible response
+	responseMsg := &utils.Response{
+		ResponseData: response.Payload,
+		Signature:    []byte("fake-signature"),
+		PublicKey:    []byte("fake-pk"),
+	}
+	responseBytes, _ := json.Marshal(responseMsg)
+	return shim.Success(responseBytes)
+}
+
+func NewMockAuction() shim.Chaincode {
+	actions := map[string]func(shim.ChaincodeStubInterface, []string) pb.Response{
+		"createAuction":         createAuction,
+		"getAuctionDetails":     getAuctionDetails,
+		"getAuctionStatus":      getAuctionStatus,
+		"submitClockBid":        submitClockBid,
+		"endRound":              endRound,
+		"startNextRound":        startNextRound,
+		"getRoundInfo":          getRoundInfo,
+		"getBidderRoundResults": getBidderRoundResults,
+	}
+	return &MockAuction{dispatcher: actions}
+}

--- a/demo/chaincode/golang/cmd/main.go
+++ b/demo/chaincode/golang/cmd/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	cc "github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/golang"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+var logger = flogging.MustGetLogger("go_mock_auction")
+
+func main() {
+	// create enclave chaincode
+	t := cc.NewMockAuction()
+
+	// start chaincode
+	if err := shim.Start(t); err != nil {
+		logger.Errorf("Error starting ecc: %s", err)
+	}
+}

--- a/demo/chaincode/golang/messages.go
+++ b/demo/chaincode/golang/messages.go
@@ -1,0 +1,113 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package golang
+
+import (
+	"encoding/json"
+)
+
+// Messages
+type AuctionStatus struct {
+	State       string `json:"state"` // "clock" | "assign" | "done" | "failed_fsr"
+	ClockRound  int    `json:"clockRound"`
+	RoundActive bool   `json:"roundActive"`
+}
+
+type Status struct {
+	Rc  int    `json:"rc"`
+	Msg string `json:"msg"`
+}
+
+type ReturnMsg struct {
+	Status   *Status     `json:"status"`
+	Response interface{} `json:"response"`
+}
+
+func buildReturnJson(status *Status, response interface{}) []byte {
+	msg := ReturnMsg{
+		Status:   status,
+		Response: response,
+	}
+
+	payload, _ := json.Marshal(msg)
+	return payload
+}
+
+type RoundRequest struct {
+	AuctionId int `json:"auctionId"`
+	Round     int `json:"round"`
+}
+
+type RoundInfo struct {
+	Prices []Price `json:"prices"`
+	Active bool    `json:"active"`
+}
+
+type Price struct {
+	TerritoryId int `json:"terId"`
+	MinPrice    int `json:"minPrice"`
+	ClockPrice  int `json:"clockPrice"`
+}
+
+type BidderRoundResult struct {
+	Result                 []Result `json:"result"`
+	FutureEligibility      int      `json:"futureEligibility"`
+	RequiredFutureActivity int      `json:"requiredFutureActivity"`
+}
+
+type Result struct {
+	TerritoryId       int `json:"terId"`
+	PostedPrice       int `json:"postedPrice"`
+	ExcessDemand      int `json:"excessDemand"`
+	ProcessedLicenses int `json:"processedLicenses"`
+}
+
+type AuctionRequest struct {
+	AuctionId int `json:"auctionId"`
+}
+
+// State
+
+type Auction struct {
+	Owner                         *Principle    `json:"owner"`
+	Name                          string        `json:"name"`
+	Territories                   []Territory   `json:"territories"`
+	Bidders                       []Bidder      `json:"bidders"`
+	InitialEligibilities          []Eligibility `json:"initialEligibilities"`
+	ActivityRequirementPercentage int           `json:"activityRequirementPercentage"`
+	ClockPriceIncrementPercentage int           `json:"clockPriceIncrementPercentage"`
+}
+
+type Principle struct {
+	Mspid []byte `json:"mspid"`
+	Dn    string `json:"dn"`
+}
+
+type Territory struct {
+	Id           int       `json:"id"`
+	Name         string    `json:"name"`
+	IsHighDemand bool      `json:"isHighDemand"`
+	MinPrice     int       `json:"minPrice"`
+	Channels     []Channel `json:"channels"`
+}
+
+type Eligibility struct {
+	BidderId int `json:"bidderId"`
+	Number   int `json:"number"`
+}
+
+type Bidder struct {
+	Id          int        `json:"id"`
+	DisplayName string     `json:"displayName"`
+	Principle   *Principle `json:"principle"`
+}
+
+type Channel struct {
+	Id         int    `json:"id"`
+	Name       string `json:"name"`
+	Impairment int    `json:"impairment"`
+}

--- a/demo/client/backend/mock/Makefile
+++ b/demo/client/backend/mock/Makefile
@@ -1,0 +1,17 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOP = ../../../..
+include $(TOP)/build.mk
+
+CC_NAME = auction_mock_chaincode
+DOCKER_IMAGE = auction_mock_backend
+APP_SRC = ${PWD}
+
+run-go:
+	$(GO) run .
+
+run-fpc:
+	$(GO) build -tags fpc
+	./mock

--- a/demo/client/backend/mock/README.md
+++ b/demo/client/backend/mock/README.md
@@ -1,0 +1,64 @@
+# FPC Mock Server
+
+This mock server allows to run a FPC chaincode without a Fabric peer and exposes the chaincode interface via REST.
+
+The goal of this tool is to simplify FPC chaincode development and enabled quick testing of FPC chaincodes without
+deploying on Fabric network. 
+
+## Start with go chaincode
+
+    $ make run-go
+
+## Start with fpc chaincode
+
+The mock server uses ECC to load and interact with an FPC chaincode. First make sure you have build FPC.  
+
+    $ cd $FPC_PATH
+    $ make clean && make
+    $ cd $FPC_PATH/ecc
+    $ make sym-links
+
+Next build your FPC chaincode.
+    
+    $ cd $FPC_PATH/examples/YOUR_CHAINCODE
+    $ make
+
+We are almost there ...
+   
+    $ cd $FPC_PATH/demo/client/backend/mock
+    $ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+"${LD_LIBRARY_PATH}:"}${FPC_PATH}/ecc_enclave/_build/lib
+    $ ln -s $FPC_PATH/examples/YOUR_CHAINCODE/_build/ enclave
+
+Finally, we can build the mock server running our FPC chaincode
+      
+    $ make run-fpc
+
+### Additional notes
+
+When running inside FPC dev docker container, please make sure that you run `make godeps` in `$FPC_PATH` before starting the mock server.
+
+### Building manually
+
+In case you want to build and start the mock server by hand you can do that easily by following these instructions. 
+
+    $ go build -tags fpc
+    $ ./mock
+
+By default the mock server starts on port 3000. If you need to start the server on a different port you can can do it by running the following command:
+
+    $ ./mock --port=8080
+
+## Usage
+
+Once the server is up and running it can receive invoke and query requests and forward them to the chaincode.
+
+Example:
+
+    curl -H "Content-Type: application/json" -H "x-user:fake-user" -X POST -d '{"tx":"someChaincodeFunction","args":["arg1", "arg2"]}' http://localhost:3000/api/cc/invoke
+    curl -H "Content-Type: application/json" -H "x-user:fake-user" -X POST -d '{"tx":"anotherChaincodeFunction","args":["arg1", "arg2"]}' http://localhost:3000/api/cc/query
+
+### Logging
+
+In order to get FPC Chaincode Debug logging you need to compile the chaincode with `SGX_BUILD=DEBUG`.
+
+Good luck!

--- a/demo/client/backend/mock/api/mock_data.go
+++ b/demo/client/backend/mock/api/mock_data.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+var MockData map[string]interface{}
+
+func init() {
+	MockData, _ = loadMockData()
+}
+
+func loadMockData() (map[string]interface{}, error) {
+	jsonFile, err := os.Open("api/serverapi.json")
+	defer jsonFile.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(byteValue, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/demo/client/backend/mock/api/serverapi.json
+++ b/demo/client/backend/mock/api/serverapi.json
@@ -1,0 +1,275 @@
+{
+  "getRegisteredUsers": [
+    {
+      "id": "A-Telecom",
+      "approle": "auction.bidder"
+    },
+    {
+      "id": "B-Net",
+      "approle": "auction.bidder"
+    },
+    {
+      "id": "C-Mobile",
+      "approle": "auction.bidder"
+    },
+    {
+      "id": "Auctioneer1",
+      "approle": "auction.auctioneer"
+    }
+  ],
+  "getDefaultAuction": {
+    "name": "Spectrum Auction 2020",
+    "activityRequirementPercentage": 95,
+    "clockPriceIncrementPercentage": 10,
+    "territories": [
+      {
+        "id": 1,
+        "name": "Elbograd",
+        "isHighDemand": false,
+        "minPrice": 10000,
+        "channels": [
+          {
+            "id": 1,
+            "name": "a",
+            "impairment": 13
+          },
+          {
+            "id": 2,
+            "name": "b",
+            "impairment": 0
+          },
+          {
+            "id": 3,
+            "name": "c",
+            "impairment": 5
+          },
+          {
+            "id": 4,
+            "name": "d",
+            "impairment": 6
+          },
+          {
+            "id": 5,
+            "name": "e",
+            "impairment": 0
+          },
+          {
+            "id": 6,
+            "name": "f",
+            "impairment": 12
+          },
+          {
+            "id": 7,
+            "name": "g",
+            "impairment": 20
+          },
+          {
+            "id": 8,
+            "name": "h",
+            "impairment": 5
+          },
+          {
+            "id": 9,
+            "name": "i",
+            "impairment": 0
+          },
+          {
+            "id": 10,
+            "name": "j",
+            "impairment": 10
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "name": "Mudberg",
+        "isHighDemand": false,
+        "minPrice": 6000,
+        "channels": [
+          {
+            "id": 1,
+            "name": "a",
+            "impairment": 20
+          },
+          {
+            "id": 2,
+            "name": "b",
+            "impairment": 25
+          },
+          {
+            "id": 3,
+            "name": "c",
+            "impairment": 10
+          },
+          {
+            "id": 4,
+            "name": "d",
+            "impairment": 5
+          },
+          {
+            "id": 5,
+            "name": "e",
+            "impairment": 0
+          },
+          {
+            "id": 6,
+            "name": "f",
+            "impairment": 0
+          },
+          {
+            "id": 7,
+            "name": "g",
+            "impairment": 0
+          },
+          {
+            "id": 8,
+            "name": "h",
+            "impairment": 0
+          },
+          {
+            "id": 9,
+            "name": "i",
+            "impairment": 15
+          },
+          {
+            "id": 10,
+            "name": "j",
+            "impairment": 23
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "name": "Deserton",
+        "isHighDemand": false,
+        "minPrice": 6000,
+        "channels": [
+          {
+            "id": 1,
+            "name": "a",
+            "impairment": 0
+          },
+          {
+            "id": 2,
+            "name": "b",
+            "impairment": 0
+          },
+          {
+            "id": 3,
+            "name": "c",
+            "impairment": 6
+          },
+          {
+            "id": 4,
+            "name": "d",
+            "impairment": 10
+          },
+          {
+            "id": 5,
+            "name": "e",
+            "impairment": 5
+          },
+          {
+            "id": 6,
+            "name": "f",
+            "impairment": 0
+          },
+          {
+            "id": 7,
+            "name": "g",
+            "impairment": 0
+          },
+          {
+            "id": 8,
+            "name": "h",
+            "impairment": 0
+          },
+          {
+            "id": 9,
+            "name": "i",
+            "impairment": 0
+          }
+        ]
+      },
+      {
+        "id": 4,
+        "name": "Phlimsk",
+        "isHighDemand": false,
+        "minPrice": 4000,
+        "channels": [
+          {
+            "id": 1,
+            "name": "a",
+            "impairment": 0
+          },
+          {
+            "id": 2,
+            "name": "b",
+            "impairment": 0
+          },
+          {
+            "id": 3,
+            "name": "c",
+            "impairment": 0
+          },
+          {
+            "id": 4,
+            "name": "d",
+            "impairment": 8
+          },
+          {
+            "id": 5,
+            "name": "e",
+            "impairment": 25
+          },
+          {
+            "id": 6,
+            "name": "f",
+            "impairment": 30
+          }
+        ]
+      }
+    ],
+    "bidders": [
+      {
+        "id": 1,
+        "displayName": "A-Telecom",
+        "principle": {
+          "mspid": "org1",
+          "dn": "bidder@org1"
+        }
+      },
+      {
+        "id": 2,
+        "displayName": "B-Net",
+        "principle": {
+          "mspid": "org2",
+          "dn": "bidder@org2"
+        }
+      },
+      {
+        "id": 3,
+        "displayName": "C-Mobil",
+        "principle": {
+          "mspid": "org3",
+          "dn": "bidder@org3"
+        }
+      }
+    ],
+    "initialEligibilities": [
+      {
+        "bidderId": 1,
+        "number": 10000
+      },
+      {
+        "bidderId": 2,
+        "number": 10000
+      },
+      {
+        "bidderId": 3,
+        "number": 10000
+      }
+    ]
+  }
+}
+

--- a/demo/client/backend/mock/chaincode/fpc_chaincode.go
+++ b/demo/client/backend/mock/chaincode/fpc_chaincode.go
@@ -1,0 +1,18 @@
+// +build fpc
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"github.com/hyperledger-labs/fabric-private-chaincode/ecc"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+func NewMockAuction() shim.Chaincode {
+	return ecc.CreateMockedECC()
+}

--- a/demo/client/backend/mock/chaincode/go_chaincode.go
+++ b/demo/client/backend/mock/chaincode/go_chaincode.go
@@ -1,0 +1,18 @@
+// +build !fpc
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	cc "github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/golang"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+func NewMockAuction() shim.Chaincode {
+	return cc.NewMockAuction()
+}

--- a/demo/client/backend/mock/server.go
+++ b/demo/client/backend/mock/server.go
@@ -1,0 +1,121 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-contrib/cors"
+	"github.com/gin-gonic/gin"
+	"github.com/hyperledger-labs/fabric-private-chaincode/demo/client/backend/mock/api"
+	"github.com/hyperledger-labs/fabric-private-chaincode/demo/client/backend/mock/chaincode"
+	"github.com/hyperledger-labs/fabric-private-chaincode/utils"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+var flagPort string
+var stub *shim.MockStub
+var logger = shim.NewLogger("server")
+
+const ccName = "ecc"
+
+func init() {
+	flag.StringVar(&flagPort, "port", "3000", "Port to listen on")
+}
+
+func main() {
+	flag.Parse()
+
+	stub = shim.NewMockStub(ccName, chaincode.NewMockAuction())
+
+	// setup and init
+	stub.MockInvoke("someTxID", [][]byte{[]byte("__setup"), []byte("ercc"), []byte("mychannel"), []byte("tlcc")})
+	stub.MockInvoke("1", [][]byte{[]byte("__init"), []byte("My Auction")})
+
+	config := cors.DefaultConfig()
+	config.AllowAllOrigins = true
+	config.AllowHeaders = append(config.AllowHeaders, "x-user")
+
+	r := gin.Default()
+	r.Use(cors.New(config))
+
+	r.GET("/api/getRegisteredUsers", getAllUsers)
+	r.GET("/api/clock_auction/getDefaultAuction", getDefaultAuction)
+	r.POST("/api/cc/invoke", invoke)
+	// note that using a MockStub there is no need to differentiate between query and invoke
+	r.POST("/api/cc/query", invoke)
+
+	r.Run(":" + flagPort)
+}
+
+func getAllUsers(c *gin.Context) {
+	users := api.MockData["getRegisteredUsers"]
+	c.IndentedJSON(http.StatusOK, users)
+}
+
+func getDefaultAuction(c *gin.Context) {
+	users := api.MockData["getDefaultAuction"]
+	c.IndentedJSON(http.StatusOK, users)
+}
+
+type Payload struct {
+	Tx   string
+	Args []string
+}
+
+func invoke(c *gin.Context) {
+
+	user := c.GetHeader("x-user")
+	logger.Debug(fmt.Sprintf("user: %s\n", user))
+
+	// TODO set creator
+
+	args, err := parsePayload(c)
+	if err != nil {
+		//fmt.Println("Request Error: " + err.Error())
+		logger.Error(fmt.Sprintf("Request Error: %s\n", err))
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	res := stub.MockInvoke("someTxID", args)
+	if res.Status != shim.OK {
+		//fmt.Printf("Chaincode error: %s", res.Message)
+		logger.Error(fmt.Sprintf("Chaincode Error: %s\n", res.Message))
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": res.Message})
+		return
+	}
+
+	// unwarp ecc response and return only responseData
+	// a proper client would now also verify response signature
+	var response utils.Response
+	err = json.Unmarshal(res.Payload, &response)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		return
+	}
+
+	c.Data(http.StatusOK, c.ContentType(), response.ResponseData)
+}
+
+func parsePayload(c *gin.Context) ([][]byte, error) {
+	var payload Payload
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		return nil, err
+	}
+
+	args := make([][]byte, 0)
+	args = append(args, []byte(payload.Tx))
+	for _, b := range payload.Args {
+		args = append(args, []byte(b))
+	}
+
+	return args, nil
+}

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -37,7 +37,7 @@ sym-links:
 	ln -sfn ../../ecc_enclave/_build/include enclave/ecc-enclave-include
 
 ecc: ecc_enclave
-	$(GO) build
+	$(GO) build -o ecc cmd/main.go
 
 vscc-plugin: $(VSCC_SRC)
 	$(GO) build -o $(VSCC_OUT) -buildmode=plugin $^

--- a/ecc/cmd/main.go
+++ b/ecc/cmd/main.go
@@ -1,0 +1,26 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"github.com/hyperledger-labs/fabric-private-chaincode/ecc"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+)
+
+var logger = flogging.MustGetLogger("ecc")
+
+func main() {
+	// create enclave chaincode
+	t := ecc.NewEcc()
+	defer t.Destroy()
+
+	// start chaincode
+	if err := shim.Start(t); err != nil {
+		logger.Errorf("Error starting ecc: %s", err)
+	}
+}

--- a/ecc/enclave_chaincode.go
+++ b/ecc/enclave_chaincode.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package main
+package ecc
 
 import (
 	"encoding/base64"
@@ -38,6 +38,15 @@ func NewEcc() *EnclaveChaincode {
 	return &EnclaveChaincode{
 		erccStub: &ercc.EnclaveRegistryStubImpl{},
 		tlccStub: &tlcc.TLCCStubImpl{},
+		enclave:  enclave.NewEnclave(),
+		verifier: &crypto.ECDSAVerifier{},
+	}
+}
+
+func CreateMockedECC() *EnclaveChaincode {
+	return &EnclaveChaincode{
+		erccStub: &ercc.MockEnclaveRegistryStub{},
+		tlccStub: &tlcc.MockTLCCStub{},
 		enclave:  enclave.NewEnclave(),
 		verifier: &crypto.ECDSAVerifier{},
 	}
@@ -262,22 +271,11 @@ func (t *EnclaveChaincode) getEnclavePk(stub shim.ChaincodeStubInterface) pb.Res
 	return shim.Success(responseBytes)
 }
 
-// TODO: check if destroy is called
-func (t *EnclaveChaincode) destroy() {
+// TODO: check if Destroy is called
+func (t *EnclaveChaincode) Destroy() {
 	if err := t.enclave.Destroy(); err != nil {
 		err_msg := fmt.Sprintf("t.enclave.Destroy failed: %s", err)
 		logger.Errorf(err_msg)
 		panic(err_msg)
-	}
-}
-
-func main() {
-	// create enclave chaincode
-	t := NewEcc()
-	defer t.destroy()
-
-	// start chaincode
-	if err := shim.Start(t); err != nil {
-		logger.Errorf("Error starting ecc: %s", err)
 	}
 }

--- a/ecc/enclave_chaincode_test.go
+++ b/ecc/enclave_chaincode_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package main
+package ecc
 
 import (
 	"crypto/ecdsa"
@@ -18,9 +18,6 @@ import (
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/ecc/crypto"
-	enc "github.com/hyperledger-labs/fabric-private-chaincode/ecc/enclave"
-	"github.com/hyperledger-labs/fabric-private-chaincode/ecc/ercc"
-	"github.com/hyperledger-labs/fabric-private-chaincode/ecc/tlcc"
 	"github.com/hyperledger-labs/fabric-private-chaincode/eval/benchmark/executor"
 	th "github.com/hyperledger-labs/fabric-private-chaincode/utils"
 
@@ -34,7 +31,7 @@ func createArgs(stringArgs []string, pk string) [][]byte {
 
 // my tests
 func TestEnclaveChaincode_Init(t *testing.T) {
-	ecc := createECC()
+	ecc := CreateMockedECC()
 	stub := shim.NewMockStub("ecc", ecc)
 
 	th.CheckInit(t, stub, nil)
@@ -42,7 +39,7 @@ func TestEnclaveChaincode_Init(t *testing.T) {
 }
 
 func TestEnclaveChaincode_Setup(t *testing.T) {
-	ecc := createECC()
+	ecc := CreateMockedECC()
 	stub := shim.NewMockStub("ecc", ecc)
 
 	th.CheckInit(t, stub, nil)
@@ -50,7 +47,7 @@ func TestEnclaveChaincode_Setup(t *testing.T) {
 }
 
 func TestEnclaveChaincode_Invoke(t *testing.T) {
-	ecc := createECC()
+	ecc := CreateMockedECC()
 	stub := shim.NewMockStub("ecc", ecc)
 
 	th.CheckInit(t, stub, nil)
@@ -89,7 +86,7 @@ func (t *Task) doInvoke() error {
 }
 
 func TestEnclaveChaincode_Invoke_Auction(t *testing.T) {
-	ecc := createECC()
+	ecc := CreateMockedECC()
 	stub := shim.NewMockStub("ecc", ecc)
 
 	pk := ""
@@ -192,7 +189,7 @@ func TestEnclaveChaincode_Invoke_Auction(t *testing.T) {
 }
 
 func TestEnclaveChaincode_EncryptedInvoke(t *testing.T) {
-	ecc := createECC()
+	ecc := CreateMockedECC()
 	stub := shim.NewMockStub("ecc", ecc)
 
 	th.CheckInit(t, stub, nil)
@@ -250,14 +247,5 @@ func TestEnclaveChaincode_EncryptedInvoke(t *testing.T) {
 			fmt.Println("Invoke getPK failed", string(res.Message))
 			t.FailNow()
 		}
-	}
-}
-
-func createECC() *EnclaveChaincode {
-	return &EnclaveChaincode{
-		erccStub: &ercc.MockEnclaveRegistryStub{},
-		tlccStub: &tlcc.MockTLCCStub{},
-		enclave:  enc.NewEnclave(),
-		verifier: &crypto.ECDSAVerifier{},
 	}
 }


### PR DESCRIPTION
This commit introduces a fpc chaincode mock server that exposes the
chaincode interface as a simple REST interface. Internally, this testing
server relies on shim.MockStub. The server can load normal go chaincodes
and fpc chaincodes by using ecc. This required a small refactoring of
ecc.

This mock server will be used to simplify fpc auction demo development,
in particular it allows rapid testing of the actual fpc chaincode and
the UI without the need to run an actual fabric network.

Moreover, this commit provides a simple mock implementation of the
auction written in go.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>