### PR TITLE
Spectrum auction chaincode

### DIFF
--- a/demo/chaincode/fpc/CMakeLists.txt
+++ b/demo/chaincode/fpc/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2019 Intel Corporation
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.5.1)
+
+set(SOURCE_FILES
+    dispatcher.cpp
+    entry.cpp
+    error-codes.cpp
+    spectrum-auction.cpp
+    spectrum-auction-message.cpp
+    storage.cpp
+    principal.cpp
+    territory.cpp
+    eligibility.cpp
+    bidder.cpp
+    auction-state.cpp
+    utils.cpp
+    evaluate.cpp
+    bid.cpp
+    )
+
+include($ENV{FPC_PATH}/ecc_enclave/enclave/CMakeLists-common-app-enclave.txt)
+

--- a/demo/chaincode/fpc/Makefile
+++ b/demo/chaincode/fpc/Makefile
@@ -1,0 +1,22 @@
+# Copyright 2019 Intel Corporation
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOP = $(FPC_PATH)
+include $(TOP)/build.mk
+
+BUILD_DIR := _build
+
+$(BUILD_DIR):
+	@if [ ! -d $(BUILD_DIR) ]; then \
+		mkdir -p $(BUILD_DIR) && \
+		cd $(BUILD_DIR) && \
+		cmake ./..; \
+	fi
+
+build: $(BUILD_DIR)
+	$(MAKE) --directory=$<
+
+clean:
+	-rm -rf $(BUILD_DIR)

