### PR TITLE
Mock with Creator 

### DIFF
--- a/demo/chaincode/golang/messages.go
+++ b/demo/chaincode/golang/messages.go
@@ -73,7 +73,7 @@ type AuctionRequest struct {
 // State
 
 type Auction struct {
-	Owner                         *Principle    `json:"owner"`
+	Owner                         *Principal    `json:"owner"`
 	Name                          string        `json:"name"`
 	Territories                   []Territory   `json:"territories"`
 	Bidders                       []Bidder      `json:"bidders"`
@@ -82,8 +82,8 @@ type Auction struct {
 	ClockPriceIncrementPercentage int           `json:"clockPriceIncrementPercentage"`
 }
 
-type Principle struct {
-	Mspid []byte `json:"mspid"`
+type Principal struct {
+	Mspid string `json:"mspid"`
 	Dn    string `json:"dn"`
 }
 
@@ -103,7 +103,7 @@ type Eligibility struct {
 type Bidder struct {
 	Id          int        `json:"id"`
 	DisplayName string     `json:"displayName"`
-	Principle   *Principle `json:"principle"`
+	Principal   *Principal `json:"principal"`
 }
 
 type Channel struct {

--- a/demo/client/backend/fabric-gateway/auction.json
+++ b/demo/client/backend/fabric-gateway/auction.json
@@ -170,23 +170,23 @@
 	"bidders": [{
 		"id": 1,
 		"displayName": "A-Telecom",
-		"principle": {
-			"mspid": "Org1MSP",
-			"dn": "bidder@org1"
+		"principal": {
+			"mspid": "org1",
+			"dn": "CN=A-Telecom,OU=user+OU=org1"
 		}
 	}, {
 		"id": 2,
 		"displayName": "B-Net",
-		"principle": {
-			"mspid": "Org1MSP",
-			"dn": "bidder@org2"
+		"principal": {
+			"mspid": "org1",
+			"dn": "CN=B-Net,OU=user+OU=org1"
 		}
 	}, {
 		"id": 3,
 		"displayName": "C-Mobile",
-		"principle": {
-			"mspid": "Org1MSP",
-			"dn": "bidder@org3"
+		"principal": {
+			"mspid": "org1",
+			"dn": "CN=C-Mobile,OU=user+OU=org1"
 		}
 	}],
 	"initialEligibilities": [{

--- a/demo/client/backend/fabric-gateway/config.json
+++ b/demo/client/backend/fabric-gateway/config.json
@@ -8,8 +8,8 @@
     "backend_port": 3000,
 
     "users" : [
-    {"userName":  "A-Telecom",   "userRole" : "auction.bidder", "MSPID" : "Org1MSP"} ,
-    {"userName":  "B-Net",       "userRole" : "auction.bidder", "MSPID" : "Org1MSP"},
-    {"userName":  "C-Mobile",    "userRole" : "auction.bidder", "MSPID" : "Org1MSP"} ,
-    {"userName":  "Auctioneer1", "userRole" : "auction.auctioneer", "MSPID" : "Org1MSP"} ]
+    {"userName":  "A-Telecom",   "userRole" : "auction.bidder",     "MSPID" : "org1"} ,
+    {"userName":  "B-Net",       "userRole" : "auction.bidder",     "MSPID" : "org1"},
+    {"userName":  "C-Mobile",    "userRole" : "auction.bidder",     "MSPID" : "org1"} ,
+    {"userName":  "Auctioneer1", "userRole" : "auction.auctioneer", "MSPID" : "org1"} ]
 }

--- a/demo/client/backend/mock/api/serverapi.json
+++ b/demo/client/backend/mock/api/serverapi.json
@@ -234,25 +234,25 @@
       {
         "id": 1,
         "displayName": "A-Telecom",
-        "principle": {
+        "principal": {
           "mspid": "org1",
-          "dn": "bidder@org1"
+          "dn": "CN=,OU=user+OU=org1"
         }
       },
       {
         "id": 2,
         "displayName": "B-Net",
-        "principle": {
-          "mspid": "org2",
-          "dn": "bidder@org2"
+        "principal": {
+          "mspid": "org1",
+          "dn": "CN=,OU=user+OU=org1"
         }
       },
       {
         "id": 3,
-        "displayName": "C-Mobil",
-        "principle": {
-          "mspid": "org3",
-          "dn": "bidder@org3"
+        "displayName": "C-Mobile",
+        "principal": {
+          "mspid": "org1",
+          "dn": "CN=,OU=user+OU=org1"
         }
       }
     ],

--- a/demo/client/backend/mock/mock_creator.go
+++ b/demo/client/backend/mock/mock_creator.go
@@ -1,0 +1,67 @@
+/*
+Copyright Intel Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/protos/msp"
+)
+
+func generateMockCreator(mspId string, user string) ([]byte, error) {
+	// (1) generate key
+	//     NOTE:RSA gen is relative expensive, if turns into problem we
+	//     could cache or move to ECDSA
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return nil, err
+	}
+
+	// (2) generate (self-signed) x509 certificate
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(100),
+		Subject: pkix.Name{
+			CommonName:         user,
+			OrganizationalUnit: []string{"user", mspId},
+			// Below RDNs would be likely in a real certificates but
+			// seem to be skipped by dy default in fabric-ca ...
+			//   Organization: []string{mspId+".example.com"},
+			//   Locality: []string{"San Francisco"},
+			//   Province: []string{"California"},
+			//   Country: []string{"US"},
+		},
+	}
+
+	publicKeyCert, err := x509.CreateCertificate(rand.Reader, &template, &template, privateKey.Public(), privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// (3) PEM encode certificate
+	publicKeyCertPEM := string(pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: publicKeyCert,
+		},
+	))
+
+	// (4) encode in protobuf & marshall
+	sid := &msp.SerializedIdentity{Mspid: mspId,
+		IdBytes: []byte(publicKeyCertPEM)}
+	encodedSid, err := proto.Marshal(sid)
+	if err != nil {
+		return nil, err
+	}
+
+	return encodedSid, nil
+}

--- a/fabric/0001-mock-also-creator-identity-like-signedproposal-or-Ch.patch
+++ b/fabric/0001-mock-also-creator-identity-like-signedproposal-or-Ch.patch
@@ -1,0 +1,36 @@
+From 9ba29b96a85150596a5bc45a5196693c46d5dc3e Mon Sep 17 00:00:00 2001
+From: Michael Steiner <michael.steiner@intel.com>
+Date: Wed, 25 Dec 2019 19:04:22 -0700
+Subject: [PATCH] * mock also creator identity like signedproposal or ChannelID
+
+Signed-off-by: Michael Steiner <michael.steiner@intel.com>
+---
+ core/chaincode/shim/mockstub.go | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/core/chaincode/shim/mockstub.go b/core/chaincode/shim/mockstub.go
+index d58db9c4a..8b4b83ab5 100644
+--- a/core/chaincode/shim/mockstub.go
++++ b/core/chaincode/shim/mockstub.go
+@@ -55,6 +55,9 @@ type MockStub struct {
+ 	// mocked signedProposal
+ 	signedProposal *pb.SignedProposal
+ 
++	// mocked creator
++	Creator []byte
++
+ 	// stores a channel ID of the proposal
+ 	ChannelID string
+ 
+@@ -357,7 +360,7 @@ func (stub *MockStub) InvokeChaincode(chaincodeName string, args [][]byte, chann
+ 
+ // Not implemented
+ func (stub *MockStub) GetCreator() ([]byte, error) {
+-	return nil, nil
++	return stub.Creator, nil
+ }
+ 
+ // Not implemented
+-- 
+2.17.1
+


### PR DESCRIPTION
This PR adds a Creator field to the mock stub (i.e., a new fabric patch!) and then adds logic to create a creator object from the X-User field in the mock backend.   The format should match the identities we would see in "production" based on `demo/client/backend/fabric-gateway/registerUsers.sh`; the auction creation templates are also accordingly updated.

Note: to test you will need the additional fabric test. Assuming your environment already has the previous patches, then the following should be sufficient
```
cd $FPC_PATH
pushd ../../hyperledger/fabric
git am $FPC_PATH/fabric/0001-mock-also-creator-identity-like-signedproposal-or-Ch.patch
GO_TAGS=pluginsenabled make peer
popd
make clean
make
```

Also, license test will fail due to the *.json and patch-file not being able to have license headers ....