### PR TITLE
Return response/payload also on errors (WIP) & various length-related fixes & improvements

### DIFF
--- a/demo/chaincode/golang/messages.go
+++ b/demo/chaincode/golang/messages.go
@@ -19,7 +19,7 @@ type AuctionStatus struct {
 
 type Status struct {
 	Rc  int    `json:"rc"`
-	Msg string `json:"msg"`
+	Msg string `json:"message"`
 }
 
 type ReturnMsg struct {

--- a/demo/client/backend/fabric-gateway/Dockerfile
+++ b/demo/client/backend/fabric-gateway/Dockerfile
@@ -9,15 +9,18 @@ FROM node:8.16
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app/package.json
-COPY package-lock.json /usr/src/app/package-lock.json
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
-WORKDIR /usr/src/app
 
-# RUN npm rebuild
-
-COPY gateway /usr/src/app/gateway
+COPY \
+    package.json \
+    package-lock.json\
+    config.json\
+    fabric-sdk-node_fabric-network_lib_transaction.js.patch\
+  /usr/src/app/
 COPY src /usr/src/app/src
-COPY config.json /usr/src/app/config.json
-RUN npm install
+COPY gateway /usr/src/app/gateway
+
+RUN npm install \
+  &&  patch -R -p0 < ./fabric-sdk-node_fabric-network_lib_transaction.js.patch
+
 CMD npm start

--- a/demo/client/backend/fabric-gateway/fabric-sdk-node_fabric-network_lib_transaction.js.patch
+++ b/demo/client/backend/fabric-gateway/fabric-sdk-node_fabric-network_lib_transaction.js.patch
@@ -1,0 +1,31 @@
+--- transaction.js	2019-12-22 17:18:22.004770000 +0000
++++ node_modules/fabric-network/lib/transaction.js	1985-10-26 08:15:00.000000000 +0000
+@@ -218,24 +218,18 @@
+ 		});
+ 
+ 		if (validResponses.length === 0) {
+-			const errorMessages = errorResponses.map((response) => util.format('peer=%s, status=%s, message=%s, payload=%s',
+-				response.peer.name, response.status, response.message, response.payload));
++			const errorMessages = errorResponses.map((response) => util.format('peer=%s, status=%s, message=%s',
++				response.peer.name, response.status, response.message));
+ 			const messages = Array.of(`No valid responses from any peers. ${errorResponses.length} peer error responses:`,
+ 				...errorMessages);
+ 			const msg = messages.join('\n    ');
+ 			logger.error('_validatePeerResponses: ' + msg);
+-			throw new class FPCError extends Error {
+-	    			constructor(message, responses) {
+-                		    super(message);
+-				    this.name = this.constructor.name;
+-				    this.responses = responses;
+-				    this.payload = responses[0].payload;
+-	    			}
+-			    }(msg, errorResponses);
++			throw new Error(msg);
+ 		}
+ 
+ 		return {validResponses, invalidResponses: errorResponses};
+ 	}
++
+ 	/**
+ 	 * Evaluate a transaction function and return its results.
+ 	 * The transaction function will be evaluated on the endorsing peers but

--- a/demo/client/backend/mock/Makefile
+++ b/demo/client/backend/mock/Makefile
@@ -14,4 +14,4 @@ run-go:
 
 run-fpc:
 	$(GO) build -tags fpc
-	./mock
+	./mock --debug

--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -5,6 +5,11 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+/*
+TODO:
+- add everywhere explicit (& consistent) return errors to ocalls/ecalls
+*/
+
 package enclave
 
 import (
@@ -67,8 +72,7 @@ import "C"
 
 const EPID_SIZE = 8
 const SPID_SIZE = 16
-const MAX_OUTPUT_SIZE = 1024
-const MAX_RESPONSET_SIZE = 1024
+const MAX_RESPONSE_SIZE = 1024 * 100 // Let's be really conservative ...
 const SIGNATURE_SIZE = 64
 const PUB_KEY_SIZE = 64
 const TARGET_INFO_SIZE = 512
@@ -123,10 +127,6 @@ func (r *Registry) Get(i int) *Stubs {
 	return stubs
 }
 
-// TODO: everywhere below
-// - we should check the max_*_len parameters!!!
-// - we should do more meaningful error handling than panic ..
-
 //export golog
 func golog(str *C.char) {
 	logger.Infof("%s", C.GoString(str))
@@ -140,6 +140,10 @@ var _logger = func(in string) {
 //export get_creator_name
 func get_creator_name(msp_id *C.char, max_msp_id_len C.uint32_t, dn *C.char, max_dn_len C.uint32_t, ctx unsafe.Pointer) {
 	stubs := registry.Get(*(*int)(ctx))
+
+	// TODO (eventually): replace/simplify below via ext.ClientIdentity,
+	// should also make it easier to eventually return more than only
+	// msp & dn ..
 
 	serializedID, err := stubs.shimStub.GetCreator()
 	if err != nil {
@@ -165,6 +169,7 @@ func get_creator_name(msp_id *C.char, max_msp_id_len C.uint32_t, dn *C.char, max
 
 	var goDn = cert.Subject.String()
 	C._cpy_str(dn, goDn, max_dn_len)
+	// TODO (eventually): return the eror case of the dn buffer being too small
 }
 
 //export get_state
@@ -180,6 +185,14 @@ func get_state(key *C.char, val *C.uint8_t, max_val_len C.uint32_t, val_len *C.u
 	data, err := stubs.shimStub.GetState(key_str)
 	if err != nil {
 		panic("error while getting state")
+	}
+	if C.uint32_t(len(data)) > max_val_len {
+		C._set_int(val_len, C.uint32_t(0))
+		// NOTE: there is currently no way to explicitly return an error
+		// to distinguish from absence of key.  However, iff key exist
+		// and we return an error, this should trigger an integrity
+		// error, so the shim implicitly notice the difference.
+		return
 	}
 	C._cpy_bytes(val, (*C.uint8_t)(C.CBytes(data)), C.uint32_t(len(data)))
 	C._set_int(val_len, C.uint32_t(len(data)))
@@ -209,7 +222,7 @@ func put_state(key *C.char, val unsafe.Pointer, val_len C.int, ctx unsafe.Pointe
 }
 
 //export get_state_by_partial_composite_key
-func get_state_by_partial_composite_key(comp_key *C.char, values *C.uint8_t, max_vales_len C.uint32_t, values_len *C.uint32_t, cmac *C.uint8_t, ctx unsafe.Pointer) {
+func get_state_by_partial_composite_key(comp_key *C.char, values *C.uint8_t, max_values_len C.uint32_t, values_len *C.uint32_t, cmac *C.uint8_t, ctx unsafe.Pointer) {
 	stubs := registry.Get(*(*int)(ctx))
 
 	// split and get a proper composite key
@@ -240,6 +253,14 @@ func get_state_by_partial_composite_key(comp_key *C.char, values *C.uint8_t, max
 	buf.WriteString("]")
 	data := buf.Bytes()
 
+	if C.uint32_t(len(data)) > max_values_len {
+		C._set_int(values_len, C.uint32_t(0))
+		// NOTE: there is currently no way to explicitly return an error
+		// to distinguish from absence of key.  However, iff key exist
+		// and we return an error, this should trigger an integrity
+		// error, so the shim implicitly notice the difference.
+		return
+	}
 	C._cpy_bytes(values, (*C.uint8_t)(C.CBytes(data)), C.uint32_t(len(data)))
 	C._set_int(values_len, C.uint32_t(len(data)))
 
@@ -360,8 +381,8 @@ func (e *StubImpl) Init(args []byte, shimStub shim.ChaincodeStubInterface, tlccS
 	defer C.free(unsafe.Pointer(argsPtr))
 
 	// response
-	responseLenOut := C.uint32_t(MAX_RESPONSET_SIZE)
-	responsePtr := C.malloc(MAX_RESPONSET_SIZE)
+	responseLenOut := C.uint32_t(0) // We pass maximal length separatedly; set to zero so we can detect valid responses
+	responsePtr := C.malloc(MAX_RESPONSE_SIZE)
 	defer C.free(responsePtr)
 
 	// signature
@@ -372,7 +393,7 @@ func (e *StubImpl) Init(args []byte, shimStub shim.ChaincodeStubInterface, tlccS
 	// invoke (init) enclave
 	ret := C.sgxcc_init(e.eid,
 		argsPtr,
-		(*C.uint8_t)(responsePtr), C.uint32_t(MAX_RESPONSET_SIZE), &responseLenOut,
+		(*C.uint8_t)(responsePtr), C.uint32_t(MAX_RESPONSE_SIZE), &responseLenOut,
 		(*C.ec256_signature_t)(signaturePtr),
 		ctx)
 	e.sem.Release(1)
@@ -409,8 +430,8 @@ func (e *StubImpl) Invoke(args []byte, pk []byte, shimStub shim.ChaincodeStubInt
 	defer C.free(unsafe.Pointer(pkPtr))
 
 	// response
-	responseLenOut := C.uint32_t(MAX_RESPONSET_SIZE)
-	responsePtr := C.malloc(MAX_RESPONSET_SIZE)
+	responseLenOut := C.uint32_t(0) // We pass maximal length separatedly; set to zero so we can detect valid responses
+	responsePtr := C.malloc(MAX_RESPONSE_SIZE)
 	defer C.free(responsePtr)
 
 	// signature
@@ -422,7 +443,7 @@ func (e *StubImpl) Invoke(args []byte, pk []byte, shimStub shim.ChaincodeStubInt
 	ret := C.sgxcc_invoke(e.eid,
 		argsPtr,
 		pkPtr,
-		(*C.uint8_t)(responsePtr), C.uint32_t(MAX_RESPONSET_SIZE), &responseLenOut,
+		(*C.uint8_t)(responsePtr), C.uint32_t(MAX_RESPONSE_SIZE), &responseLenOut,
 		(*C.ec256_signature_t)(signaturePtr),
 		ctx)
 	e.sem.Release(1)

--- a/ecc_enclave/enclave/CMakeLists-common-app-enclave.txt
+++ b/ecc_enclave/enclave/CMakeLists-common-app-enclave.txt
@@ -5,11 +5,11 @@
 
 # This CMake file is included by the CMake files in chaincode example
 
-include(../../cmake/Init.cmake)
-include(../../cmake/ConfigSGX.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/Init.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/ConfigSGX.cmake)
 
-set(COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../common)
-set(ECC_ENCLAVE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../ecc_enclave)
+set(COMMON_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../common)
+set(ECC_ENCLAVE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../ecc_enclave)
 
 include(${ECC_ENCLAVE_DIR}/enclave/CMakeVariables.txt)
 

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -60,7 +60,12 @@ void get_state(
         sgx_sha256_msg(encoded_cipher, encoded_cipher_len, &state_hash);
     }
 
-    if (check_cmac(key, NULL, &state_hash, &session_key, &cmac) == 0)
+    if (check_cmac(key, NULL, &state_hash, &session_key, &cmac) != 0)
+    {
+        LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
+        // TODO: proper error handling/abort rather than just continue
+    }
+    else
     {
         LOG_DEBUG("Enclave: State verification: cmac correct!! :D");
     }
@@ -180,6 +185,7 @@ void get_state_by_partial_composite_key(
     if (check_cmac(comp_key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
+        // TODO: proper error handling/abort rather than just continue
     }
     else
     {

--- a/tlcc/enclave/Makefile
+++ b/tlcc/enclave/Makefile
@@ -11,7 +11,7 @@ build:
 	go build
 
 test:
-	LD_LIBRARY_PATH=./lib go test -test.v
+	LD_LIBRARY_PATH=./lib:${LD_LIBRARY_PATH} go test -test.v
 
 clean:
 	go clean

--- a/tlcc/enclave/enclave_stub.go
+++ b/tlcc/enclave/enclave_stub.go
@@ -22,8 +22,6 @@ import "C"
 
 const EPID_SIZE = 8
 const SPID_SIZE = 16
-const MAX_OUTPUT_SIZE = 1024
-const MAX_RESPONSET_SIZE = 1024
 const SIGNATURE_SIZE = 64
 const PUB_KEY_SIZE = 64
 const REPORT_SIZE = 432

--- a/tlcc_enclave/enclave/ledger.cpp
+++ b/tlcc_enclave/enclave/ledger.cpp
@@ -700,12 +700,16 @@ int parse_endorser_transaction(
                 if (function.compare("__setup") != 0)
                 {
                     LOG_DEBUG("Ledger: Validate ECC tx");
-                    uint8_t response_data[96];
-                    uint32_t response_len = 0;
-                    uint8_t signature[96];
-                    uint32_t signature_len = 0;
-                    uint8_t pk[96];
-                    uint32_t pk_len = 0;
+                    uint8_t response_data[cc_action.response.payload
+                                              ->size];  // no compression involved, so this should
+                                                        // be a safe upperbound ...
+                    uint32_t response_len = sizeof(response_data);
+                    uint8_t signature[96];  // TODO: replace me with something more robust than a
+                                            // simply (unexplained) constant ..
+                    uint32_t signature_len = sizeof(signature);
+                    uint8_t pk[96];  // TODO: replace me with something more robust than a simply
+                                     // (unexplained) constant ..
+                    uint32_t pk_len = sizeof(pk);
 
                     unmarshal_ecc_response((const uint8_t*)cc_action.response.payload->bytes,
                         cc_action.response.payload->size, (uint8_t*)&response_data, &response_len,


### PR DESCRIPTION
Main objective of this PR is to pass any response objects also on failure case &make sure  in client front-end that there is always status object. While it works for mock backend, peer cli interface and fabric-gateway/node client for queries, alas for vanilla node sdk it doesn't work for invoke as the sdk does not return the response object on errors in this case.  I've figured out how to patch the SDK with a relatively small patch `demo/client/backend/fabric-gateway/fabric-sdk-node_fabric-network_lib_transaction.js.patch`  it does work as intended. But patching SDK is sub-ideal, to say the least and so far i also haven't integrated the patch in the build process.

The reason to publish already a WIP PR is that at least you can test with mock (or by applying patch also with fabric-gateway) and start the discussion on how we should solve this.  It seems we have at least following options:
(a) use the patch and apply it in docker after npm install or alike
(b) rewrite fabric-gateway replacing high-level fabric-network APIs with the lower level APIs
(c) return success instead of error to shim for any chaincode errors (implying that transactions are also committed!) so we never need response object from error situations
(d) ...?
From above (a) probably is still the best short-term solution as (b) seems a lot of work, (c) is also ugly and in the long-run we anyway have to modify the client sdk to handle decryption and the kind of stuff the peer wrapper does (e.g., if you use FPC chaincode, remember to prefix in `config.json` the chaincode name with `ecc_`!)

Opinions?

Other fixes in this PR
    * fix issues #195 (missing bounds checks)
    * mitigate #187 for now by making response buffer conservative 100k
    * fix issue #177 (missing bounds check)
    * make test work also for simulator mode
    * bug fix to allow FPC chaincode build from arbitrary location
    * two other small bug fixes ..