--- a/demo/chaincode/fpc/README.md
+++ b/demo/chaincode/fpc/README.md
@@ -1,0 +1,26 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+# Spectrum Auction Chaincode
+
+The code in this folder implements a demo Spectrum Auction by heavily building on [documents](https://wireless.fcc.gov/auctions/1002/resources/fABS_tutorial_final/presentation_html5.html) of the Federal Communications Commission (FCC). *This demo is for demonstration purposes only, and not meant for production use.*
+
+The purpose of this demo chaincode is to showcase the privacy enhancements that the Fabric Private Chaincode project brings to Hyperledger Fabric by using Intel(R) SGX. To run such demo, please see the documents to set up the Hyperledger Fabric Network and the User Interface.
+The present document only provides references to the auction specification, and instructions to build the auction chaincode and run its tests.
+
+A [specification document](https://docs.google.com/document/d/1YUF4mzzuybzWk3fbXbTANWO8-tr757BP85qcwE7gQdk) is available for additional information about APIs, input and output messages.
+
+
+## Build the code
+
+* make sure the the `FPC_PATH` environment variable is set to the root folder of the Fabric Private Chaincode project
+* run `make`
+
+## Test the code
+
+The auction chaincode can be conveniently developed and tested by using the [FPC Mock Server](../../client/backend/mock) as follows:
+* build the auction chaincode
+* follow the instruction in the Mock Server [Readme](../../client/backend/mock/README.md) file to build the server and make sure the server can access the compiled auction artifacts
+* run `./test.sh`
+

--- a/demo/chaincode/fpc/README.md
+++ b/demo/chaincode/fpc/README.md
@@ -11,6 +11,7 @@ The present document only provides references to the auction specification, and 
 
 A [specification document](https://docs.google.com/document/d/1YUF4mzzuybzWk3fbXbTANWO8-tr757BP85qcwE7gQdk) is available for additional information about APIs, input and output messages.
 
+The chaincode implements a simple randomized version of the Assignment phase of the auction. Hence, it does not implement the `submitAssignmentBid` API. In particular, the Assignment phase is terminated immediately, with no bids. Then, the assignment is performed randomly. Finally, the phase, and so the auction itself, is closed.
 
 ## Build the code
 

--- a/demo/chaincode/fpc/auction-state.cpp
+++ b/demo/chaincode/fpc/auction-state.cpp
@@ -1,0 +1,1034 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "auction-state.h"
+#include "common.h"
+#include "utils.h"
+
+bool ClockAuction::StaticAuctionState::toJsonObject(JSON_Object* root_object) const
+{
+    {
+        JSON_Object* o = ClockAuction::JsonUtils::openJsonObject(NULL);
+        owner_.toJsonObject(o);
+        json_object_set_value(root_object, "owner", json_object_get_wrapping_value(o));
+        // do not close json object here -- it will be freed when parent object is closed
+    }
+    {
+        json_object_set_string(root_object, "name", name_.c_str());
+    }
+    {
+        json_object_set_value(root_object, "territories", json_value_init_array());
+        JSON_Array* territory_array = json_object_get_array(root_object, "territories");
+        for (unsigned int i = 0; i < territories_.size(); i++)
+        {
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            territories_[i].toJsonObject(o);
+            json_array_append_value(territory_array, v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "bidders", json_value_init_array());
+        JSON_Array* bidder_array = json_object_get_array(root_object, "bidders");
+        for (unsigned int i = 0; i < bidders_.size(); i++)
+        {
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            bidders_[i].toJsonObject(o);
+            json_array_append_value(bidder_array, v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "initialEligibilities", json_value_init_array());
+        JSON_Array* eligibility_array = json_object_get_array(root_object, "initialEligibilities");
+        for (unsigned int i = 0; i < initialEligibilities_.size(); i++)
+        {
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            initialEligibilities_[i].toJsonObject(o);
+            json_array_append_value(eligibility_array, v);
+        }
+    }
+    {
+        json_object_set_number(
+            root_object, "activityRequirementPercentage", activityRequirementPercentage_);
+    }
+    {
+        json_object_set_number(
+            root_object, "clockPriceIncrementPercentage", clockPriceIncrementPercentage_);
+    }
+    return true;
+}
+
+bool ClockAuction::StaticAuctionState::fromJsonObject(const JSON_Object* root_object)
+{
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, root_object == NULL);
+
+    {
+        const char* str = json_object_get_string(root_object, "name");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, str == 0);
+        name_ = std::string(str);
+    }
+    {
+        JSON_Array* territory_array = json_object_get_array(root_object, "territories");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, territory_array == 0);
+        unsigned int territoryN = json_array_get_count(territory_array);
+        for (unsigned int i = 0; i < territoryN; i++)
+        {
+            JSON_Object* o = json_array_get_object(territory_array, i);
+            Territory territory;
+            FAST_FAIL_CHECK_EX(er_, &territory.er_, EC_INVALID_INPUT, !territory.fromJsonObject(o));
+            territories_.push_back(territory);
+        }
+    }
+    {
+        JSON_Array* bidder_array = json_object_get_array(root_object, "bidders");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, bidder_array == 0);
+        unsigned int bidderN = json_array_get_count(bidder_array);
+        for (unsigned int i = 0; i < bidderN; i++)
+        {
+            JSON_Object* o = json_array_get_object(bidder_array, i);
+            Bidder bidder;
+            FAST_FAIL_CHECK_EX(er_, &bidder.er_, EC_INVALID_INPUT, !bidder.fromJsonObject(o));
+            bidders_.push_back(bidder);
+        }
+    }
+    {
+        JSON_Array* eligibility_array = json_object_get_array(root_object, "initialEligibilities");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, eligibility_array == 0);
+        unsigned int eligibilityN = json_array_get_count(eligibility_array);
+        for (unsigned int i = 0; i < eligibilityN; i++)
+        {
+            JSON_Object* o = json_array_get_object(eligibility_array, i);
+            Eligibility eligibility;
+            FAST_FAIL_CHECK_EX(
+                er_, &eligibility.er_, EC_INVALID_INPUT, !eligibility.fromJsonObject(o));
+            initialEligibilities_.push_back(eligibility);
+        }
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(
+                root_object, "activityRequirementPercentage", JSONNumber));
+        double d = json_object_get_number(root_object, "activityRequirementPercentage");
+        activityRequirementPercentage_ = d;
+        // TODO check integer
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, d < 0 || d > 100);
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(
+                root_object, "clockPriceIncrementPercentage", JSONNumber));
+        double d = json_object_get_number(root_object, "clockPriceIncrementPercentage");
+        clockPriceIncrementPercentage_ = d;
+        // TODO check integer
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, d < 0);
+    }
+    return true;
+}
+
+bool ClockAuction::StaticAuctionState::fromExtendedJsonObject(const JSON_Object* root_object)
+{
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, root_object == NULL);
+    {
+        JSON_Value* v = json_object_get_value(root_object, "owner");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, v == 0);
+        JSON_Object* o = json_value_get_object(v);
+        FAST_FAIL_CHECK_EX(er_, &owner_.er_, EC_INVALID_INPUT, !owner_.fromJsonObject(o));
+    }
+    return fromJsonObject(root_object);
+}
+
+bool ClockAuction::StaticAuctionState::checkValidity()
+{
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, name_.length() == 0);
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, territories_.size() == 0);
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, bidders_.size() == 0);
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, initialEligibilities_.size() == 0);
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, bidders_.size() != initialEligibilities_.size());
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, activityRequirementPercentage_ > 100);
+    FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, clockPriceIncrementPercentage_ > 100);
+    return true;
+}
+
+void ClockAuction::StaticAuctionState::setOwner(const Principal& p)
+{
+    owner_ = p;
+}
+
+ClockAuction::ErrorReport ClockAuction::StaticAuctionState::getErrorReport()
+{
+    return er_;
+}
+
+bool ClockAuction::StaticAuctionState::isTerritoryIdValid(uint32_t checkId)
+{
+    for (unsigned int i = 0; i < territories_.size(); i++)
+    {
+        if (checkId == territories_[i].getTerritoryId())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+const ClockAuction::Territory* ClockAuction::StaticAuctionState::getTerritory(
+    uint32_t territoryId) const
+{
+    for (auto it = territories_.begin(); it != territories_.end(); ++it)
+    {
+        if (it->getTerritoryId() == territoryId)
+        {
+            return &(*it);
+        }
+    }
+    return NULL;
+}
+
+int32_t ClockAuction::StaticAuctionState::getTerritoryIndex(uint32_t territoryId) const
+{
+    for (unsigned int i = 0; i < territories_.size(); i++)
+    {
+        if (territories_[i].getTerritoryId() == territoryId)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+std::vector<uint32_t> ClockAuction::StaticAuctionState::getTerritoryIds() const
+{
+    std::vector<uint32_t> territoryIds;
+    for (unsigned int i = 0; i < territories_.size(); i++)
+    {
+        territoryIds.push_back(territories_[i].getTerritoryId());
+    }
+    return territoryIds;
+}
+
+std::vector<uint32_t> ClockAuction::StaticAuctionState::getSupply() const
+{
+    std::vector<uint32_t> supply;
+    for (unsigned int i = 0; i < territories_.size(); i++)
+    {
+        supply.push_back(territories_[i].numberOfChannels());
+    }
+    return supply;
+}
+
+std::vector<bool> ClockAuction::StaticAuctionState::getHighDemandVector() const
+{
+    std::vector<bool> highDemand;
+    for (unsigned int i = 0; i < territories_.size(); i++)
+    {
+        highDemand.push_back(territories_[i].isHighDemand());
+    }
+    return highDemand;
+}
+
+bool ClockAuction::StaticAuctionState::isPrincipalOwner(const Principal& p) const
+{
+    return p == owner_;
+}
+
+bool ClockAuction::StaticAuctionState::isPrincipalBidder(const Principal& p)
+{
+    return fromPrincipalToBidderId(p) != 0;
+}
+
+uint32_t ClockAuction::StaticAuctionState::fromPrincipalToBidderId(const Principal& p) const
+{
+    for (unsigned int i = 0; i < bidders_.size(); i++)
+    {
+        if (bidders_[i].matchPrincipal(p))
+        {
+            return bidders_[i].getId();
+        }
+    }
+    return 0;  // no bidder id
+}
+
+int32_t ClockAuction::StaticAuctionState::fromBidderIdToBidderIndex(uint32_t bidderId) const
+{
+    for (unsigned int i = 0; i < bidders_.size(); i++)
+    {
+        if (bidders_[i].getId() == bidderId)
+        {
+            return i;
+        }
+    }
+    return -1;  // no bidder id/index
+}
+
+uint32_t ClockAuction::StaticAuctionState::fromBidderIndexToBidderId(uint32_t bidderIndex) const
+{
+    return bidders_[bidderIndex].getId();
+}
+
+const ClockAuction::Principal ClockAuction::StaticAuctionState::fromBidderIdToPrincipal(
+    uint32_t bidderId) const
+{
+    for (unsigned int i = 0; i < bidders_.size(); i++)
+    {
+        if (bidders_[i].getId() == bidderId)
+        {
+            return bidders_[i].getPrincipal();
+        }
+    }
+}
+
+uint32_t ClockAuction::StaticAuctionState::getEligibilityNumber(uint32_t bidderId) const
+{
+    for (unsigned int i = 0; i < initialEligibilities_.size(); i++)
+    {
+        if (initialEligibilities_[i].matchBidderId(bidderId))
+        {
+            return initialEligibilities_[i].getNumber();
+        }
+    }
+}
+
+std::vector<double> ClockAuction::StaticAuctionState::getInitialPrices() const
+{
+    std::vector<double> initialPrices;
+    for (unsigned int i = 0; i < territories_.size(); i++)
+    {
+        initialPrices.push_back(territories_[i].getMinPrice());
+    }
+    return initialPrices;
+}
+
+std::vector<uint32_t> ClockAuction::StaticAuctionState::getInitialEligibilities() const
+{
+    std::vector<uint32_t> initialEligibilities;
+    for (unsigned int i = 0; i < initialEligibilities_.size(); i++)
+    {
+        initialEligibilities.push_back(initialEligibilities_[i].getNumber());
+    }
+    return initialEligibilities;
+}
+
+uint32_t ClockAuction::StaticAuctionState::getActivityRequirementPercentage() const
+{
+    return activityRequirementPercentage_;
+}
+
+uint32_t ClockAuction::StaticAuctionState::getClockPriceIncrementPercentage() const
+{
+    return clockPriceIncrementPercentage_;
+}
+
+uint32_t ClockAuction::StaticAuctionState::getBiddersN() const
+{
+    return bidders_.size();
+}
+
+uint32_t ClockAuction::StaticAuctionState::getTerritoryN() const
+{
+    return territories_.size();
+}
+
+/*
+ * *************************************
+ * DYNAMIC STATE ***********************
+ * *************************************
+ */
+
+ClockAuction::DynamicAuctionState::DynamicAuctionState(shim_ctx_ptr_t ctx)
+{
+    identifySubmitter(ctx);
+}
+
+void ClockAuction::DynamicAuctionState::initialize(auction_state_e auctionState,
+    uint32_t clockRound,
+    bool roundActive,
+    StaticAuctionState& staticAuctionState)
+{
+    staticAuctionState.setOwner(submitterPrincipal_);
+    auctionState_ = auctionState;
+    clockRound_ = clockRound;
+    roundActive_ = roundActive;
+
+    {  // initialize posted prices
+        std::vector<double> initialPrices = staticAuctionState.getInitialPrices();
+        postedPrice_.resize(2);
+        postedPrice_[0] = initialPrices;               // posted price of round 0
+        postedPrice_[1].resize(initialPrices.size());  // zero posted price vector for round 1
+    }
+    {                           // initialize clock prices
+        clockPrice_.resize(1);  // dummy 0th
+        clockPrice_.push_back(
+            postedPrice_[0]);  // copy posted prices of round 0 in clock prices of round 1
+        for (unsigned int i = 0; i < clockPrice_[clockRound_].size(); i++)
+        {
+            clockPrice_[clockRound_][i] *=
+                (1 + ((double)staticAuctionState.getClockPriceIncrementPercentage() / 100));
+        }
+    }
+    {                            // initialize eligibilities
+        eligibility_.resize(1);  // dummy 0th
+        eligibility_.push_back(staticAuctionState.getInitialEligibilities());
+    }
+    {
+        // initialize clock bids
+        clockBids_.resize(1);  // dummy 0th
+    }
+    {
+        // initialize processed licenses
+        processedLicenses_.resize(1);  // dummy 0th
+    }
+    {
+        // initialized excess demand
+        excessDemand_.resize(1);  // dummy 0th
+    }
+}
+
+void ClockAuction::DynamicAuctionState::identifySubmitter(shim_ctx_ptr_t ctx)
+{
+    char mspId[1 << 12];
+    char dn[1 << 12];
+    get_creator_name(mspId, sizeof(mspId), dn, sizeof(dn), ctx);
+    submitterPrincipal_ = Principal(mspId, dn);
+    LOG_INFO("Identified submitter: mspid %s dn %s", mspId, dn);
+}
+
+bool ClockAuction::DynamicAuctionState::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "state", auctionState_);
+    json_object_set_number(root_object, "clockRound", clockRound_);
+    json_object_set_boolean(root_object, "roundActive", (int)roundActive_);
+    {
+        json_object_set_value(root_object, "postedPrice", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "postedPrice");
+        for (unsigned int i = 0; i < postedPrice_.size(); i++)
+        {
+            JSON_Value* perround_v = json_value_init_array();
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            for (unsigned int j = 0; j < postedPrice_[i].size(); j++)
+            {
+                json_array_append_number(perround_array, postedPrice_[i][j]);
+            }
+            json_array_append_value(json_array, perround_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "clockPrice", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "clockPrice");
+        for (unsigned int i = 0; i < clockPrice_.size(); i++)
+        {
+            JSON_Value* perround_v = json_value_init_array();
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            for (unsigned int j = 0; j < clockPrice_[i].size(); j++)
+            {
+                json_array_append_number(perround_array, clockPrice_[i][j]);
+            }
+            json_array_append_value(json_array, perround_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "eligibility", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "eligibility");
+        for (unsigned int i = 0; i < eligibility_.size(); i++)
+        {
+            JSON_Value* perround_v = json_value_init_array();
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            for (unsigned int j = 0; j < eligibility_[i].size(); j++)
+            {
+                json_array_append_number(perround_array, eligibility_[i][j]);
+            }
+            json_array_append_value(json_array, perround_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "clockBids", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "clockBids");
+        for (unsigned int i = 0; i < clockBids_.size(); i++)
+        {
+            JSON_Value* perround_v = json_value_init_array();
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            for (unsigned int j = 0; j < clockBids_[i].size(); j++)
+            {
+                JSON_Value* v = json_value_init_object();
+                JSON_Object* o = json_value_get_object(v);
+                clockBids_[i][j].toJsonObject(o);
+                json_array_append_value(perround_array, v);
+            }
+            json_array_append_value(json_array, perround_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "processedLicenses", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "processedLicenses");
+        for (unsigned int i = 0; i < processedLicenses_.size(); i++)  // for each round
+        {
+            JSON_Value* perround_v = json_value_init_array();
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            for (unsigned int j = 0; j < processedLicenses_[i].size(); j++)  // for each bidder
+            {
+                JSON_Value* perbidder_v = json_value_init_array();
+                JSON_Array* perbidder_array = json_value_get_array(perbidder_v);
+                for (unsigned int k = 0; k < processedLicenses_[i][j].size();
+                     k++)  // for each territory
+                {
+                    json_array_append_number(perbidder_array, processedLicenses_[i][j][k]);
+                }
+                json_array_append_value(perround_array, perbidder_v);
+            }
+            json_array_append_value(json_array, perround_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "excessDemand", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "excessDemand");
+        for (unsigned int i = 0; i < excessDemand_.size(); i++)
+        {
+            JSON_Value* perround_v = json_value_init_array();
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            for (unsigned int j = 0; j < excessDemand_[i].size(); j++)
+            {
+                json_array_append_number(perround_array, excessDemand_[i][j]);
+            }
+            json_array_append_value(json_array, perround_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "winAssign", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "winAssign");
+        for (unsigned int i = 0; i < winAssign_.size(); i++)  // for each territory
+        {
+            JSON_Value* perterritory_v = json_value_init_array();
+            JSON_Array* perterritory_array = json_value_get_array(perterritory_v);
+            for (unsigned int j = 0; j < winAssign_[i].size(); j++)  // for each channel
+            {
+                json_array_append_number(perterritory_array, winAssign_[i][j]);
+            }
+            json_array_append_value(json_array, perterritory_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "assignCost", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "assignCost");
+        for (unsigned int i = 0; i < assignCost_.size(); i++)  // for each territory
+        {
+            JSON_Value* perterritory_v = json_value_init_array();
+            JSON_Array* perterritory_array = json_value_get_array(perterritory_v);
+            for (unsigned int j = 0; j < assignCost_[i].size(); j++)  // for each bidder
+            {
+                json_array_append_number(perterritory_array, assignCost_[i][j]);
+            }
+            json_array_append_value(json_array, perterritory_v);
+        }
+    }
+    {
+        json_object_set_value(root_object, "channelPrice", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "channelPrice");
+        for (unsigned int i = 0; i < channelPrice_.size(); i++)  // for each territory
+        {
+            JSON_Value* perterritory_v = json_value_init_array();
+            JSON_Array* perterritory_array = json_value_get_array(perterritory_v);
+            for (unsigned int j = 0; j < channelPrice_[i].size(); j++)  // for each channel
+            {
+                json_array_append_number(perterritory_array, channelPrice_[i][j]);
+            }
+            json_array_append_value(json_array, perterritory_v);
+        }
+    }
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "state", JSONNumber));
+        double d = json_object_get_number(root_object, "state");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        auctionState_ = (d >= 0 && d <= MAX_STATE_INDEX ? (auction_state_e)d : STATE_UNDEFINED);
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, auctionState_ == 0);
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "clockRound", JSONNumber));
+        double d = json_object_get_number(root_object, "clockRound");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        clockRound_ = (uint32_t)d;
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, clockRound_ == 0);
+    }
+    {
+        int b = json_object_get_boolean(root_object, "roundActive");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, roundActive_ == -1);
+        roundActive_ = b;
+    }
+    {
+        JSON_Array* postedprice_array = json_object_get_array(root_object, "postedPrice");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, postedprice_array == 0);
+        unsigned int postedPriceN = json_array_get_count(postedprice_array);
+        for (unsigned int i = 0; i < postedPriceN; i++)
+        {
+            JSON_Value* perround_v = json_array_get_value(postedprice_array, i);
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            unsigned int roundPostedPriceN = json_array_get_count(perround_array);
+            std::vector<double> roundPostedPrice;
+            for (unsigned int j = 0; j < roundPostedPriceN; j++)
+            {
+                roundPostedPrice.push_back(json_array_get_number(perround_array, j));
+            }
+            postedPrice_.push_back(roundPostedPrice);
+        }
+    }
+    {
+        JSON_Array* clockprice_array = json_object_get_array(root_object, "clockPrice");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, clockprice_array == 0);
+        unsigned int clockPriceN = json_array_get_count(clockprice_array);
+        for (unsigned int i = 0; i < clockPriceN; i++)
+        {
+            JSON_Value* perround_v = json_array_get_value(clockprice_array, i);
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            unsigned int roundClockPriceN = json_array_get_count(perround_array);
+            std::vector<double> roundClockPrice;
+            for (unsigned int j = 0; j < roundClockPriceN; j++)
+            {
+                roundClockPrice.push_back(json_array_get_number(perround_array, j));
+            }
+            clockPrice_.push_back(roundClockPrice);
+        }
+    }
+    {
+        JSON_Array* eligibility_array = json_object_get_array(root_object, "eligibility");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, eligibility_array == 0);
+        unsigned int eligibilityN = json_array_get_count(eligibility_array);
+        for (unsigned int i = 0; i < eligibilityN; i++)
+        {
+            JSON_Value* perround_v = json_array_get_value(eligibility_array, i);
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            unsigned int roundEligibilityN = json_array_get_count(perround_array);
+            std::vector<uint32_t> roundEligibility;
+            for (unsigned int j = 0; j < roundEligibilityN; j++)
+            {
+                roundEligibility.push_back(json_array_get_number(perround_array, j));
+            }
+            eligibility_.push_back(roundEligibility);
+        }
+    }
+    {
+        JSON_Array* json_array = json_object_get_array(root_object, "clockBids");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, json_array == 0);
+        unsigned int arrayN = json_array_get_count(json_array);
+        for (unsigned int i = 0; i < arrayN; i++)
+        {
+            JSON_Value* perround_v = json_array_get_value(json_array, i);
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            unsigned int roundArrayN = json_array_get_count(perround_array);
+            std::vector<Bid> roundClockBids;
+            for (unsigned int j = 0; j < roundArrayN; j++)
+            {
+                JSON_Object* o = json_array_get_object(perround_array, j);
+                Bid bid;
+                FAST_FAIL_CHECK_EX(er_, &bid.er_, EC_INVALID_INPUT, !bid.fromJsonObject(o));
+                roundClockBids.push_back(bid);
+            }
+            clockBids_.push_back(roundClockBids);
+        }
+    }
+    {
+        JSON_Array* json_array = json_object_get_array(root_object, "processedLicenses");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, json_array == 0);
+        unsigned int arrayN = json_array_get_count(json_array);
+        for (unsigned int i = 0; i < arrayN; i++)  // for each round
+        {
+            JSON_Value* perround_v = json_array_get_value(json_array, i);
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            unsigned int roundArrayN = json_array_get_count(perround_array);
+            std::vector<std::vector<uint32_t> > perBidderProcessedLicenses;
+            for (unsigned int j = 0; j < roundArrayN; j++)  // for each bidder
+            {
+                JSON_Value* perbidder_v = json_array_get_value(perround_array, j);
+                JSON_Array* perbidder_array = json_value_get_array(perbidder_v);
+                unsigned int bidderArrayN = json_array_get_count(perbidder_array);
+                std::vector<uint32_t> perTerritoryProcessedLicenses;
+                for (unsigned int k = 0; k < bidderArrayN; k++)  // for each territory
+                {
+                    perTerritoryProcessedLicenses.push_back(
+                        json_array_get_number(perbidder_array, k));
+                }
+                perBidderProcessedLicenses.push_back(perTerritoryProcessedLicenses);
+            }
+            processedLicenses_.push_back(perBidderProcessedLicenses);
+        }
+    }
+    {
+        JSON_Array* json_array = json_object_get_array(root_object, "excessDemand");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, json_array == 0);
+        unsigned int arrayN = json_array_get_count(json_array);
+        for (unsigned int i = 0; i < arrayN; i++)
+        {
+            JSON_Value* perround_v = json_array_get_value(json_array, i);
+            JSON_Array* perround_array = json_value_get_array(perround_v);
+            unsigned int roundArrayN = json_array_get_count(perround_array);
+            std::vector<int32_t> roundExcessDemand;
+            for (unsigned int j = 0; j < roundArrayN; j++)
+            {
+                roundExcessDemand.push_back(json_array_get_number(perround_array, j));
+            }
+            excessDemand_.push_back(roundExcessDemand);
+        }
+    }
+    {
+        JSON_Array* json_array = json_object_get_array(root_object, "winAssign");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, json_array == 0);
+        unsigned int arrayN = json_array_get_count(json_array);
+        for (unsigned int i = 0; i < arrayN; i++)  // for each territory
+        {
+            JSON_Value* perterritory_v = json_array_get_value(json_array, i);
+            JSON_Array* perterritory_array = json_value_get_array(perterritory_v);
+            unsigned int territoryArrayN = json_array_get_count(perterritory_array);
+            std::vector<int32_t> perTerritoryWinAssign;
+            for (unsigned int j = 0; j < territoryArrayN; j++)  // for each channel
+            {
+                perTerritoryWinAssign.push_back(json_array_get_number(perterritory_array, j));
+            }
+            winAssign_.push_back(perTerritoryWinAssign);
+        }
+    }
+    {
+        JSON_Array* json_array = json_object_get_array(root_object, "assignCost");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, json_array == 0);
+        unsigned int arrayN = json_array_get_count(json_array);
+        for (unsigned int i = 0; i < arrayN; i++)  // for each territory
+        {
+            JSON_Value* perterritory_v = json_array_get_value(json_array, i);
+            JSON_Array* perterritory_array = json_value_get_array(perterritory_v);
+            unsigned int territoryArrayN = json_array_get_count(perterritory_array);
+            std::vector<double> perTerritoryAssignCost;
+            for (unsigned int j = 0; j < territoryArrayN; j++)  // for each bidder
+            {
+                perTerritoryAssignCost.push_back(json_array_get_number(perterritory_array, j));
+            }
+            assignCost_.push_back(perTerritoryAssignCost);
+        }
+    }
+    {
+        JSON_Array* json_array = json_object_get_array(root_object, "channelPrice");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, json_array == 0);
+        unsigned int arrayN = json_array_get_count(json_array);
+        for (unsigned int i = 0; i < arrayN; i++)  // for each territory
+        {
+            JSON_Value* perterritory_v = json_array_get_value(json_array, i);
+            JSON_Array* perterritory_array = json_value_get_array(perterritory_v);
+            unsigned int territoryArrayN = json_array_get_count(perterritory_array);
+            std::vector<double> perTerritoryChannelPrice;
+            for (unsigned int j = 0; j < territoryArrayN; j++)  // for each channel
+            {
+                perTerritoryChannelPrice.push_back(json_array_get_number(perterritory_array, j));
+            }
+            channelPrice_.push_back(perTerritoryChannelPrice);
+        }
+    }
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::toRoundInfoJsonObject(
+    JSON_Object* root_object, const ClockAuction::StaticAuctionState& sState, uint32_t round) const
+{
+    {
+        json_object_set_value(root_object, "prices", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "prices");
+        std::vector<uint32_t> terIds = sState.getTerritoryIds();
+        for (unsigned int i = 0; i < terIds.size(); i++)
+        {
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            json_object_set_number(o, "terId", terIds[i]);
+            json_object_set_number(o, "minPrice", postedPrice_[round - 1][i]);
+            json_object_set_number(o, "clockPrice", clockPrice_[round][i]);
+
+            json_array_append_value(json_array, v);
+        }
+    }
+    json_object_set_boolean(
+        root_object, "active", (round == getRound() ? (int)roundActive_ : (int)false));
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::toBidderRoundResultsJsonObject(
+    JSON_Object* root_object, const ClockAuction::StaticAuctionState& sState, uint32_t round) const
+{
+    uint32_t bidderIndex =
+        sState.fromBidderIdToBidderIndex(sState.fromPrincipalToBidderId(submitterPrincipal_));
+    {
+        json_object_set_value(root_object, "result", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "result");
+        std::vector<uint32_t> terIds = sState.getTerritoryIds();
+        for (unsigned int i = 0; i < terIds.size(); i++)
+        {
+            if (processedLicenses_[round][bidderIndex][i] == 0)
+            {
+                continue;
+            }
+
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            json_object_set_number(o, "terId", terIds[i]);
+            json_object_set_number(o, "postedPrice", postedPrice_[round][i]);
+            json_object_set_number(o, "excessDemand", excessDemand_[round][i]);
+            json_object_set_number(
+                o, "processedLicenses", processedLicenses_[round][bidderIndex][i]);
+
+            json_array_append_value(json_array, v);
+        }
+    }
+    if (!isLastClockRound(round))
+    {
+        // NOTE: since this is not the last clock round, there exists a next (round+1) round
+        uint32_t elig = eligibility_[round + 1][bidderIndex];
+        json_object_set_number(root_object, "futureEligibility", elig);
+        uint32_t requiredFutureElig = elig * sState.getActivityRequirementPercentage() / 100;
+        json_object_set_number(root_object, "requiredFutureEligibility", requiredFutureElig);
+    }
+
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::toOwnerRoundResultsJsonObject(
+    JSON_Object* root_object, const ClockAuction::StaticAuctionState& sState, uint32_t round) const
+{
+    {
+        json_object_set_value(root_object, "result", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "result");
+        std::vector<uint32_t> terIds = sState.getTerritoryIds();
+        uint32_t biddersN = sState.getBiddersN();
+        for (unsigned int i = 0; i < terIds.size(); i++)
+        {
+            uint32_t activeBidders = 0;
+            for (unsigned int j = 0; j < biddersN; j++)
+            {
+                activeBidders += (processedLicenses_[round][j][i] > 0 ? 1 : 0);
+            }
+
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            json_object_set_number(o, "terId", terIds[i]);
+            json_object_set_number(o, "postedPrice", postedPrice_[round][i]);
+            json_object_set_number(o, "excessDemand", excessDemand_[round][i]);
+            json_object_set_number(o, "activeBidders", activeBidders);
+
+            json_array_append_value(json_array, v);
+        }
+    }
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::toAssignmentResultsJsonObject(
+    JSON_Object* root_object, const ClockAuction::StaticAuctionState& sState) const
+{
+    {
+        json_object_set_value(root_object, "result", json_value_init_array());
+        JSON_Array* json_array = json_object_get_array(root_object, "result");
+        std::vector<uint32_t> terIds = sState.getTerritoryIds();
+        uint32_t biddersN = sState.getBiddersN();
+        for (unsigned int i = 0; i < biddersN; i++)
+        {
+            JSON_Value* v = json_value_init_object();
+            JSON_Object* o = json_value_get_object(v);
+            json_object_set_number(o, "bidderId", sState.fromBidderIndexToBidderId(i));
+            json_object_set_value(o, "assignment", json_value_init_array());
+            JSON_Array* assignment_json_array = json_object_get_array(o, "assignment");
+            for (unsigned int j = 0; j < terIds.size(); j++)
+            {
+                if (processedLicenses_[getRound()][i][j] == 0)
+                {
+                    continue;
+                }
+                JSON_Value* assignment_v = json_value_init_object();
+                JSON_Object* assignment_o = json_value_get_object(assignment_v);
+                json_object_set_number(assignment_o, "territoryId", terIds[j]);
+                json_object_set_number(assignment_o, "assignCost", assignCost_[j][i]);
+                json_object_set_value(assignment_o, "channels", json_value_init_array());
+                JSON_Array* channels_json_array = json_object_get_array(assignment_o, "channels");
+                const Territory* t = sState.getTerritory(terIds[j]);
+                std::vector<uint32_t> channelIds = t->getChannelIds();
+                for (unsigned k = 0; k < channelIds.size(); k++)
+                {
+                    if (winAssign_[j][k] != i)
+                    {
+                        continue;
+                    }
+
+                    JSON_Value* channel_v = json_value_init_object();
+                    JSON_Object* channel_o = json_value_get_object(channel_v);
+                    json_object_set_number(channel_o, "channelId", channelIds[k]);
+                    json_object_set_number(channel_o, "price", channelPrice_[j][k]);
+
+                    json_array_append_value(channels_json_array, channel_v);
+                }
+
+                json_array_append_value(assignment_json_array, assignment_v);
+            }
+
+            json_array_append_value(json_array, v);
+        }
+    }
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::isRoundActive() const
+{
+    return roundActive_;
+}
+
+void ClockAuction::DynamicAuctionState::startRound(const ClockAuction::StaticAuctionState& sState)
+{
+    if (isStateClockPhase())
+    {
+        // add another vector of bids, which will be filled/updated as bidder submit bids
+        if (clockBids_.size() < clockRound_ + 1)
+        {
+            clockBids_.resize(clockBids_.size() + 1);
+            clockBids_[clockRound_].resize(sState.getBiddersN());
+        }
+    }
+
+    roundActive_ = true;
+}
+
+void ClockAuction::DynamicAuctionState::endRound()
+{
+    roundActive_ = false;
+}
+
+void ClockAuction::DynamicAuctionState::endRoundAndAdvance()
+{
+    endRound();
+    clockRound_++;
+}
+
+bool ClockAuction::DynamicAuctionState::isStateClockPhase() const
+{
+    return auctionState_ == CLOCK_PHASE;
+}
+
+bool ClockAuction::DynamicAuctionState::isStateAssignmentPhase() const
+{
+    return auctionState_ == ASSIGNMENT_PHASE;
+}
+
+bool ClockAuction::DynamicAuctionState::isStateClosedPhase() const
+{
+    return auctionState_ == CLOSED;
+}
+
+uint32_t ClockAuction::DynamicAuctionState::getRound() const
+{
+    return clockRound_;
+}
+
+bool ClockAuction::DynamicAuctionState::isLastClockRound(uint32_t round) const
+{
+    // last clock round is: the stored round when the auction is in assignment phase or closed
+    return round == getRound() && (isStateAssignmentPhase() || isStateClosedPhase());
+}
+
+void ClockAuction::DynamicAuctionState::closeAuctionState()
+{
+    auctionState_ = CLOSED;
+}
+
+const ClockAuction::Principal ClockAuction::DynamicAuctionState::getSubmitter() const
+{
+    return submitterPrincipal_;
+}
+
+bool ClockAuction::DynamicAuctionState::isValidBid(const StaticAuctionState& sState, const Bid& bid)
+{
+    FAST_FAIL_CHECK(er_, EC_UNRECOGNIZED_SUBMITTER, !isValidBidder(sState));
+
+    std::set<uint32_t> duplicateIdTracker;
+    FAST_FAIL_CHECK(er_, EC_ROUND_NOT_CURRENT, clockRound_ != bid.round_);
+    FAST_FAIL_CHECK(er_, EC_ROUND_NOT_ACTIVE, !roundActive_);
+
+    for (unsigned int i = 0; i < bid.demands_.size(); i++)
+    {
+        const Territory* pTerritory = sState.getTerritory(bid.demands_[i].territoryId_);
+        int32_t tIndex = sState.getTerritoryIndex(bid.demands_[i].territoryId_);
+
+        // check territory existence
+        FAST_FAIL_CHECK(er_, EC_UNRECOGNIZED_TERRITORY, pTerritory == NULL || tIndex == -1);
+
+        // check if entered territory is duplicate
+        auto it = duplicateIdTracker.find(bid.demands_[i].territoryId_);
+        FAST_FAIL_CHECK(er_, EC_DUPLICATE_TERRITORIES, it != duplicateIdTracker.end());
+        duplicateIdTracker.insert(bid.demands_[i].territoryId_);
+
+        // check demand does not exceed supply
+        FAST_FAIL_CHECK(
+            er_, EC_TOO_MUCH_DEMAND, bid.demands_[i].quantity_ > pTerritory->numberOfChannels());
+
+        if (clockRound_ == 1)
+        {
+            // check demand does not exceed eligibility
+            uint32_t elig =
+                sState.getEligibilityNumber(sState.fromPrincipalToBidderId(submitterPrincipal_));
+            FAST_FAIL_CHECK(er_, EC_NOT_ENOUGH_ELIGIBILITY, bid.sumQuantityDemands() > elig);
+            // no price check in first round
+        }
+        else
+        {
+            FAST_FAIL_CHECK(er_, EC_BELOW_POSTED_PRICE,
+                bid.demands_[i].price_ < postedPrice_[clockRound_ - 1][tIndex]);
+            FAST_FAIL_CHECK(er_, EC_ABOVE_CLOCK_PRICE,
+                bid.demands_[i].price_ > clockPrice_[clockRound_][tIndex]);
+        }
+    }
+    return true;
+}
+
+bool ClockAuction::DynamicAuctionState::isValidBidder(const StaticAuctionState& sState)
+{
+    uint32_t bidderId = sState.fromPrincipalToBidderId(submitterPrincipal_);
+    return bidderId != 0;
+}
+
+bool ClockAuction::DynamicAuctionState::isValidOwner(const StaticAuctionState& sState)
+{
+    return sState.isPrincipalOwner(submitterPrincipal_);
+}
+
+void ClockAuction::DynamicAuctionState::storeBid(const StaticAuctionState& sState, const Bid& bid)
+{
+    uint32_t bidderId = sState.fromPrincipalToBidderId(submitterPrincipal_);
+    int32_t bidderIndex = sState.fromBidderIdToBidderIndex(bidderId);
+    clockBids_[clockRound_][bidderIndex] = bid;
+}
+
+void ClockAuction::DynamicAuctionState::fillMissingBids(
+    const StaticAuctionState& sState, uint32_t auctionId)
+{
+    std::vector<uint32_t> territoryIds = sState.getTerritoryIds();
+    sort(territoryIds.begin(), territoryIds.end());
+    for (unsigned int i = 0; i < sState.getBiddersN(); i++)
+    {
+        // compute territory ids of missing bids
+        std::vector<uint32_t> demandedTerritoryIds =
+            clockBids_[clockRound_][i].getDemandedTerritoryIds();
+        sort(demandedTerritoryIds.begin(), demandedTerritoryIds.end());
+        std::vector<uint32_t> diff(sState.getTerritoryN());
+        auto it = std::set_difference(territoryIds.begin(), territoryIds.end(),
+            demandedTerritoryIds.begin(), demandedTerritoryIds.end(), diff.begin());
+        diff.resize(it - diff.begin());
+
+        // fill all fields in the available (possible empty) Bid
+        clockBids_[clockRound_][i].auctionId_ = auctionId;
+        clockBids_[clockRound_][i].round_ = clockRound_;
+        for (unsigned int j = 0; j < diff.size(); j++)
+        {
+            uint32_t territoryIndex = sState.getTerritoryIndex(diff[j]);
+            ClockAuction::Demand d(diff[j], 0, postedPrice_[clockRound_ - 1][territoryIndex]);
+            clockBids_[clockRound_][i].demands_.push_back(d);
+        }
+    }
+}

--- a/demo/chaincode/fpc/auction-state.h
+++ b/demo/chaincode/fpc/auction-state.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "bid.h"
+#include "bidder.h"
+#include "common.h"
+#include "eligibility.h"
+#include "error-codes.h"
+#include "principal.h"
+#include "territory.h"
+
+typedef enum
+{
+    STATE_UNDEFINED,
+    CLOCK_PHASE,
+    ASSIGNMENT_PHASE,
+    FSR_FAILED,
+    CLOSED,
+    MAX_STATE_INDEX
+} auction_state_e;
+
+#define INITIAL_CLOCK_ROUND_NUMBER 1
+
+namespace ClockAuction
+{
+class StaticAuctionState
+{
+private:
+    Principal owner_;
+    std::string name_;
+    std::vector<Territory> territories_;
+    std::vector<Bidder> bidders_;
+    std::vector<Eligibility> initialEligibilities_;
+    uint32_t activityRequirementPercentage_;
+    uint32_t clockPriceIncrementPercentage_;
+
+public:
+    bool toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+    bool fromExtendedJsonObject(const JSON_Object* root_object);
+    bool checkValidity();
+    void setOwner(const Principal& p);
+    ErrorReport getErrorReport();
+    ErrorReport er_;
+
+    bool isTerritoryIdValid(uint32_t checkId);
+    const Territory* getTerritory(uint32_t territoryId) const;
+    int32_t getTerritoryIndex(uint32_t territoryId) const;
+    std::vector<uint32_t> getTerritoryIds() const;
+    std::vector<bool> getHighDemandVector() const;
+    std::vector<uint32_t> getSupply() const;
+
+    bool isPrincipalOwner(const Principal& p) const;
+    bool isPrincipalBidder(const Principal& p);
+    uint32_t fromPrincipalToBidderId(const Principal& p) const;
+    int32_t fromBidderIdToBidderIndex(uint32_t bidderId) const;
+    uint32_t fromBidderIndexToBidderId(uint32_t bidderIndex) const;
+    const Principal fromBidderIdToPrincipal(uint32_t bidderId) const;
+    uint32_t getEligibilityNumber(uint32_t bidderId) const;
+
+    std::vector<double> getInitialPrices() const;
+    std::vector<uint32_t> getInitialEligibilities() const;
+    uint32_t getActivityRequirementPercentage() const;
+    uint32_t getClockPriceIncrementPercentage() const;
+    uint32_t getBiddersN() const;
+    uint32_t getTerritoryN() const;
+};
+
+class DynamicAuctionState
+{
+private:
+    auction_state_e auctionState_;
+    uint32_t clockRound_;
+    bool roundActive_;
+
+    Principal submitterPrincipal_;
+
+    std::vector<std::vector<double> > postedPrice_;    // vector: [round][territory-index]  = price
+    std::vector<std::vector<double> > clockPrice_;     // vector: [round][territory-index]  = price
+    std::vector<std::vector<uint32_t> > eligibility_;  // vector: [round][bidder-index]     = number
+    std::vector<std::vector<ClockAuction::Bid> >
+        clockBids_;                                    // vector: [round][bidder-index]     = bid
+    std::vector<std::vector<int32_t> > excessDemand_;  // vector: [round][territory-index]  = number
+    std::vector<std::vector<std::vector<uint32_t> > >
+        processedLicenses_;  // vector: [round][bidder-index][territory-index] = number
+    std::vector<std::vector<int32_t> >
+        winAssign_;  // vector: [territory-index][channel-index] = bidder-index (-1=unassigned)
+    std::vector<std::vector<double> >
+        assignCost_;  // vector: [territory-index][bidder-index] = price
+    std::vector<std::vector<double> >
+        channelPrice_;  // vector: [territory-index][channel-index] = price
+
+    void identifySubmitter(shim_ctx_ptr_t ctx);
+
+public:
+    ErrorReport er_;
+    DynamicAuctionState(shim_ctx_ptr_t ctx);
+    void initialize(auction_state_e auctionState,
+        uint32_t clockRound,
+        bool roundActive,
+        StaticAuctionState& staticAuctionState);
+    bool toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+
+    bool toRoundInfoJsonObject(JSON_Object* root_object,
+        const ClockAuction::StaticAuctionState& sState,
+        uint32_t round) const;
+    bool toBidderRoundResultsJsonObject(JSON_Object* root_object,
+        const ClockAuction::StaticAuctionState& sState,
+        uint32_t round) const;
+    bool toOwnerRoundResultsJsonObject(JSON_Object* root_object,
+        const ClockAuction::StaticAuctionState& sState,
+        uint32_t round) const;
+    bool toAssignmentResultsJsonObject(
+        JSON_Object* root_object, const ClockAuction::StaticAuctionState& sState) const;
+
+    bool isRoundActive() const;
+    void startRound(const StaticAuctionState& sState);
+    void endRound();
+    void endRoundAndAdvance();
+    bool isStateClockPhase() const;
+    bool isStateAssignmentPhase() const;
+    bool isStateClosedPhase() const;
+    uint32_t getRound() const;
+    bool isLastClockRound(uint32_t round) const;
+    void closeAuctionState();
+
+    const Principal getSubmitter() const;
+
+    bool isValidBid(const StaticAuctionState& sState, const Bid& bid);
+    bool isValidBidder(const StaticAuctionState& sState);
+    bool isValidOwner(const StaticAuctionState& sState);
+    void storeBid(const StaticAuctionState& sState, const Bid& bid);
+    void fillMissingBids(const StaticAuctionState& sState, uint32_t auctionId);
+
+    void processInitialRoundBids(StaticAuctionState& sState, uint32_t auctionId);
+    void processRegularRoundBids(StaticAuctionState& sState, uint32_t auctionId);
+    void processBidsPostamble(StaticAuctionState& sState);
+    void processAssignmentRound(StaticAuctionState& sState);
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/auction-state.h
+++ b/demo/chaincode/fpc/auction-state.h
@@ -138,6 +138,7 @@ public:
     void storeBid(const StaticAuctionState& sState, const Bid& bid);
     void fillMissingBids(const StaticAuctionState& sState, uint32_t auctionId);
 
+    void processBidsPreamble();
     void processInitialRoundBids(StaticAuctionState& sState, uint32_t auctionId);
     void processRegularRoundBids(StaticAuctionState& sState, uint32_t auctionId);
     void processBidsPostamble(StaticAuctionState& sState);

--- a/demo/chaincode/fpc/bid.cpp
+++ b/demo/chaincode/fpc/bid.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bid.h"
+#include "auction-state.h"
+#include "utils.h"
+
+ClockAuction::Demand::Demand() {}
+
+ClockAuction::Demand::Demand(uint32_t territoryId, uint32_t quantity, double price)
+    : territoryId_(territoryId), quantity_(quantity), price_(price)
+{
+}
+
+bool ClockAuction::Demand::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "terId", JSONNumber));
+        double d = json_object_get_number(root_object, "terId");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        territoryId_ = (uint32_t)d;
+    }
+    {
+        FAST_FAIL_CHECK(
+            er_, EC_INVALID_INPUT, !json_object_has_value_of_type(root_object, "qty", JSONNumber));
+        double d = json_object_get_number(root_object, "qty");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        quantity_ = (uint32_t)d;
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "price", JSONNumber));
+        double d = json_object_get_number(root_object, "price");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        price_ = (uint32_t)d;
+    }
+    return true;
+}
+
+void ClockAuction::Demand::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "terId", territoryId_);
+    json_object_set_number(root_object, "qty", quantity_);
+    json_object_set_number(root_object, "price", price_);
+}
+
+bool ClockAuction::Bid::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "auctionId", JSONNumber));
+        double d = json_object_get_number(root_object, "auctionId");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        auctionId_ = (uint32_t)d;
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "round", JSONNumber));
+        double d = json_object_get_number(root_object, "round");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        round_ = (uint32_t)d;
+    }
+    {
+        JSON_Array* demand_array = json_object_get_array(root_object, "bids");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, demand_array == 0);
+        unsigned int bidsN = json_array_get_count(demand_array);
+        // NOTE: the following check (bidsN == 0 && auctionId_ != 0) allows to have
+        // no bids when auctionid is 0. This is useful to immediately store/retrieve
+        // missing bids in the dynamic state for each bidder.
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, bidsN == 0 && auctionId_ != 0);
+        for (unsigned int i = 0; i < bidsN; i++)
+        {
+            JSON_Object* o = json_array_get_object(demand_array, i);
+            Demand d;
+            FAST_FAIL_CHECK_EX(er_, &d.er_, EC_INVALID_INPUT, !d.fromJsonObject(o));
+            demands_.push_back(d);
+        }
+    }
+    return true;
+}
+
+void ClockAuction::Bid::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "auctionId", auctionId_);
+    json_object_set_number(root_object, "round", round_);
+    json_object_set_value(root_object, "bids", json_value_init_array());
+    JSON_Array* demand_array = json_object_get_array(root_object, "bids");
+    for (unsigned int i = 0; i < demands_.size(); i++)
+    {
+        JSON_Value* v = json_value_init_object();
+        JSON_Object* o = json_value_get_object(v);
+        demands_[i].toJsonObject(o);
+        json_array_append_value(demand_array, v);
+    }
+}
+
+uint32_t ClockAuction::Bid::sumQuantityDemands() const
+{
+    uint32_t total = 0;
+    for (unsigned int i = 0; i < demands_.size(); i++)
+    {
+        total += demands_[i].quantity_;
+    }
+    return total;
+}
+
+std::vector<uint32_t> ClockAuction::Bid::getDemandedTerritoryIds() const
+{
+    std::vector<uint32_t> demandedTerritoryIds;
+    for (unsigned int i = 0; i < demands_.size(); i++)
+    {
+        demandedTerritoryIds.push_back(demands_[i].territoryId_);
+    }
+    return demandedTerritoryIds;
+}
+
+bool ClockAuction::compareByDecreasingPricePoint(const enqueuedBid& b1, const enqueuedBid& b2)
+{
+    if (b1.pricePoint > b2.pricePoint)
+        return true;
+    if (b1.pricePoint < b2.pricePoint)
+        return false;
+    if (b1.randomValue > b2.randomValue)
+        return true;
+    return false;
+}
+
+bool ClockAuction::compareByIncreasingPricePoint(const enqueuedBid& b1, const enqueuedBid& b2)
+{
+    return !compareByDecreasingPricePoint(b1, b2);
+}

--- a/demo/chaincode/fpc/bid.h
+++ b/demo/chaincode/fpc/bid.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+#include "error-codes.h"
+
+namespace ClockAuction
+{
+class Demand
+{
+public:
+    Demand();
+    Demand(uint32_t territoryId, uint32_t quantity, double price);
+    uint32_t territoryId_;
+    uint32_t quantity_;
+    double price_;
+
+    ErrorReport er_;
+
+    bool fromJsonObject(const JSON_Object* root_object);
+    void toJsonObject(JSON_Object* root_object) const;
+};
+
+class Bid
+{
+public:
+    uint32_t auctionId_;
+    uint32_t round_;
+    std::vector<Demand> demands_;
+    ErrorReport er_;
+
+    bool fromJsonObject(const JSON_Object* root_object);
+    void toJsonObject(JSON_Object* root_object) const;
+
+    //            bool isValid(const ClockAuction::StaticAuctionState& sState, const
+    //            ClockAuction::DynamicAuctionState& dState);
+    uint32_t sumQuantityDemands() const;
+    std::vector<uint32_t> getDemandedTerritoryIds() const;
+};
+
+class enqueuedBid
+{
+public:
+    uint32_t bidderIndex;
+    uint32_t territoryIndex;
+    Demand demand;
+    uint32_t pricePoint;
+    uint32_t randomValue;
+};
+bool compareByDecreasingPricePoint(const enqueuedBid& b1, const enqueuedBid& b2);
+bool compareByIncreasingPricePoint(const enqueuedBid& b1, const enqueuedBid& b2);
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/bidder.cpp
+++ b/demo/chaincode/fpc/bidder.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bidder.h"
+#include "common.h"
+#include "utils.h"
+
+bool ClockAuction::Bidder::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "id", id_);
+    json_object_set_string(root_object, "displayName", displayName_.c_str());
+    JSON_Value* v = json_value_init_object();
+    JSON_Object* o = json_value_get_object(v);
+    principal_.toJsonObject(o);
+    json_object_set_value(root_object, "principal", v);
+    return true;
+}
+
+bool ClockAuction::Bidder::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(
+            er_, EC_INVALID_INPUT, !json_object_has_value_of_type(root_object, "id", JSONNumber));
+        double d = json_object_get_number(root_object, "id");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        id_ = (uint32_t)d;
+    }
+    {
+        const char* str = json_object_get_string(root_object, "displayName");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, str == 0);
+        displayName_ = std::string(str);
+    }
+    {
+        JSON_Value* v = json_object_get_value(root_object, "principal");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, v == 0);
+        JSON_Object* o = json_value_get_object(v);
+        FAST_FAIL_CHECK_EX(er_, &principal_.er_, EC_INVALID_INPUT, !principal_.fromJsonObject(o));
+    }
+    return true;
+}
+
+bool ClockAuction::Bidder::matchPrincipal(const Principal& p) const
+{
+    return p == principal_;
+}
+
+uint32_t ClockAuction::Bidder::getId() const
+{
+    return id_;
+}
+
+const ClockAuction::Principal ClockAuction::Bidder::getPrincipal() const
+{
+    return principal_;
+}

--- a/demo/chaincode/fpc/bidder.h
+++ b/demo/chaincode/fpc/bidder.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+#include "error-codes.h"
+#include "principal.h"
+
+namespace ClockAuction
+{
+class Bidder
+{
+private:
+    uint32_t id_;
+    std::string displayName_;
+    Principal principal_;
+
+public:
+    bool toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+    ErrorReport er_;
+
+    bool matchPrincipal(const Principal& p) const;
+    uint32_t getId() const;
+    const Principal getPrincipal() const;
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/common.h
+++ b/demo/chaincode/fpc/common.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+//#define DO_DEBUG true
+
+#include <list>
+#include <numeric>
+#include <queue>
+#include <set>
+#include <string>
+#include <vector>
+#include "json/parson.h"
+#include "logging.h"
+#include "shim.h"

--- a/demo/chaincode/fpc/dispatcher.cpp
+++ b/demo/chaincode/fpc/dispatcher.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "dispatcher.h"
+#include <string>
+#include "common.h"
+#include "error-codes.h"
+#include "spectrum-auction.h"
+
+ClockAuction::Dispatcher::Dispatcher(const std::string& functionName,
+    const std::vector<std::string>& functionParameters,
+    uint8_t* response,
+    const uint32_t max_response_len,
+    uint32_t* actual_response_len,
+    shim_ctx_ptr_t ctx)
+    : functionName_(functionName),
+      functionParameters_(functionParameters),
+      response_(response),
+      max_response_len_(max_response_len),
+      actual_response_len_(actual_response_len),
+      spectrumAuction_(ctx)
+{
+    static std::map<std::string, spectrumAuctionFunctionP> fMap_ = {
+        {"createAuction", &ClockAuction::SpectrumAuction::createAuction},
+        {"getAuctionDetails", &ClockAuction::SpectrumAuction::getAuctionDetails},
+        {"getAuctionStatus", &ClockAuction::SpectrumAuction::getAuctionStatus},
+        {"startNextRound", &ClockAuction::SpectrumAuction::startNextRound},
+        {"endRound", &ClockAuction::SpectrumAuction::endRound},
+        {"submitClockBid", &ClockAuction::SpectrumAuction::submitClockBid},
+        {"getRoundInfo", &ClockAuction::SpectrumAuction::getRoundInfo},
+        {"getBidderRoundResults", &ClockAuction::SpectrumAuction::getBidderRoundResults},
+        {"getOwnerRoundResults", &ClockAuction::SpectrumAuction::getOwnerRoundResults},
+        {"submitAssignmentBid", &ClockAuction::SpectrumAuction::submitAssignmentBid},
+        {"getAssignmentResults", &ClockAuction::SpectrumAuction::getAssignmentResults}};
+
+    LOG_DEBUG("Try dispatch function %s with parameters %s", functionName_.c_str(),
+        functionParameters[0].c_str());
+
+    // Call auction function
+    auto fIter = fMap_.find(functionName_);
+    if (fIter == fMap_.end())
+    {
+        // No such function
+        CUSTOM_ERROR_REPORT(errorReport_, EC_BAD_FUNCTION_NAME, "Auction API not found");
+    }
+    else
+    {
+        LOG_DEBUG("Auction API found, call it");
+        (spectrumAuction_.*(fIter->second))(functionParameters[0], responseString_, errorReport_);
+        LOG_DEBUG("API response string: %s", responseString_.c_str());
+    }
+
+    // prepare response string
+    if (responseString_.length() == 0 || !errorReport_.isSuccess())
+    {
+        // an error occurred: fill the response with the error/status message
+        errorReport_.toWrappedStatusJsonString(responseString_);
+        LOG_DEBUG("Error response string set: %s", responseString_.c_str());
+    }
+
+    if (responseString_.length() > max_response_len_)
+    {
+        LOG_ERROR("Response string too long to be output");
+        CUSTOM_ERROR_REPORT(
+            errorReport_, EC_SHORT_RESPONSE_BUFFER, "Response string too long to be output");
+        errorReport_.toWrappedStatusJsonString(responseString_);
+    }
+
+    // write response string (if possible)
+    *actual_response_len_ =
+        (responseString_.length() > max_response_len_ ? 0 : responseString_.length());
+    memcpy(response_, responseString_.c_str(), *actual_response_len_);
+    LOG_DEBUG("Response written (length %u)", *actual_response_len_);
+}

--- a/demo/chaincode/fpc/dispatcher.h
+++ b/demo/chaincode/fpc/dispatcher.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <map>
+#include <vector>
+#include "common.h"
+#include "spectrum-auction.h"
+
+namespace ClockAuction
+{
+class Dispatcher
+{
+private:
+    const std::string functionName_;
+    const std::vector<std::string> functionParameters_;
+    uint8_t* response_;
+    const uint32_t max_response_len_;
+    uint32_t* actual_response_len_;
+
+    std::string responseString_;
+
+    ClockAuction::SpectrumAuction spectrumAuction_;
+
+public:
+    ClockAuction::ErrorReport errorReport_;
+
+    Dispatcher(const std::string& functionName,
+        const std::vector<std::string>& functionParameters,
+        uint8_t* response,
+        const uint32_t max_response_len,
+        uint32_t* actual_response_len,
+        shim_ctx_ptr_t ctx);
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/eligibility.cpp
+++ b/demo/chaincode/fpc/eligibility.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "eligibility.h"
+#include "utils.h"
+
+bool ClockAuction::Eligibility::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "bidderId", bidderId_);
+    json_object_set_number(root_object, "number", number_);
+    return true;
+}
+
+bool ClockAuction::Eligibility::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "bidderId", JSONNumber));
+        double d = json_object_get_number(root_object, "bidderId");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        bidderId_ = (uint32_t)d;
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "number", JSONNumber));
+        double d = json_object_get_number(root_object, "number");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        number_ = (uint32_t)d;
+    }
+    return true;
+}
+
+bool ClockAuction::Eligibility::matchBidderId(uint32_t bidderId) const
+{
+    return bidderId == bidderId_;
+}
+
+uint32_t ClockAuction::Eligibility::getNumber() const
+{
+    return number_;
+}

--- a/demo/chaincode/fpc/eligibility.h
+++ b/demo/chaincode/fpc/eligibility.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+#include "error-codes.h"
+
+namespace ClockAuction
+{
+class Eligibility
+{
+private:
+    uint32_t bidderId_;
+    uint32_t number_;
+
+public:
+    bool toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+    ErrorReport er_;
+
+    bool matchBidderId(uint32_t bidderId) const;
+    uint32_t getNumber() const;
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/entry.cpp
+++ b/demo/chaincode/fpc/entry.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "base64/base64.h"
+#include "common.h"
+#include "dispatcher.h"
+#include "json/parson.h"
+
+int init(
+    uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)
+{
+    return 0;
+}
+
+int invoke(
+    uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)
+{
+    LOG_INFO("Clock Auction: executing...");
+
+    int ret = -1;
+    std::string functionName;
+    std::vector<std::string> functionParameters;
+
+    get_func_and_params(functionName, functionParameters, ctx);
+
+    ClockAuction::Dispatcher auctionApiDispatcher(
+        functionName, functionParameters, response, max_response_len, actual_response_len, ctx);
+    if (!auctionApiDispatcher.errorReport_.isSuccess())
+    {
+        LOG_ERROR("Execution failed.");
+        ret = -1;
+    }
+    else
+    {
+        LOG_DEBUG("Execution successful");
+        ret = 0;
+    }
+
+    // double check that the response has been filled
+    if (*actual_response_len == 0)
+    {
+        LOG_ERROR("Response length is zero");
+        ret = -1;
+    }
+
+    LOG_INFO("Clock Auction: exiting.");
+    return ret;
+}

--- a/demo/chaincode/fpc/error-codes.cpp
+++ b/demo/chaincode/fpc/error-codes.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "error-codes.h"
+#include <string>
+#include "spectrum-auction-message.h"
+
+ClockAuction::ErrorReport::ErrorReport() {}
+
+void ClockAuction::ErrorReport::set(error_codes_e e, const std::string& s)
+{
+    ec_ = e;
+    errorString_ = s;
+}
+
+void ClockAuction::ErrorReport::toStatusJsonString(std::string& jsonString)
+{
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toStatusJsonString(ec_, errorString_, jsonString);
+}
+
+void ClockAuction::ErrorReport::toWrappedStatusJsonString(std::string& jsonString)
+{
+    ClockAuction::SpectrumAuctionMessage msg;
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    msg.toWrappedStatusJsonObject(root_object, ec_, errorString_);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString);
+}
+
+bool ClockAuction::ErrorReport::isSuccess()
+{
+    if (ec_ == EC_SUCCESS)
+    {
+        return true;
+    }
+    return false;
+}

--- a/demo/chaincode/fpc/error-codes.h
+++ b/demo/chaincode/fpc/error-codes.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <string>
+
+typedef enum
+{
+    EC_UNDEFINED,                 // 0
+    EC_SUCCESS,                   // 1
+    EC_ERROR,                     // 2
+    EC_HIDDEN,                    // 3
+    EC_BAD_FUNCTION_NAME,         // 4
+    EC_INVALID_INPUT,             // 5
+    EC_MEMORY_ERROR,              // 6
+    EC_SHORT_RESPONSE_BUFFER,     // 7
+    EC_BAD_PARAMETERS,            // 8
+    EC_AUCTION_RELATED_CODES,     // 9
+    EC_ROUND_ACTIVE,              // 10
+    EC_RESTRICTED_AUCTION_STATE,  // 11
+    EC_NOT_IN_CLOCK_PHASE,        // 12
+    EC_NOT_IN_ASSIGNMENT_PHASE,   // 13
+    EC_ROUND_NOT_CURRENT,         // 14
+    EC_UNRECOGNIZED_TERRITORY,    // 15
+    EC_UNAVAILABLE_QUANTITY,      // 16
+    EC_DUPLICATE_TERRITORIES,     // 17
+    EC_PRICE_OUT_OF_RANGE,        // 18
+    EC_ROUND_NOT_ACTIVE,          // 19
+    EC_NOT_ENOUGH_ELIGIBILITY,    // 20
+    EC_TOO_MUCH_DEMAND,           // 21
+    EC_UNRECOGNIZED_SUBMITTER,    // 22
+    EC_BELOW_POSTED_PRICE,        // 23
+    EC_ABOVE_CLOCK_PRICE,         // 24
+    EC_EVALUATION_ERROR,          // 25
+    EC_UNIMPLEMENTED_API          // 26
+} error_codes_e;
+
+namespace ClockAuction
+{
+class ErrorReport
+{
+private:
+    error_codes_e ec_;
+    std::string errorString_;
+
+public:
+    ErrorReport();
+
+    void set(error_codes_e ec, const std::string& errorString);
+    void toStatusJsonString(std::string& jsonString);
+    void toWrappedStatusJsonString(std::string& jsonString);
+    bool isSuccess();
+};
+}  // namespace ClockAuction
+
+#define CUSTOM_ERROR_REPORT(er, code, message) er.set(code, std::string(#code) + ":" + message);
+
+#define DEFAULT_ERROR_REPORT(er, code) \
+    er.set(code, std::string(#code) + ":" + std::string(__FILE__) + ":" + std::to_string(__LINE__));
+
+#define FAST_FAIL_CHECK(errorReport, code, b)       \
+    {                                               \
+        if (b)                                      \
+        {                                           \
+            DEFAULT_ERROR_REPORT(errorReport, code) \
+            return false;                           \
+        }                                           \
+    }
+
+#define FAST_FAIL_CHECK_EX(parentErrorReport, pChildErrorReport, code, b) \
+    {                                                                     \
+        if (b)                                                            \
+        {                                                                 \
+            if (pChildErrorReport)                                        \
+            {                                                             \
+                parentErrorReport = *pChildErrorReport;                   \
+            }                                                             \
+            else                                                          \
+            {                                                             \
+                DEFAULT_ERROR_REPORT(parentErrorReport, code)             \
+            }                                                             \
+            return false;                                                 \
+        }                                                                 \
+    }

--- a/demo/chaincode/fpc/evaluate.cpp
+++ b/demo/chaincode/fpc/evaluate.cpp
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "auction-state.h"
+#include "common.h"
+#include "crypto.h"
+#include "spectrum-auction.h"
+
+void ClockAuction::SpectrumAuction::evaluateClockRound()
+{
+    if (dynamicAuctionState_.getRound() == 1)
+    {
+        LOG_DEBUG("Processing initial bids");
+        dynamicAuctionState_.processInitialRoundBids(staticAuctionState_, auctionIdCounter_);
+    }
+    else
+    {
+        LOG_DEBUG("Processing regular bids");
+        dynamicAuctionState_.processRegularRoundBids(staticAuctionState_, auctionIdCounter_);
+    }
+
+    dynamicAuctionState_.processBidsPostamble(staticAuctionState_);
+    LOG_DEBUG("Processing complete");
+}
+
+void ClockAuction::SpectrumAuction::evaluateAssignmentRound()
+{
+    dynamicAuctionState_.processAssignmentRound(staticAuctionState_);
+}
+
+void ClockAuction::DynamicAuctionState::processInitialRoundBids(
+    StaticAuctionState& sState, uint32_t auctionId)
+{
+    // missing bids
+    fillMissingBids(sState, auctionId);
+
+    // NOTE: missing bids are already set in startStart.
+    // Such bids can be recognized by the auctionId = 0
+
+    // set processed licenses
+    processedLicenses_.resize(2);  // add the processedLicenses_[round=1] vector
+    processedLicenses_[1].resize(sState.getBiddersN());
+    for (unsigned int i = 0; i < sState.getBiddersN(); i++)
+    {
+        processedLicenses_[1][i].resize(sState.getTerritoryN());
+
+        for (unsigned int j = 0; j < clockBids_[1][i].demands_.size(); j++)
+        {
+            uint32_t demandedTerritoryId = clockBids_[1][i].demands_[j].territoryId_;
+            uint32_t demandedQuantity = clockBids_[1][i].demands_[j].quantity_;
+            processedLicenses_[1][i][sState.getTerritoryIndex(demandedTerritoryId)] =
+                demandedQuantity;
+        }
+    }
+
+    // set postedPrice to min/initial price
+    postedPrice_.resize(2);  // ensures postedPrice_[1] is defined
+    postedPrice_[1] = sState.getInitialPrices();
+}
+
+void ClockAuction::DynamicAuctionState::processBidsPostamble(StaticAuctionState& sState)
+{
+    // aggregated demand (per territory)
+    std::vector<uint32_t> aggregatedDemand(sState.getTerritoryN());
+    for (unsigned int i = 0; i < aggregatedDemand.size(); i++)
+    {
+        aggregatedDemand[i] = 0;
+        for (unsigned int j = 0; j < sState.getBiddersN(); j++)
+        {
+            aggregatedDemand[i] += processedLicenses_[clockRound_][j][i];
+        }
+    }
+
+    // excess demand
+    std::vector<uint32_t> supply = sState.getSupply();
+    std::vector<int32_t> roundExcessDemand(sState.getTerritoryN());
+    for (unsigned int i = 0; i < sState.getTerritoryN(); i++)
+    {
+        roundExcessDemand[i] = aggregatedDemand[i] - supply[i];
+    }
+    excessDemand_.push_back(roundExcessDemand);
+
+    // final stage rule check
+    std::vector<bool> highDemand = sState.getHighDemandVector();
+    for (unsigned int i = 0; i < roundExcessDemand.size(); i++)
+    {
+        if (roundExcessDemand[i] < 0 && highDemand[i])
+        {
+            LOG_INFO(
+                "Final Stage Rule: FAILED - demand below supply for  %u-th high-demand territory",
+                i);
+            auctionState_ = FSR_FAILED;
+        }
+    }
+
+    // check clock phase termination
+    if (auctionState_ == CLOCK_PHASE)
+    {
+        if (*max_element(roundExcessDemand.begin(), roundExcessDemand.end()) <= 0)
+        {
+            LOG_INFO("Clock Phase: COMPLETED!");
+            auctionState_ = ASSIGNMENT_PHASE;
+        }
+        else
+        {
+            LOG_INFO("Clock Phase: to be continued");
+
+            // processed activity, required activity and new eligibility
+            std::vector<uint32_t> processedActivity(sState.getBiddersN());
+            std::vector<uint32_t> requiredActivity(sState.getBiddersN());
+            std::vector<uint32_t> newRoundEligibility(sState.getBiddersN());
+            for (unsigned int i = 0; i < sState.getBiddersN(); i++)
+            {
+                processedActivity[i] = 0;
+                for (unsigned int j = 0; j < sState.getTerritoryN(); j++)
+                {
+                    processedActivity[i] += processedLicenses_[clockRound_][i][j];
+                }
+                requiredActivity[i] = eligibility_[clockRound_][i] *
+                                      sState.getActivityRequirementPercentage() / 100.0;
+                if (processedActivity[i] >= requiredActivity[i])
+                {
+                    newRoundEligibility[i] = eligibility_[clockRound_][i];
+                }
+                else
+                {
+                    newRoundEligibility[i] =
+                        processedActivity[i] * 100 / sState.getActivityRequirementPercentage();
+                }
+            }
+            eligibility_.push_back(newRoundEligibility);
+
+            // clock price
+            std::vector<double> newRoundClockPrice = postedPrice_[clockRound_];
+            for (unsigned int j = 0; j < sState.getTerritoryN(); j++)
+            {
+                newRoundClockPrice[j] *=
+                    (1.0 + ((double)sState.getClockPriceIncrementPercentage() / 100.0));
+            }
+            clockPrice_.push_back(newRoundClockPrice);
+
+            // new round
+            clockRound_++;
+        }
+    }
+}
+
+void ClockAuction::DynamicAuctionState::processRegularRoundBids(
+    StaticAuctionState& sState, uint32_t auctionId)
+{
+    // missing bids
+    fillMissingBids(sState, auctionId);
+
+    // pre-set posted price
+    std::vector<double> roundPostedPrice(sState.getTerritoryN());
+    postedPrice_.push_back(roundPostedPrice);
+    for (unsigned int i = 0; i < sState.getTerritoryN(); i++)
+    {
+        if (excessDemand_[clockRound_ - 1][i] > 0)
+        {
+            postedPrice_[clockRound_][i] = clockPrice_[clockRound_][i];
+        }
+        else
+        {
+            postedPrice_[clockRound_][i] = postedPrice_[clockRound_ - 1][i];
+        }
+    }
+
+    // prepare bids to be processed
+    std::list<enqueuedBid> eBidContainer;
+    for (unsigned int i = 0; i < sState.getBiddersN(); i++)
+    {
+        // remove bids (actually, demands) that maintain current demand
+        for (int j = clockBids_[clockRound_][i].demands_.size() - 1; j >= 0; j--)
+        {
+            // copy the bid
+            enqueuedBid eBid;
+            eBid.bidderIndex = i;
+            eBid.demand = clockBids_[clockRound_][i].demands_[j];
+            eBid.territoryIndex = sState.getTerritoryIndex(eBid.demand.territoryId_);
+
+            // skip bid if it maintains demand
+            unsigned int processedDemand =
+                processedLicenses_[clockRound_ - 1][eBid.bidderIndex][eBid.territoryIndex];
+            if (processedDemand == eBid.demand.quantity_)
+            {
+                continue;
+            }
+
+            // compute price point
+            double minPrice = postedPrice_[clockRound_ - 1][eBid.territoryIndex];
+            double clockPrice = clockPrice_[clockRound_][eBid.territoryIndex];
+            double pp = (eBid.demand.price_ - minPrice) / (clockPrice - minPrice);
+            eBid.pricePoint = (uint32_t)pp;
+
+            // compute random value for breaking ties
+            if (get_random_bytes((uint8_t*)&eBid.randomValue, sizeof(eBid.randomValue)) != 0)
+            {
+                std::string s("error getting random value, stop bid processing");
+                LOG_ERROR("%s", s.c_str());
+                er_.set(EC_EVALUATION_ERROR, s);
+                return;
+            }
+
+            // enqueue bid
+            eBidContainer.push_back(eBid);
+        }
+    }
+    // sort bids by ascending price points
+    eBidContainer.sort(compareByIncreasingPricePoint);
+
+    // initialize current round processed licenses with previous round processed licenses
+    processedLicenses_.push_back(processedLicenses_[clockRound_ - 1]);
+
+    // compute available eligibility
+    std::vector<uint32_t> eligibilityCap = eligibility_[clockRound_];
+    for (unsigned int i = 0; i < sState.getBiddersN(); i++)
+    {
+        uint32_t bidderProcessedLicenses =
+            std::accumulate(processedLicenses_[clockRound_ - 1][i].begin(),
+                processedLicenses_[clockRound_ - 1][i].end(), 0);
+        eligibilityCap[i] -= bidderProcessedLicenses;
+    }
+
+    // initialize excess demand for this round with the excess demand of the previous round
+    excessDemand_.push_back(excessDemand_[clockRound_ - 1]);
+
+    // process bids
+    auto it = eBidContainer.begin();
+    while (it != eBidContainer.end())
+    {
+        enqueuedBid& eBid = *it;
+
+        bool fullyAppliedBid = false;
+        unsigned int ownedQuantity =
+            processedLicenses_[clockRound_][eBid.bidderIndex][eBid.territoryIndex];
+        unsigned int demandedQuantity = eBid.demand.quantity_;
+
+        if (demandedQuantity > ownedQuantity)
+        {  // demand strictly increases
+            // no eligibility => do not apply bid
+            if (eligibilityCap[eBid.bidderIndex] == 0)
+            {
+                ++it;
+                continue;
+            }
+
+            // compute processable quantity
+            unsigned int deltaQuantity = demandedQuantity - ownedQuantity;
+            unsigned int processableDeltaQuantity =
+                (deltaQuantity <= eligibilityCap[eBid.bidderIndex]
+                        ? deltaQuantity
+                        : eligibilityCap[eBid.bidderIndex]);
+
+            // set fully applied bid flag
+            fullyAppliedBid = (processableDeltaQuantity == deltaQuantity);
+
+            // update processed licenses, excess demand and eligibility accordingly
+            processedLicenses_[clockRound_][eBid.bidderIndex][eBid.territoryIndex] +=
+                processableDeltaQuantity;
+            excessDemand_[clockRound_][eBid.territoryIndex] += processableDeltaQuantity;
+            eligibilityCap[eBid.bidderIndex] -= processableDeltaQuantity;
+
+            if (excessDemand_[clockRound_][eBid.territoryIndex] - processableDeltaQuantity == 0)
+            {  // if excess demand was 0, reset posted price to clock price
+                postedPrice_[clockRound_][eBid.territoryIndex] =
+                    clockPrice_[clockRound_][eBid.territoryIndex];
+            }
+        }
+        else  // demand strictly decreases (it cannot be equal, because we do not process those
+              // bids)
+        {
+            // no excess demand => do not apply bid
+            if (excessDemand_[clockRound_][eBid.territoryIndex] <= 0)
+            {
+                ++it;
+                continue;
+            }
+
+            // compute processable quantity
+            unsigned int deltaQuantity = ownedQuantity - demandedQuantity;
+            unsigned int processableDeltaQuantity =
+                (deltaQuantity <= excessDemand_[clockRound_][eBid.territoryIndex]
+                        ? deltaQuantity
+                        : excessDemand_[clockRound_][eBid.territoryIndex]);
+
+            // set fully applied bid flag
+            fullyAppliedBid = (processableDeltaQuantity == deltaQuantity);
+
+            // update processed licenses, excess demand and eligibility accordingly
+            processedLicenses_[clockRound_][eBid.bidderIndex][eBid.territoryIndex] -=
+                processableDeltaQuantity;
+            excessDemand_[clockRound_][eBid.territoryIndex] -= processableDeltaQuantity;
+            eligibilityCap[eBid.bidderIndex] += processableDeltaQuantity;
+
+            if (excessDemand_[clockRound_][eBid.territoryIndex] == 0)
+            {  // if excess demand is now zero, the bid's price is the posted price
+                postedPrice_[clockRound_][eBid.territoryIndex] = eBid.demand.price_;
+            }
+        }
+
+        // remove bid if fully processed
+        if (fullyAppliedBid)
+        {
+            it = eBidContainer.erase(it);
+        }
+
+        // restart bid processing to enforce increasing-price-point bid processing
+        // (skipped/partially-fulfilled bids might be processable now)
+        it = eBidContainer.begin();
+    }
+}
+
+void ClockAuction::DynamicAuctionState::processAssignmentRound(StaticAuctionState& sState)
+{
+    {
+        // randomly assign channels to winning bidders
+        std::vector<uint32_t> terIds = sState.getTerritoryIds();
+        winAssign_.resize(terIds.size());
+        assignCost_.resize(terIds.size());
+        channelPrice_.resize(terIds.size());
+        for (unsigned int i = 0; i < terIds.size(); i++)
+        {
+            const Territory* t = sState.getTerritory(terIds[i]);
+            uint32_t channelsN = t->numberOfChannels();
+
+            // initialize vectors
+            winAssign_[i].resize(channelsN, -1);
+            channelPrice_[i].resize(channelsN, 0);
+            assignCost_[i].resize(sState.getBiddersN(), 0);
+
+            // compute a random vector of channel indexes
+            std::vector<uint32_t> randomChannelIndexes;
+            for (unsigned int j = 0; j < channelsN; j++)
+                randomChannelIndexes.push_back(j);
+            for (unsigned int j = 0; j < channelsN; j++)
+            {
+                unsigned int r;
+                if (get_random_bytes((uint8_t*)&r, sizeof(unsigned int)) != 0)
+                {
+                    std::string s("error getting random value, stop assignment processing");
+                    LOG_ERROR("%s", s.c_str());
+                    er_.set(EC_EVALUATION_ERROR, s);
+                    return;
+                }
+                r = r % channelsN;
+                uint32_t a = randomChannelIndexes[j];
+                randomChannelIndexes[j] = randomChannelIndexes[r];
+                randomChannelIndexes[r] = a;
+            }
+
+            // compute channel prices
+            std::vector<uint32_t> impairments = t->getChannelImpairments();
+            for (unsigned int j = 0; j < channelsN; j++)
+            {
+                channelPrice_[i][j] =
+                    postedPrice_[getRound()][i] * (double)(impairments[j]) / 100.0;
+            }
+
+            // assign the randomized channel indexes to winning bidders
+            uint32_t indexToAssign = 0;
+            for (unsigned int j = 0; j < sState.getBiddersN(); j++)
+            {
+                for (unsigned int k = 0; k < processedLicenses_[getRound()][j][i]; k++)
+                {
+                    winAssign_[i][randomChannelIndexes[indexToAssign]] = j;
+                    indexToAssign++;
+                }
+            }
+        }
+    }
+
+    closeAuctionState();
+}

--- a/demo/chaincode/fpc/evaluate.cpp
+++ b/demo/chaincode/fpc/evaluate.cpp
@@ -357,7 +357,7 @@ void ClockAuction::DynamicAuctionState::processAssignmentRound(StaticAuctionStat
             for (unsigned int j = 0; j < channelsN; j++)
             {
                 channelPrice_[i][j] =
-                    postedPrice_[getRound()][i] * (double)(impairments[j]) / 100.0;
+                    postedPrice_[getRound()][i] * ((100.0 - (double)(impairments[j])) / 100.0);
             }
 
             // assign the randomized channel indexes to winning bidders

--- a/demo/chaincode/fpc/evaluate.cpp
+++ b/demo/chaincode/fpc/evaluate.cpp
@@ -6,7 +6,7 @@
 
 #include "auction-state.h"
 #include "common.h"
-#include "crypto.h"
+#include "shim.h"  // get_random_bytes
 #include "spectrum-auction.h"
 
 void ClockAuction::SpectrumAuction::evaluateClockRound()

--- a/demo/chaincode/fpc/principal.cpp
+++ b/demo/chaincode/fpc/principal.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "principal.h"
+
+ClockAuction::Principal::Principal() {}
+
+ClockAuction::Principal::Principal(std::string m, std::string d) : mspId_(m), dn_(d) {}
+
+bool operator==(const ClockAuction::Principal& p1, const ClockAuction::Principal& p2)
+{
+    if (p1.getDn() == p2.getDn() && p1.getMspId() == p2.getMspId())
+    {
+        return true;
+    }
+    return false;
+}
+
+std::string ClockAuction::Principal::getDn() const
+{
+    return dn_;
+}
+
+std::string ClockAuction::Principal::getMspId() const
+{
+    return mspId_;
+}
+
+bool ClockAuction::Principal::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_string(root_object, "mspId", mspId_.c_str());
+    json_object_set_string(root_object, "dn", dn_.c_str());
+    return true;
+}
+
+bool ClockAuction::Principal::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        const char* str = json_object_get_string(root_object, "mspId");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, str == 0);
+        mspId_ = std::string(str);
+    }
+    {
+        const char* str = json_object_get_string(root_object, "dn");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, str == 0);
+        dn_ = std::string(str);
+    }
+    return true;
+}

--- a/demo/chaincode/fpc/principal.h
+++ b/demo/chaincode/fpc/principal.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+#include "error-codes.h"
+
+namespace ClockAuction
+{
+class Principal
+{
+private:
+    // uint32_t id_;
+    std::string mspId_;
+    std::string dn_;
+    // std::string name_;
+
+public:
+    Principal();
+    Principal(std::string m, std::string d);
+    bool toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+    std::string getDn() const;
+    std::string getMspId() const;
+    ErrorReport er_;
+};
+}  // namespace ClockAuction
+
+bool operator==(const ClockAuction::Principal& p1, const ClockAuction::Principal& p2);

--- a/demo/chaincode/fpc/spectrum-auction-message.cpp
+++ b/demo/chaincode/fpc/spectrum-auction-message.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spectrum-auction-message.h"
+#include "common.h"
+#include "error-codes.h"
+#include "utils.h"
+
+ClockAuction::SpectrumAuctionMessage::SpectrumAuctionMessage() {}
+
+ClockAuction::SpectrumAuctionMessage::SpectrumAuctionMessage(const std::string& message)
+    : inputJsonString_(message)
+{
+}
+
+ClockAuction::ErrorReport ClockAuction::SpectrumAuctionMessage::getErrorReport()
+{
+    return er_;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toStatusJsonObject(
+    JSON_Object* root_object, int rc, const std::string& message)
+{
+    json_object_set_number(root_object, "rc", rc);
+    json_object_set_string(root_object, "message", message.c_str());
+}
+
+void ClockAuction::SpectrumAuctionMessage::toWrappedStatusJsonObject(
+    JSON_Object* root_object, int rc, const std::string& message)
+{
+    JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+    toStatusJsonObject(r, rc, message);
+    json_object_set_value(root_object, "status", json_object_get_wrapping_value(r));
+}
+
+void ClockAuction::SpectrumAuctionMessage::toStatusJsonString(
+    int rc, std::string& message, std::string& jsonString)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    toStatusJsonObject(root_object, rc, message);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString);
+}
+
+std::string ClockAuction::SpectrumAuctionMessage::getJsonString()
+{
+    return jsonString_;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toCreateAuctionJson(
+    int rc, const std::string& message, unsigned int auctionId)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        json_object_set_number(r, "auctionId", auctionId);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromCreateAuctionJson(
+    StaticAuctionState& staticAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    bool b = staticAuctionState.fromJsonObject(root_object);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    FAST_FAIL_CHECK_EX(er_, &staticAuctionState.er_, EC_INVALID_INPUT, !b);
+    return true;
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromGetAuctionDetailsJson(uint32_t& auctionId)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return auctionId != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toGetAuctionDetailsJson(
+    int rc, const std::string& message, const StaticAuctionState& staticAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        staticAuctionState.toJsonObject(r);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromGetAuctionStatusJson(uint32_t& auctionId)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return auctionId != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toGetAuctionStatusJson(
+    int rc, const std::string& message, const DynamicAuctionState& dynamicAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        dynamicAuctionState.toJsonObject(r);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromStartNextRoundJson(uint32_t& auctionId)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return auctionId != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toStartNextRoundJson(int rc, const std::string& message)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromEndRoundJson(uint32_t& auctionId)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return auctionId != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toEndRoundJson(int rc, const std::string& message)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromSubmitClockBidJson(Bid& bid)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    FAST_FAIL_CHECK_EX(er_, &bid.er_, EC_INVALID_INPUT, !bid.fromJsonObject(root_object));
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return true;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toSubmitClockBidJson(int rc, const std::string& message)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+void ClockAuction::SpectrumAuctionMessage::toStaticAuctionStateJson(
+    const StaticAuctionState& staticAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    staticAuctionState.toJsonObject(root_object);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromStaticAuctionStateJson(
+    StaticAuctionState& staticAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(jsonString_.c_str());
+    bool b = staticAuctionState.fromJsonObject(root_object);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return b;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toDynamicAuctionStateJson(
+    const DynamicAuctionState& dynamicAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    dynamicAuctionState.toJsonObject(root_object);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromDynamicAuctionStateJson(
+    DynamicAuctionState& dynamicAuctionState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(jsonString_.c_str());
+    bool b = dynamicAuctionState.fromJsonObject(root_object);
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    return b;
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromGetRoundInfoJson(
+    uint32_t& auctionId, uint32_t& requestedRound)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    requestedRound = json_object_get_number(root_object, "round");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    // returns false is any of the parameters does not exist or is 0
+    return auctionId != 0 && requestedRound != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toGetRoundInfoJson(int rc,
+    const std::string& message,
+    const StaticAuctionState& sState,
+    const DynamicAuctionState& dState,
+    uint32_t requestedRound)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        dState.toRoundInfoJsonObject(r, sState, requestedRound);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromGetBidderRoundResultsJson(
+    uint32_t& auctionId, uint32_t& requestedRound)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    requestedRound = json_object_get_number(root_object, "round");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    // returns false is any of the parameters does not exist or is 0
+    return auctionId != 0 && requestedRound != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toGetBidderRoundResultsJson(int rc,
+    const std::string& message,
+    const StaticAuctionState& sState,
+    const DynamicAuctionState& dState,
+    uint32_t requestedRound)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        dState.toBidderRoundResultsJsonObject(r, sState, requestedRound);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromGetOwnerRoundResultsJson(
+    uint32_t& auctionId, uint32_t& requestedRound)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    requestedRound = json_object_get_number(root_object, "round");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    // returns false is any of the parameters does not exist or is 0
+    return auctionId != 0 && requestedRound != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toGetOwnerRoundResultsJson(int rc,
+    const std::string& message,
+    const StaticAuctionState& sState,
+    const DynamicAuctionState& dState,
+    uint32_t requestedRound)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        dState.toOwnerRoundResultsJsonObject(r, sState, requestedRound);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}
+
+bool ClockAuction::SpectrumAuctionMessage::fromGetAssignmentResultsJson(uint32_t& auctionId)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(inputJsonString_.c_str());
+    auctionId = json_object_get_number(root_object, "auctionId");
+    ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    // returns false is any of the parameters does not exist or is 0
+    return auctionId != 0;
+}
+
+void ClockAuction::SpectrumAuctionMessage::toGetAssignmentResultsJson(int rc,
+    const std::string& message,
+    const StaticAuctionState& sState,
+    const DynamicAuctionState& dState)
+{
+    JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(NULL);
+    {
+        toWrappedStatusJsonObject(root_object, rc, message);
+    }
+    {
+        JSON_Object* r = ClockAuction::JsonUtils::openJsonObject(NULL);
+        dState.toAssignmentResultsJsonObject(r, sState);
+        json_object_set_value(root_object, "response", json_object_get_wrapping_value(r));
+    }
+    ClockAuction::JsonUtils::closeJsonObject(root_object, &jsonString_);
+}

--- a/demo/chaincode/fpc/spectrum-auction-message.h
+++ b/demo/chaincode/fpc/spectrum-auction-message.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "auction-state.h"
+#include "bid.h"
+#include "common.h"
+#include "error-codes.h"
+#include "utils.h"
+
+typedef struct
+{
+    std::string s;
+} create_auction_t;
+
+namespace ClockAuction
+{
+class SpectrumAuctionMessage
+{
+private:
+    const std::string inputJsonString_;
+    std::string jsonString_;
+
+public:
+    ErrorReport er_;
+
+    SpectrumAuctionMessage();
+    SpectrumAuctionMessage(const std::string& message);
+    ErrorReport getErrorReport();
+
+    std::string getJsonString();
+
+    void toStatusJsonObject(JSON_Object* root_object, int rc, const std::string& message);
+    void toWrappedStatusJsonObject(JSON_Object* root_object, int rc, const std::string& message);
+    void toStatusJsonString(int rc, std::string& message, std::string& jsonString);
+
+    void toCreateAuctionJson(int rc, const std::string& message, unsigned int auctionId);
+    bool fromCreateAuctionJson(StaticAuctionState& staticAuctionState);
+
+    void toStaticAuctionStateJson(const StaticAuctionState& staticAuctionState);
+    bool fromStaticAuctionStateJson(StaticAuctionState& staticAuctionState);
+
+    void toDynamicAuctionStateJson(const DynamicAuctionState& dynamicAuctionState);
+    bool fromDynamicAuctionStateJson(DynamicAuctionState& dynamicAuctionState);
+
+    bool fromGetAuctionDetailsJson(uint32_t& auctionId);
+    void toGetAuctionDetailsJson(
+        int rc, const std::string& message, const StaticAuctionState& staticAuctionState);
+
+    bool fromGetAuctionStatusJson(uint32_t& auctionId);
+    void toGetAuctionStatusJson(
+        int rc, const std::string& message, const DynamicAuctionState& dynamicAuctionState);
+
+    bool fromStartNextRoundJson(uint32_t& auctionId);
+    void toStartNextRoundJson(int rc, const std::string& message);
+
+    bool fromEndRoundJson(uint32_t& auctionId);
+    void toEndRoundJson(int rc, const std::string& message);
+
+    bool fromSubmitClockBidJson(ClockAuction::Bid& bid);
+    void toSubmitClockBidJson(int rc, const std::string& message);
+
+    bool fromGetRoundInfoJson(uint32_t& auctionId, uint32_t& requestedRound);
+    void toGetRoundInfoJson(int rc,
+        const std::string& message,
+        const StaticAuctionState& sState,
+        const DynamicAuctionState& dState,
+        uint32_t requestedRound);
+
+    bool fromGetBidderRoundResultsJson(uint32_t& auctionId, uint32_t& requestedRound);
+    void toGetBidderRoundResultsJson(int rc,
+        const std::string& message,
+        const StaticAuctionState& sState,
+        const DynamicAuctionState& dState,
+        uint32_t requestedRound);
+
+    bool fromGetOwnerRoundResultsJson(uint32_t& auctionId, uint32_t& requestedRound);
+    void toGetOwnerRoundResultsJson(int rc,
+        const std::string& message,
+        const StaticAuctionState& sState,
+        const DynamicAuctionState& dState,
+        uint32_t requestedRound);
+
+    bool fromGetAssignmentResultsJson(uint32_t& auctionId);
+    void toGetAssignmentResultsJson(int rc,
+        const std::string& message,
+        const StaticAuctionState& sState,
+        const DynamicAuctionState& dState);
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/spectrum-auction.cpp
+++ b/demo/chaincode/fpc/spectrum-auction.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spectrum-auction.h"
+#include <string>
+#include "bid.h"
+#include "error-codes.h"
+#include "spectrum-auction-message.h"
+#include "storage.h"
+#include "utils.h"
+
+#define AUCTION_ID_COUNTER_STRING "AuctionIdCounter"
+#define AUCTION_ID_FIRST_COUNTER_VALUE 1
+
+ClockAuction::SpectrumAuction::SpectrumAuction(shim_ctx_ptr_t ctx)
+    : dynamicAuctionState_(ctx), auctionStorage_(ctx)
+{
+}
+
+void ClockAuction::SpectrumAuction::InitializeAuctionIdCounter()
+{
+    uint32_t bytesRead = 0;
+    const uint8_t* key = (const uint8_t*)AUCTION_ID_COUNTER_STRING;
+    uint32_t keyLength = strlen(AUCTION_ID_COUNTER_STRING);
+    uint8_t* value = (uint8_t*)&auctionIdCounter_;
+    uint32_t valueLength = sizeof(auctionIdCounter_);
+    auctionStorage_.ledgerPrivateGetBinary(key, keyLength, value, valueLength, &bytesRead);
+    if (bytesRead == 0)
+        auctionIdCounter_ = AUCTION_ID_FIRST_COUNTER_VALUE;
+}
+
+void ClockAuction::SpectrumAuction::IncrementAndStoreAuctionIdCounter()
+{
+    uint32_t c = auctionIdCounter_ + 1;
+    const uint8_t* key = (const uint8_t*)AUCTION_ID_COUNTER_STRING;
+    uint32_t keyLength = strlen(AUCTION_ID_COUNTER_STRING);
+    uint8_t* value = (uint8_t*)&c;
+    uint32_t valueLength = sizeof(auctionIdCounter_);
+    auctionStorage_.ledgerPrivatePutBinary(key, keyLength, value, valueLength);
+}
+
+void ClockAuction::SpectrumAuction::storeAuctionState()
+{
+    {  // store static state
+        ClockAuction::SpectrumAuctionMessage outStateMsg;
+        outStateMsg.toStaticAuctionStateJson(staticAuctionState_);
+        std::string stateKey(
+            "Auction." + std::to_string(auctionIdCounter_) + ".staticAuctionState");
+        auctionStorage_.ledgerPrivatePutString(stateKey, outStateMsg.getJsonString());
+        LOG_DEBUG("Stored static state: %s", (outStateMsg.getJsonString()).c_str());
+    }
+    {  // store dynamic state
+        ClockAuction::SpectrumAuctionMessage outStateMsg;
+        outStateMsg.toDynamicAuctionStateJson(dynamicAuctionState_);
+        std::string stateKey(
+            "Auction." + std::to_string(auctionIdCounter_) + ".dynamicAuctionState");
+        auctionStorage_.ledgerPrivatePutString(stateKey, outStateMsg.getJsonString());
+        LOG_DEBUG("Stored dynamic state: %s", (outStateMsg.getJsonString()).c_str());
+    }
+}
+
+bool ClockAuction::SpectrumAuction::loadAuctionState()
+{
+    {  // load static state
+        std::string stateKey(
+            "Auction." + std::to_string(auctionIdCounter_) + ".staticAuctionState");
+        std::string stateValue;
+        auctionStorage_.ledgerPrivateGetString(stateKey, stateValue);
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, stateValue.length() == 0);
+        // next is same as for createAuction
+        JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(stateValue.c_str());
+        FAST_FAIL_CHECK_EX(er_, &staticAuctionState_.er_, EC_INVALID_INPUT,
+            !staticAuctionState_.fromExtendedJsonObject(root_object));
+        ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    }
+    {  // load dynamic state
+        std::string stateKey(
+            "Auction." + std::to_string(auctionIdCounter_) + ".dynamicAuctionState");
+        std::string stateValue;
+        auctionStorage_.ledgerPrivateGetString(stateKey, stateValue);
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, stateValue.length() == 0);
+        JSON_Object* root_object = ClockAuction::JsonUtils::openJsonObject(stateValue.c_str());
+        FAST_FAIL_CHECK_EX(er_, &dynamicAuctionState_.er_, EC_INVALID_INPUT,
+            !dynamicAuctionState_.fromJsonObject(root_object));
+        ClockAuction::JsonUtils::closeJsonObject(root_object, NULL);
+    }
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::createAuction)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    FAST_FAIL_CHECK_EX(
+        er, &inMsg.er_, EC_INVALID_INPUT, !inMsg.fromCreateAuctionJson(staticAuctionState_));
+    FAST_FAIL_CHECK_EX(
+        er, &staticAuctionState_.er_, EC_INVALID_INPUT, !staticAuctionState_.checkValidity());
+
+    // no authentication, anybody can create
+
+    // all check passed, install auction
+
+    // get auction id
+    InitializeAuctionIdCounter();
+    IncrementAndStoreAuctionIdCounter();
+
+    // initialize dynamic state
+    dynamicAuctionState_.initialize(
+        CLOCK_PHASE, INITIAL_CLOCK_ROUND_NUMBER, false, staticAuctionState_);
+
+    // store static and dynamic state
+    storeAuctionState();
+
+    er.set(EC_SUCCESS, "");
+
+    // prepare response message
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toCreateAuctionJson(0, "Auction created", auctionIdCounter_);
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::getAuctionDetails)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, !inMsg.fromGetAuctionDetailsJson(auctionIdCounter_));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+
+    // no authentication, anybody can execute
+
+    // all check passed, return details
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toGetAuctionDetailsJson(0, "Auction details", staticAuctionState_);
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::getAuctionStatus)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, !inMsg.fromGetAuctionStatusJson(auctionIdCounter_));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+
+    // no authentication, anybody can execute
+
+    // all check passed, return status
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toGetAuctionStatusJson(0, "Auction status", dynamicAuctionState_);
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::startNextRound)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, !inMsg.fromStartNextRoundJson(auctionIdCounter_));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+    FAST_FAIL_CHECK(er, EC_ROUND_ACTIVE, dynamicAuctionState_.isRoundActive());
+    FAST_FAIL_CHECK(er, EC_RESTRICTED_AUCTION_STATE,
+        !dynamicAuctionState_.isStateClockPhase() &&
+            !dynamicAuctionState_.isStateAssignmentPhase());
+
+    // authenticate auction owner
+    FAST_FAIL_CHECK(
+        er, EC_UNRECOGNIZED_SUBMITTER, !dynamicAuctionState_.isValidOwner(staticAuctionState_));
+
+    // all check passed
+
+    dynamicAuctionState_.startRound(staticAuctionState_);
+
+    if (dynamicAuctionState_.isStateAssignmentPhase())
+    {
+        // *********
+        // IMPORTANT: we shortcut the assignment phase and terminate it immediately with a random
+        // assignment
+        // *********
+        LOG_INFO("Assignment phase: random assignment and immediate termination");
+        dynamicAuctionState_.endRound();
+        evaluateAssignmentRound();
+    }
+
+    storeAuctionState();
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toStartNextRoundJson(0, "Start next round");
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::endRound)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, !inMsg.fromEndRoundJson(auctionIdCounter_));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+    FAST_FAIL_CHECK(er, EC_ROUND_NOT_ACTIVE, !dynamicAuctionState_.isRoundActive());
+    FAST_FAIL_CHECK(er, EC_RESTRICTED_AUCTION_STATE,
+        !dynamicAuctionState_.isStateClockPhase() &&
+            !dynamicAuctionState_.isStateAssignmentPhase());
+
+    // authenticate auction owner
+    FAST_FAIL_CHECK(
+        er, EC_UNRECOGNIZED_SUBMITTER, !dynamicAuctionState_.isValidOwner(staticAuctionState_));
+
+    // all check passed
+
+    dynamicAuctionState_.endRound();
+    evaluateClockRound();
+    storeAuctionState();
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toEndRoundJson(0, "End round");
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::submitClockBid)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    Bid submittedBid;
+    FAST_FAIL_CHECK_EX(
+        er, &inMsg.er_, EC_INVALID_INPUT, !inMsg.fromSubmitClockBidJson(submittedBid));
+    auctionIdCounter_ = submittedBid.auctionId_;
+    // retrieve auction data (also checks the auction id)
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+
+    // check clock phase
+    FAST_FAIL_CHECK(er, EC_NOT_IN_CLOCK_PHASE, !dynamicAuctionState_.isStateClockPhase());
+
+    // authenticate bidder
+    FAST_FAIL_CHECK(
+        er, EC_UNRECOGNIZED_SUBMITTER, !dynamicAuctionState_.isValidBidder(staticAuctionState_));
+
+    // validate bid
+    FAST_FAIL_CHECK_EX(er, &dynamicAuctionState_.er_, EC_INVALID_INPUT,
+        !dynamicAuctionState_.isValidBid(staticAuctionState_, submittedBid));
+
+    // all check passed
+
+    dynamicAuctionState_.storeBid(staticAuctionState_, submittedBid);
+
+    storeAuctionState();
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toSubmitClockBidJson(0, "Submit clock bid");
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::getRoundInfo)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    uint32_t requestedRound;
+    FAST_FAIL_CHECK(
+        er, EC_INVALID_INPUT, !inMsg.fromGetRoundInfoJson(auctionIdCounter_, requestedRound));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        !dynamicAuctionState_.isStateClockPhase() &&
+            !dynamicAuctionState_.isStateAssignmentPhase() &&
+            !dynamicAuctionState_.isStateClosedPhase());
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, requestedRound > dynamicAuctionState_.getRound());
+
+    // no authentication, anybody can execute
+
+    // all check passed, return details
+
+    // nothing to store, state not updated
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toGetRoundInfoJson(
+        0, "Get round info", staticAuctionState_, dynamicAuctionState_, requestedRound);
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::getBidderRoundResults)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    uint32_t requestedRound;
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        !inMsg.fromGetBidderRoundResultsJson(auctionIdCounter_, requestedRound));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        !dynamicAuctionState_.isStateClockPhase() &&
+            !dynamicAuctionState_.isStateAssignmentPhase() &&
+            !dynamicAuctionState_.isStateClosedPhase());
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        dynamicAuctionState_.isStateClockPhase() &&
+            requestedRound >= dynamicAuctionState_.getRound());
+
+    // authenticate bidder
+    FAST_FAIL_CHECK(
+        er, EC_UNRECOGNIZED_SUBMITTER, !dynamicAuctionState_.isValidBidder(staticAuctionState_));
+
+    // all check passed, return details
+
+    // nothing to store, state not updated
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toGetBidderRoundResultsJson(
+        0, "Get bidder round results", staticAuctionState_, dynamicAuctionState_, requestedRound);
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::getOwnerRoundResults)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    uint32_t requestedRound;
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        !inMsg.fromGetOwnerRoundResultsJson(auctionIdCounter_, requestedRound));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+
+    // authenticate auction owner
+    FAST_FAIL_CHECK(
+        er, EC_UNRECOGNIZED_SUBMITTER, !dynamicAuctionState_.isValidOwner(staticAuctionState_));
+
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        !dynamicAuctionState_.isStateClockPhase() &&
+            !dynamicAuctionState_.isStateAssignmentPhase() &&
+            !dynamicAuctionState_.isStateClosedPhase());
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT,
+        dynamicAuctionState_.isStateClockPhase() &&
+            requestedRound >= dynamicAuctionState_.getRound());
+
+    // all check passed, return details
+
+    // nothing to store, state not updated
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toGetOwnerRoundResultsJson(
+        0, "Get owner round results", staticAuctionState_, dynamicAuctionState_, requestedRound);
+    outputString = msg.getJsonString();
+    return true;
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::submitAssignmentBid)
+{
+    FAST_FAIL_CHECK(er, EC_UNIMPLEMENTED_API, true);
+}
+
+AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::getAssignmentResults)
+{
+    // parse and validate input string
+    ClockAuction::SpectrumAuctionMessage inMsg(inputString);
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, !inMsg.fromGetAssignmentResultsJson(auctionIdCounter_));
+    FAST_FAIL_CHECK_EX(er, &er_, EC_INVALID_INPUT, !loadAuctionState());
+
+    FAST_FAIL_CHECK(er, EC_INVALID_INPUT, !dynamicAuctionState_.isStateClosedPhase());
+
+    // no authentication, anybody can execute
+
+    // all check passed, return details
+
+    er.set(EC_SUCCESS, "");
+    ClockAuction::SpectrumAuctionMessage msg;
+    msg.toGetAssignmentResultsJson(
+        0, "Get assignment results", staticAuctionState_, dynamicAuctionState_);
+    outputString = msg.getJsonString();
+    return true;
+}

--- a/demo/chaincode/fpc/spectrum-auction.cpp
+++ b/demo/chaincode/fpc/spectrum-auction.cpp
@@ -215,6 +215,9 @@ AUCTION_API_PROTOTYPE(ClockAuction::SpectrumAuction::endRound)
 
     dynamicAuctionState_.endRound();
     evaluateClockRound();
+    FAST_FAIL_CHECK_EX(
+        er, &dynamicAuctionState_.er_, EC_INVALID_INPUT, !dynamicAuctionState_.er_.isSuccess());
+
     storeAuctionState();
 
     er.set(EC_SUCCESS, "");

--- a/demo/chaincode/fpc/spectrum-auction.h
+++ b/demo/chaincode/fpc/spectrum-auction.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "auction-state.h"
+#include "common.h"
+#include "error-codes.h"
+#include "storage.h"
+
+#define AUCTION_API_PROTOTYPE(api_name) \
+    bool api_name(                      \
+        const std::string& inputString, std::string& outputString, ClockAuction::ErrorReport& er)
+
+namespace ClockAuction
+{
+class SpectrumAuction
+{
+private:
+    uint32_t auctionIdCounter_;
+    void InitializeAuctionIdCounter();
+    void IncrementAndStoreAuctionIdCounter();
+
+    StaticAuctionState staticAuctionState_;
+    DynamicAuctionState dynamicAuctionState_;
+    ClockAuction::Storage auctionStorage_;
+
+    void storeAuctionState();
+    bool loadAuctionState();
+
+    void evaluateClockRound();
+    void evaluateAssignmentRound();
+
+public:
+    SpectrumAuction(shim_ctx_ptr_t ctx);
+    ErrorReport er_;
+
+    AUCTION_API_PROTOTYPE(createAuction);
+    AUCTION_API_PROTOTYPE(getAuctionDetails);
+    AUCTION_API_PROTOTYPE(getAuctionStatus);
+    AUCTION_API_PROTOTYPE(startNextRound);
+    AUCTION_API_PROTOTYPE(endRound);
+    AUCTION_API_PROTOTYPE(submitClockBid);
+    AUCTION_API_PROTOTYPE(getRoundInfo);
+    AUCTION_API_PROTOTYPE(getBidderRoundResults);
+    AUCTION_API_PROTOTYPE(getOwnerRoundResults);
+    AUCTION_API_PROTOTYPE(submitAssignmentBid);
+    AUCTION_API_PROTOTYPE(getAssignmentResults);
+};
+}  // namespace ClockAuction
+
+typedef AUCTION_API_PROTOTYPE((ClockAuction::SpectrumAuction::*spectrumAuctionFunctionP));

--- a/demo/chaincode/fpc/storage.cpp
+++ b/demo/chaincode/fpc/storage.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "storage.h"
+#include "common.h"
+
+#define MAX_LENGTH_STRING_SIZE 10  // order of gigabytes
+
+ClockAuction::Storage::Storage(shim_ctx_ptr_t ctx) : ctx_(ctx) {}
+
+void ClockAuction::Storage::ledgerPrivatePutString(const std::string& key, const std::string& value)
+{
+    // first write length -- string with null char
+    unsigned int valueLength = value.length() + 1;
+    std::string valueLengthString = std::to_string(valueLength);
+    if (valueLengthString.length() == 0 || valueLengthString.length() > MAX_LENGTH_STRING_SIZE)
+    {
+        LOG_ERROR("value length is 0 or too large. No data will be written to ledger");
+        return;
+    }
+    std::string valueLengthKey = key + "L";
+    ledgerPrivatePutBinary((const uint8_t*)valueLengthKey.c_str(), valueLengthKey.length(),
+        (const uint8_t*)valueLengthString.c_str(), valueLengthString.length() + 1);
+
+    // second, write actual value
+    std::string valueKey = key + "K";
+    ledgerPrivatePutBinary(
+        (uint8_t*)valueKey.c_str(), valueKey.length(), (const uint8_t*)value.c_str(), valueLength);
+}
+
+void ClockAuction::Storage::ledgerPrivateGetString(const std::string& key, std::string& value)
+{
+    // first, get the value length
+    uint8_t valueLengthArray[MAX_LENGTH_STRING_SIZE + 1];
+    uint32_t actualValueLengthLength = 0;
+    std::string valueLengthKey = key + "L";
+    ledgerPrivateGetBinary((uint8_t*)valueLengthKey.c_str(), valueLengthKey.length(),
+        valueLengthArray, MAX_LENGTH_STRING_SIZE + 1, &actualValueLengthLength);
+    if (actualValueLengthLength == 0)
+    {
+        LOG_DEBUG("Key not found -- length not stored");
+        return;
+    }
+    if (actualValueLengthLength > MAX_LENGTH_STRING_SIZE)
+    {
+        LOG_ERROR("Value length returned is too large");
+        return;
+    }
+    if (valueLengthArray[actualValueLengthLength - 1] != '\0')
+    {
+        LOG_ERROR("Value length returned is not null terminated");
+        return;
+    }
+    uint32_t storedValueLength = std::stoul(std::string((char*)valueLengthArray), NULL, 10);
+
+    // second, get the value
+    std::string valueKey = key + "K";
+    uint8_t valueBinary[storedValueLength];
+    uint32_t actualValueLength = 0;
+    ledgerPrivateGetBinary((uint8_t*)valueKey.c_str(), valueKey.length(), valueBinary,
+        storedValueLength, &actualValueLength);
+    if (actualValueLength != storedValueLength)
+    {
+        LOG_ERROR("Unexpected length of retrieved value -- no value returned");
+        return;
+    }
+    if (valueBinary[storedValueLength - 1] != '\0')
+    {
+        LOG_ERROR("Retrieved value is not null terminated -- no value returned");
+        return;
+    }
+    value.assign((char*)valueBinary);
+}
+
+void ClockAuction::Storage::ledgerPrivatePutBinary(
+    const uint8_t* key, const uint32_t keyLength, const uint8_t* value, const uint32_t valueLength)
+{
+    put_state((const char*)key, (uint8_t*)value, valueLength, ctx_);
+}
+
+void ClockAuction::Storage::ledgerPrivateGetBinary(const uint8_t* key,
+    const uint32_t keyLength,
+    uint8_t* value,
+    const uint32_t valueLength,
+    uint32_t* actualValueLength)
+{
+    get_state((const char*)key, value, valueLength, actualValueLength, ctx_);
+}

--- a/demo/chaincode/fpc/storage.h
+++ b/demo/chaincode/fpc/storage.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+
+namespace ClockAuction
+{
+class Storage
+{
+private:
+    shim_ctx_ptr_t ctx_;
+
+public:
+    Storage(shim_ctx_ptr_t ctx);
+    void ledgerPrivatePutString(const std::string& key, const std::string& value);
+    void ledgerPrivateGetString(const std::string& key, std::string& value);
+
+    void ledgerPrivatePutBinary(const uint8_t* key,
+        const uint32_t keyLength,
+        const uint8_t* value,
+        const uint32_t valueLength);
+    void ledgerPrivateGetBinary(const uint8_t* key,
+        const uint32_t keyLength,
+        uint8_t* value,
+        const uint32_t valueLength,
+        uint32_t* actualValueLength);
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/territory.cpp
+++ b/demo/chaincode/fpc/territory.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "territory.h"
+#include "utils.h"
+
+ClockAuction::Channel::Channel() {}
+
+ClockAuction::Channel::Channel(uint32_t id, std::string& name, uint32_t impairment)
+    : id_(id), name_(name), impairment_(impairment)
+{
+}
+
+void ClockAuction::Channel::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "id", id_);
+    json_object_set_string(root_object, "name", name_.c_str());
+    json_object_set_number(root_object, "impairment", impairment_);
+}
+
+bool ClockAuction::Channel::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(
+            er_, EC_INVALID_INPUT, !json_object_has_value_of_type(root_object, "id", JSONNumber));
+        double d = json_object_get_number(root_object, "id");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        id_ = (uint32_t)d;
+    }
+    {
+        const char* str = json_object_get_string(root_object, "name");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, str == 0);
+        name_ = std::string(str);
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "impairment", JSONNumber));
+        double d = json_object_get_number(root_object, "impairment");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        impairment_ = (uint32_t)d;
+    }
+    return true;
+}
+
+uint32_t ClockAuction::Channel::getImpairment() const
+{
+    return impairment_;
+}
+
+uint32_t ClockAuction::Channel::getId() const
+{
+    return id_;
+}
+
+ClockAuction::Territory::Territory() {}
+
+ClockAuction::Territory::Territory(uint32_t id,
+    std::string& name,
+    bool isHighDemand,
+    double minPrice,
+    std::vector<Channel>& channels)
+    : id_(id), name_(name), isHighDemand_(isHighDemand), minPrice_(minPrice), channels_(channels)
+{
+}
+
+void ClockAuction::Territory::toJsonObject(JSON_Object* root_object) const
+{
+    json_object_set_number(root_object, "id", id_);
+    json_object_set_string(root_object, "name", name_.c_str());
+    json_object_set_boolean(root_object, "isHighDemand", isHighDemand_);
+    json_object_set_number(root_object, "minPrice", minPrice_);
+    json_object_set_value(root_object, "channels", json_value_init_array());
+    JSON_Array* channel_array = json_object_get_array(root_object, "channels");
+    for (unsigned int i = 0; i < channels_.size(); i++)
+    {
+        JSON_Value* v = json_value_init_object();
+        JSON_Object* o = json_value_get_object(v);
+        channels_[i].toJsonObject(o);
+        json_array_append_value(channel_array, v);
+    }
+}
+
+bool ClockAuction::Territory::fromJsonObject(const JSON_Object* root_object)
+{
+    {
+        FAST_FAIL_CHECK(
+            er_, EC_INVALID_INPUT, !json_object_has_value_of_type(root_object, "id", JSONNumber));
+        double d = json_object_get_number(root_object, "id");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, !ClockAuction::JsonUtils::isInteger(d));
+        id_ = (uint32_t)d;
+    }
+    {
+        const char* str = json_object_get_string(root_object, "name");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, str == 0);
+        name_ = std::string(str);
+    }
+    {
+        int b = json_object_get_boolean(root_object, "isHighDemand");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, b == -1);
+        isHighDemand_ = b;
+    }
+    {
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT,
+            !json_object_has_value_of_type(root_object, "minPrice", JSONNumber));
+        minPrice_ = json_object_get_number(root_object, "minPrice");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, minPrice_ < 0);
+    }
+    {
+        JSON_Array* channel_array = json_object_get_array(root_object, "channels");
+        FAST_FAIL_CHECK(er_, EC_INVALID_INPUT, channel_array == 0);
+        unsigned int channelN = json_array_get_count(channel_array);
+        for (unsigned int i = 0; i < channelN; i++)
+        {
+            JSON_Object* o = json_array_get_object(channel_array, i);
+            Channel ch;
+            FAST_FAIL_CHECK_EX(er_, &ch.er_, EC_INVALID_INPUT, !ch.fromJsonObject(o));
+            channels_.push_back(ch);
+        }
+    }
+    return true;
+}
+
+uint32_t ClockAuction::Territory::getTerritoryId() const
+{
+    return id_;
+}
+
+uint32_t ClockAuction::Territory::numberOfChannels() const
+{
+    return channels_.size();
+}
+
+double ClockAuction::Territory::getMinPrice() const
+{
+    return minPrice_;
+}
+
+bool ClockAuction::Territory::isHighDemand() const
+{
+    return isHighDemand_;
+}
+
+std::vector<uint32_t> ClockAuction::Territory::getChannelImpairments() const
+{
+    std::vector<uint32_t> impairments;
+    for (unsigned int i = 0; i < channels_.size(); i++)
+        impairments.push_back(channels_[i].getImpairment());
+    return impairments;
+}
+
+std::vector<uint32_t> ClockAuction::Territory::getChannelIds() const
+{
+    std::vector<uint32_t> ids;
+    for (unsigned int i = 0; i < channels_.size(); i++)
+        ids.push_back(channels_[i].getId());
+    return ids;
+}

--- a/demo/chaincode/fpc/territory.h
+++ b/demo/chaincode/fpc/territory.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+#include "error-codes.h"
+
+namespace ClockAuction
+{
+class Channel
+{
+private:
+    uint32_t id_;
+    std::string name_;
+    uint32_t impairment_;
+
+public:
+    Channel();
+    Channel(uint32_t id, std::string& name, uint32_t impairment);
+    void toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+
+    ErrorReport er_;
+
+    uint32_t getImpairment() const;
+    uint32_t getId() const;
+};
+
+class Territory
+{
+private:
+    uint32_t id_;
+    std::string name_;
+    bool isHighDemand_;
+    double minPrice_;
+    std::vector<Channel> channels_;
+
+public:
+    Territory();
+    Territory(uint32_t id,
+        std::string& name,
+        bool isHighDemand,
+        double minPrice,
+        std::vector<Channel>& channels);
+    void toJsonObject(JSON_Object* root_object) const;
+    bool fromJsonObject(const JSON_Object* root_object);
+
+    ErrorReport er_;
+
+    uint32_t getTerritoryId() const;
+    uint32_t numberOfChannels() const;
+    double getMinPrice() const;
+    bool isHighDemand() const;
+    std::vector<uint32_t> getChannelImpairments() const;
+    std::vector<uint32_t> getChannelIds() const;
+};
+}  // namespace ClockAuction

--- a/demo/chaincode/fpc/test.sh
+++ b/demo/chaincode/fpc/test.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+function cleanup {
+    killall mock
+}
+
+function check_success {
+    RC=`echo "$RESPONSE" | jq -r .status | jq -r .rc`; if [[ $RC == 0 ]]; then return 0; else return 1; fi
+}
+
+function check_failure {
+    if check_success; then return 1; else return 0; fi
+}
+
+FAIL_ON_SUCCESS="if check_success ; then echo \"TEST FAILED: \${LINENO}\"; exit -1; fi"
+FAIL_ON_FAILURE="if check_failure ; then echo \"TEST FAILED: \${LINENO}\"; exit -1; fi"
+
+trap cleanup EXIT
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+"${LD_LIBRARY_PATH}:"}${FPC_PATH}/ecc_enclave/_build/lib
+
+pushd ${FPC_PATH}/demo/client/backend/mock
+./mock 2>&1 /dev/null &
+pushd
+sleep 2
+
+#(fails, no territories no bidders) create auction
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"createAuction","args":["{\"name\":\"bruno\", \"territories\":[], \"bidders\":[], \"initialEligibilities\":[], \"activityRequirementPercentage\": 0, \"clockPriceIncrementPercentage\": 1000}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds) create auction
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"createAuction","args":["{\"name\":\"bruno\", \"territories\":[{\"id\": 1, \"name\": \"myterritory\", \"isHighDemand\": false, \"minPrice\": 200, \"channels\": [{\"id\": 1, \"name\": \"mychannel1\", \"impairment\":2000}, {\"id\": 2, \"name\": \"mychannel2\", \"impairment\":2000}, {\"id\": 3, \"name\": \"mychannel3\", \"impairment\":2000}]}, {\"id\": 2, \"name\": \"myterritory2\", \"isHighDemand\": false, \"minPrice\": 300, \"channels\": [{\"id\": 1, \"name\": \"mychannel3\", \"impairment\":300}, {\"id\": 2, \"name\": \"mychannel4\", \"impairment\":400}, {\"id\": 3, \"name\": \"mychannel5\", \"impairment\":500}]}], \"bidders\":[{\"id\": 1, \"displayName\": \"mickey\", \"principal\":{\"id\": 1, \"mspId\": \"org1\",\"dn\": \"CN=TestUser-1,OU=user+OU=org1\"}}, {\"id\": 2, \"displayName\": \"duffy\", \"principal\":{\"id\": 2, \"mspId\": \"org1\",\"dn\": \"CN=TestUser-2,OU=user+OU=org1\"}}, {\"id\": 3, \"displayName\": \"goku\", \"principal\":{\"id\": 3, \"mspId\": \"org1\",\"dn\": \"CN=TestUser-3,OU=user+OU=org1\"}}], \"initialEligibilities\":[{\"bidderId\": 1, \"number\": 4}, {\"bidderId\": 2, \"number\": 6}, {\"bidderId\": 3, \"number\": 6}], \"activityRequirementPercentage\": 0, \"clockPriceIncrementPercentage\": 20}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+RESPONSE=`curl -s -H "Content-Type: application/json" -X POST -d '{"tx":"getAuctionDetails", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+
+RESPONSE=`curl -s -H "Content-Type: application/json" -X POST -d '{"tx":"getAuctionStatus", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, empty bids) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(fails, unrecognized submitter) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 2, \"bids\":[{\"terId\": 1, \"qty\":4, \"price\":2000}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(fails, round not current) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 2, \"bids\":[{\"terId\": 1, \"qty\":4, \"price\":2000}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(fails, round not active) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":4, \"price\":2008}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(fails, unrecognized submitter) start next round
+RESPONSE=`curl -s -H "Content-Type: application/json" -X POST -d '{"tx":"startNextRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds) start next round
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"startNextRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, too much demand) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-2" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":4, \"price\":2008}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(fails, not enough eligibility) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":3, \"price\":2000}, {\"terId\": 2, \"qty\":3, \"price\":2000}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":2000}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds, overwrites previous one) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":1500}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-2" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":3, \"price\":1588}, {\"terId\": 2, \"qty\":3, \"price\":1588}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"endRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, round not current) submit bid 
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 1, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":1500}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds) start round
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"startNextRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, bid above clock price) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 2, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":1500}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(fails, bid below posted price) submit bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 2, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":15}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds)submit bid to maintain demand and increase demand in territory 1,2 resp.
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 2, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":200}, {\"terId\": 2, \"qty\":2, \"price\":300}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds)submit bid to maintain demand in territory 1,2
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-2" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 2, \"bids\":[{\"terId\": 1, \"qty\":3, \"price\":208}, {\"terId\": 2, \"qty\":3, \"price\":308}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds) end round
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"endRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds) start round
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"startNextRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds)submit bid to maintain demand and increase demand in territory 1,2 resp.
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitClockBid", "args":["{\"auctionId\": 1, \"round\": 3, \"bids\":[{\"terId\": 1, \"qty\":2, \"price\":240}, {\"terId\": 2, \"qty\":2, \"price\":360}]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds) end round
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"endRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds) get round info
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"getRoundInfo", "args":["{\"auctionId\": 1, \"round\": 2}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, round 0) get round info
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"getRoundInfo", "args":["{\"auctionId\": 1, \"round\": 0}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds, inner round format) get bidder round results
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"getBidderRoundResults", "args":["{\"auctionId\": 1, \"round\": 2}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds, last round format) get bidder round results
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"getBidderRoundResults", "args":["{\"auctionId\": 1, \"round\": 3}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, not owner) get owner round results
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"getOwnerRoundResults", "args":["{\"auctionId\": 1, \"round\": 2}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds, inner round) get owner round results
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"getOwnerRoundResults", "args":["{\"auctionId\": 1, \"round\": 2}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds, last round) get owner round results
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"getOwnerRoundResults", "args":["{\"auctionId\": 1, \"round\": 3}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(fails, unimplented api) submit assign bid
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestUser-1" -X POST -d '{"tx":"submitAssignmentBid", "args":["{\"auctionId\": 1, \"bids\":[]}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_SUCCESS
+
+#(succeeds, assignment evaluation) start round
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:TestAuctioneer-1" -X POST -d '{"tx":"startNextRound", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+#(succeeds, assignment results) get assignment results
+RESPONSE=`curl -s -H "Content-Type: application/json" -H "x-user:anybody" -X POST -d '{"tx":"getAssignmentResults", "args":["{\"auctionId\": 1}"]}' http://localhost:3000/api/cc/invoke`
+eval $FAIL_ON_FAILURE
+
+echo "Test successful."
+
+exit 0
+

--- a/demo/chaincode/fpc/test.sh
+++ b/demo/chaincode/fpc/test.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# Copyright 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 
 function cleanup {
     killall mock

--- a/demo/chaincode/fpc/utils.cpp
+++ b/demo/chaincode/fpc/utils.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "utils.h"
+
+JSON_Object* ClockAuction::JsonUtils::openJsonObject(const char* c_str)
+{
+    JSON_Value* root_value;
+
+    if (c_str == NULL)  // create an empty json object
+    {
+        root_value = json_value_init_object();
+    }
+    else  // parse the input json string
+    {
+        root_value = json_parse_string(c_str);
+        if (root_value == NULL)
+        {
+            return NULL;
+        }
+    }
+
+    return json_value_get_object(root_value);
+}
+
+void ClockAuction::JsonUtils::closeJsonObject(JSON_Object* root_object, std::string* str)
+{
+    if (!root_object)
+    {
+        return;
+    }
+
+    JSON_Value* root_value = json_object_get_wrapping_value(root_object);
+    if (str != NULL)  // serialize the json object to string
+    {
+        char* serialized_string = json_serialize_to_string(root_value);
+        str->assign(serialized_string);
+        json_free_serialized_string(serialized_string);
+    }
+
+    // eventually, free the root value
+    json_value_free(root_value);
+}
+
+bool ClockAuction::JsonUtils::isInteger(double d)
+{
+    return d == ((double)(int)d);
+}

--- a/demo/chaincode/fpc/utils.h
+++ b/demo/chaincode/fpc/utils.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "common.h"
+
+namespace ClockAuction
+{
+class JsonUtils
+{
+public:
+    static JSON_Object* openJsonObject(const char* c_str);
+    static void closeJsonObject(JSON_Object* root_object, std::string* string);
+    static bool isInteger(double d);
+};
+}  // namespace ClockAuction

--- a/ecc_enclave/enclave/crypto.cpp
+++ b/ecc_enclave/enclave/crypto.cpp
@@ -71,3 +71,15 @@ int decrypt_state(sgx_aes_gcm_128bit_key_t* key,
         NULL, 0,                                                   /* aad */
         (sgx_aes_gcm_128bit_tag_t*)(cipher + SGX_AESGCM_IV_SIZE)); /* tag */
 }
+
+int get_random_bytes(uint8_t* buffer, size_t length)
+{
+    /* WARNING WARNING WARNING */
+    /* WARNING WARNING WARNING */
+
+    // the implementation of this function with SGX rand forces to have a single encalve endorser
+
+    /* WARNING WARNING WARNING */
+    /* WARNING WARNING WARNING */
+    return sgx_read_rand(buffer, length);
+}

--- a/ecc_enclave/enclave/crypto.h
+++ b/ecc_enclave/enclave/crypto.h
@@ -23,3 +23,4 @@ int decrypt_state(sgx_aes_gcm_128bit_key_t* key,
     uint32_t cipher_len,
     uint8_t* plain,
     uint32_t plain_len);
+int get_random_bytes(uint8_t* buffer, size_t length);

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -218,6 +218,21 @@ void get_creator_name(char* msp_id,  // MSP id of organization to which transact
 // invokeChaincode
 // TODO (possible extensions): Currently not supported (but eventually should)
 
+// Source of Randomness
+// --------------------
+// Note-1: this is currently implemented as part of crypto.
+// Note-2: many chaincode applications require a (secure) source of randomness.
+// In Fabric, however, chaincodes with "independent" sources of randomness will produce different
+// outputs. Therefore, in multi-endorser settings, endorsers will sign different transactions and,
+// when the endorsement policy requires more than one signature, the policy check will simply fail.
+// Single-endorser settings should work fine, provided that nobody requires to check/reproduce the
+// output. Note-3: due to what highlighted in note-2, a chaincode's source of randomness should
+// rather be securely provided by the Fabric infrastructure, ensuring that chaincodes running on
+// different platforms can get access to the same random coins.
+// ***WARNING***: we implement this function using the SGX random number generator, but we expect to
+// upgrade it according to what highlighted in note-3.
+extern int get_random_bytes(uint8_t* buffer, size_t length);
+
 // logging
 //-------------------------------------------------
 void log_critical(const char* format, ...);


### PR DESCRIPTION
This PR contains:
* the spectrum auction logic based on documents of the Federal Communications Commission (FCC)
* (very) basic tests
* an extension of `ecc_enclave` crypto APIs to expose (and use in the auction) the random number generator
The chaincode implements a simple randomized version of the Assignment phase of the auction, and so it does not implement the `submitAssignmentBid`.

Note: this chaincode uses the random number generator provided by Intel SGX. Therefore, such chaincode is suitable only for single-endorser Fabric applications. This is related to #183 .
