### PR TITLE
Public state and other enhancements

### DIFF
--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -40,38 +40,11 @@ void get_creator_name(
 void get_state(
     const char* key, uint8_t* val, uint32_t max_val_len, uint32_t* val_len, shim_ctx_ptr_t ctx)
 {
-    // read state
-    ctx->read_set.insert(std::string(key));
-
-    sgx_cmac_128bit_tag_t cmac = {0};
-
     uint8_t encoded_cipher[(max_val_len + SGX_AESGCM_IV_SIZE + SGX_AESGCM_MAC_SIZE + 2) / 3 * 4];
     uint32_t encoded_cipher_len;
-    ocall_get_state(key, encoded_cipher, sizeof(encoded_cipher), &encoded_cipher_len,
-        (sgx_cmac_128bit_tag_t*)cmac, ctx->u_shim_ctx);
 
-    LOG_DEBUG("Enclave: got enc-cipher for key=%s len=%d val='%s'", key, encoded_cipher_len,
-        (encoded_cipher_len > 0 ? (const char*)encoded_cipher : ""));
+    get_public_state(key, encoded_cipher, sizeof(encoded_cipher), &encoded_cipher_len, ctx);
 
-    // create state hash
-    sgx_sha256_hash_t state_hash = {0};
-    if (encoded_cipher_len > 0)
-    {
-        sgx_sha256_msg(encoded_cipher, encoded_cipher_len, &state_hash);
-    }
-
-    if (check_cmac(key, NULL, &state_hash, &session_key, &cmac) != 0)
-    {
-        LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-	// TODO: proper error handling. Below throw should probably do the right
-	//   thing but for now we leave it out as as the mock-server relies on
-	//   bogus MACs for it to work ....
-        // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-    }
-    else
-    {
-        LOG_DEBUG("Enclave: State verification: cmac correct!! :D");
-    }
     // if nothing read, no need for decryption
     if (encoded_cipher_len == 0)
     {
@@ -108,7 +81,7 @@ void get_public_state(
 
     ocall_get_state(key, val, max_val_len, val_len, (sgx_cmac_128bit_tag_t*)cmac, ctx->u_shim_ctx);
 
-    LOG_DEBUG("Enclave: got public state for key=%s len=%d val='%s'", key, *val_len,
+    LOG_DEBUG("Enclave: got state for key=%s len=%d val='%s'", key, *val_len,
         (*val_len > 0 ? (const char*)val : ""));
 
     // create state hash
@@ -121,9 +94,9 @@ void get_public_state(
     if (check_cmac(key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-	// TODO: proper error handling. Below throw should probably do the right
-	//   thing but for now we leave it out as as the mock-server relies on
-	//   bogus MACs for it to work ....
+        // TODO: proper error handling. Below throw should probably do the right
+        //   thing but for now we leave it out as as the mock-server relies on
+        //   bogus MACs for it to work ....
         // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
     }
     else
@@ -147,13 +120,11 @@ void put_state(const char* key, uint8_t* val, uint32_t val_len, shim_ctx_ptr_t c
     std::string base64 = base64_encode((unsigned char*)cipher, cipher_len);
 
     // write state
-    ctx->write_set.insert({key, base64});
-    ocall_put_state(key, (uint8_t*)base64.c_str(), base64.size(), ctx->u_shim_ctx);
+    put_public_state(key, (uint8_t*)base64.c_str(), base64.size(), ctx);
 }
 
 void put_public_state(const char* key, uint8_t* val, uint32_t val_len, shim_ctx_ptr_t ctx)
 {
-    // write state
     std::string s((const char*)val, val_len);
     ctx->write_set.insert({key, s});
     ocall_put_state(key, val, val_len, ctx->u_shim_ctx);
@@ -184,28 +155,10 @@ int unmarshal_values(
 void get_state_by_partial_composite_key(
     const char* comp_key, std::map<std::string, std::string>& values, shim_ctx_ptr_t ctx)
 {
-    uint8_t json[262144];  // 128k needed for 1000 bids
-    uint32_t len;
-
-    sgx_cmac_128bit_tag_t cmac = {0};
-    ocall_get_state_by_partial_composite_key(
-        comp_key, json, sizeof(json), &len, (sgx_cmac_128bit_tag_t*)cmac, ctx->u_shim_ctx);
-
-    unmarshal_values(values, (const char*)json, len);
-
-    // create state hash
-    sgx_sha256_hash_t state_hash = {0};
-    sgx_sha_state_handle_t sha_handle;
-    sgx_sha256_init(&sha_handle);
+    get_public_state_by_partial_composite_key(comp_key, values, ctx);
 
     for (auto& u : values)
     {
-        ctx->read_set.insert(u.first);
-
-        // but also compute hash
-        sgx_sha256_update((const uint8_t*)u.first.c_str(), u.first.size(), sha_handle);
-        sgx_sha256_update((const uint8_t*)u.second.c_str(), u.second.size(), sha_handle);
-
         // base64 decode
         std::string cipher = base64_decode(u.second.c_str());
 
@@ -222,22 +175,6 @@ void get_state_by_partial_composite_key(
 
         std::string s((const char*)plain, plain_len);
         u.second = s;
-    }
-
-    sgx_sha256_get_hash(sha_handle, &state_hash);
-    sgx_sha256_close(sha_handle);
-
-    if (check_cmac(comp_key, NULL, &state_hash, &session_key, &cmac) != 0)
-    {
-        LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-	// TODO: proper error handling. Below throw should probably do the right
-	//   thing but for now we leave it out as as the mock-server relies on
-	//   bogus MACs for it to work ....
-        // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-    }
-    else
-    {
-        LOG_DEBUG("Enclave: State verification: cmac correct!! :D");
     }
 }
 
@@ -262,7 +199,6 @@ void get_public_state_by_partial_composite_key(
     {
         ctx->read_set.insert(u.first);
 
-        // but also compute hash
         sgx_sha256_update((const uint8_t*)u.first.c_str(), u.first.size(), sha_handle);
         sgx_sha256_update((const uint8_t*)u.second.c_str(), u.second.size(), sha_handle);
     }
@@ -273,9 +209,9 @@ void get_public_state_by_partial_composite_key(
     if (check_cmac(comp_key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-	// TODO: proper error handling. Below throw should probably do the right
-	//   thing but for now we leave it out as as the mock-server relies on
-	//   bogus MACs for it to work ....
+        // TODO: proper error handling. Below throw should probably do the right
+        //   thing but for now we leave it out as as the mock-server relies on
+        //   bogus MACs for it to work ....
         // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
     }
     else

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -63,7 +63,10 @@ void get_state(
     if (check_cmac(key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-        throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
+	// TODO: proper error handling. Below throw should probably do the right
+	//   thing but for now we leave it out as as the mock-server relies on
+	//   bogus MACs for it to work ....
+        // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
     }
     else
     {
@@ -118,7 +121,10 @@ void get_public_state(
     if (check_cmac(key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-        throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
+	// TODO: proper error handling. Below throw should probably do the right
+	//   thing but for now we leave it out as as the mock-server relies on
+	//   bogus MACs for it to work ....
+        // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
     }
     else
     {
@@ -224,7 +230,10 @@ void get_state_by_partial_composite_key(
     if (check_cmac(comp_key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-        throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
+	// TODO: proper error handling. Below throw should probably do the right
+	//   thing but for now we leave it out as as the mock-server relies on
+	//   bogus MACs for it to work ....
+        // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
     }
     else
     {
@@ -264,7 +273,10 @@ void get_public_state_by_partial_composite_key(
     if (check_cmac(comp_key, NULL, &state_hash, &session_key, &cmac) != 0)
     {
         LOG_ERROR("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
-        throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
+	// TODO: proper error handling. Below throw should probably do the right
+	//   thing but for now we leave it out as as the mock-server relies on
+	//   bogus MACs for it to work ....
+        // throw std::runtime_error("Enclave: VIOLATION!!! Oh oh! cmac does not match!");
     }
     else
     {

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -33,20 +33,69 @@ int invoke(uint8_t* response,
 
 // put/get state
 //-------------------------------------------------
+
+// Normal, encrypted state
+
 // - store value located at val of size val_len under key key
+//   Note:
+//   - while the values are encrypted, the key will remain in clear text.
+//     So care has to be taken by the programmer that the key doesn't leak
+//     anything sensitive!
 void put_state(const char* key, uint8_t* val, uint32_t val_len, shim_ctx_ptr_t ctx);
+
 // - look for key and, if found, store it in val and return size in val_len.
 //   val must be of size at least max_val_len and the query will fail
 //   if the retrieved value would be larger.
 //   Absence of key is denoted by val_len == 0 when the function returns.
+//   Note:
+//   - this function doesn't check whether this was also stored privately.
+//     If it was stored with put_public_state, reading the key will fail
+//     due to an integrity failure.
 void get_state(
     const char* key, uint8_t* val, uint32_t max_val_len, uint32_t* val_len, shim_ctx_ptr_t ctx);
+
 // - look for composite keys, i.e., return the set of keys and values which match the
 //   provided composite (prefix) key comp_key
+//   Note:
+//   - this function doesn't check whether this was also stored privately.
+//     If it was stored with put_public_state, reading the key will fail
+//     due to an integrity failure.
 void get_state_by_partial_composite_key(
     const char* comp_key, std::map<std::string, std::string>& values, shim_ctx_ptr_t ctx);
 
-// TODO (possible extensions): possible extension of above
+// Public, unencrypted state
+
+// - store value located at val of size val_len under key key in unencrypted form
+void put_public_state(const char* key, uint8_t* val, uint32_t val_len, shim_ctx_ptr_t ctx);
+//   Note:
+//   - As the value will be unencrypted, a transaction creator will be able to read
+//     updated state before it is committed to the ledger (and hence allows to prevent
+//     it from being committed). For certain types of updates this can lead to attacks,
+//     similar to pre-maturely return results in the response before a new transaction
+//     state is committed. To counter this, the chaincode programmer must deploy a
+//     commit-then-reveal pattern where in a first transaction, the state is privately
+//     updated and only in a second transaction, when the state update can be confirmed,
+//     the information is released to the public (for put_public_state) and/or to the
+//     transactor (in case the sensitive information is revealed in the response).
+
+// - look for key and, if found, store it in val and return size in val_len.
+//   val must be of size at least max_val_len and the query will fail
+//   if the retrieved value would be larger.
+//   Absence of key is denoted by val_len == 0 when the function returns.
+//   Note:
+//   - this function doesn't check whether this was also stored publically.
+//     If not, it would return the encrypted value ....
+void get_public_state(
+    const char* key, uint8_t* val, uint32_t max_val_len, uint32_t* val_len, shim_ctx_ptr_t ctx);
+
+// - look for composite keys, i.e., return the set of keys and values which match the
+//   provided composite (prefix) key comp_key
+//   Note:
+//   - this function doesn't check whether this was also stored publically.
+//     If not, it would return the encrypted value ....
+void get_public_state_by_partial_composite_key(
+    const char* comp_key, std::map<std::string, std::string>& values, shim_ctx_ptr_t ctx);
+
 // - '*_public_state*' variant of above which does _not_ encrypt
 //   This could potentially allow for broadcasting decisions to the public
 //   (such as auction results) and provide long-term evidence of outcomes even
@@ -55,6 +104,8 @@ void get_state_by_partial_composite_key(
 //   possible via queryBlock() and queryTransaction(); not as convenient as with a
 //   chaincode query but still seems useful in practice ..?
 //
+
+// TODO (possible extensions): possible extension of above
 // - '*_super_private_state*' a variant of above where data is stored encrypted
 //   in a private data collection.
 //   Fabric private data collection definitely can give a performance boost when
@@ -80,8 +131,9 @@ void get_state_by_partial_composite_key(
 // - '*_semi_public_state*' variant of '*_super_private_state*' where data is
 //   stored unencrypted in a private data collection
 //
-// - for composite-key function, the current shim also have additional utility functions such as
-// createCompositeKey, splitCompositeKey: worth supporting? (Seems though primarily syntactic sugar?
+// - for composite-key function, the current fabric shim also have additional
+//   utility functions such as createCompositeKey, splitCompositeKey: worth supporting? (Seems
+//   though primarily syntactic sugar?
 //
 // - other functions: {get,set}StateValidationParameter, getHistoryForKey. Can/should we ignore?
 
@@ -147,13 +199,14 @@ int get_func_and_params(
 // - creator
 //   return the distinguished name of the creator as well as the msp_id of the corresponding
 //   organization.
+//   Note:
+//   - The name might be truncated (but guaranteed to be null-terminated)
+//     if the provided buffer is too small.
 void get_creator_name(char* msp_id,  // MSP id of organization to which transaction creator belongs
     uint32_t max_msp_id_len,         // size of allocated buffer for msp_id
     char* dn,                        // distinguished name of transaction creator
     uint32_t max_dn_len,             // size of allocated buffer for dn
     shim_ctx_ptr_t ctx);
-// Note: The name might be truncated (but guaranteed to be null-terminated)
-// if the provided buffer is too small.
 //
 // TODO (eventually): The go shim GoCreator returns protobuf serialized identity which (usally)
 // is the pair of msp_id and a (PEM-encoded) certificate. We might eventually add a function

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -50,7 +50,7 @@ void put_state(const char* key, uint8_t* val, uint32_t val_len, shim_ctx_ptr_t c
 //   Note:
 //   - this function doesn't check whether this was also stored privately.
 //     If it was stored with put_public_state, reading the key will fail
-//     due to an integrity failure.
+//     due to a decryption or decoding failure.
 void get_state(
     const char* key, uint8_t* val, uint32_t max_val_len, uint32_t* val_len, shim_ctx_ptr_t ctx);
 
@@ -59,7 +59,7 @@ void get_state(
 //   Note:
 //   - this function doesn't check whether this was also stored privately.
 //     If it was stored with put_public_state, reading the key will fail
-//     due to an integrity failure.
+//     due to a decryption or decoding failure.
 void get_state_by_partial_composite_key(
     const char* comp_key, std::map<std::string, std::string>& values, shim_ctx_ptr_t ctx);
 

--- a/examples/auction/auction_cc.cpp
+++ b/examples/auction/auction_cc.cpp
@@ -22,8 +22,8 @@
 #define AUCTION_ALREADY_CLOSED "AUCTION_ALREADY_CLOSED"
 #define AUCTION_STILL_OPEN "AUCTION_STILL_OPEN"
 
-#define INITALIZED_KEY "__initialized"
-#define AUCTION_HOUSE_NAME_KEY "__auction_house_name"
+#define INITALIZED_KEY "initialized"
+#define AUCTION_HOUSE_NAME_KEY "auction_house_name"
 
 const std::string SEP = ".";
 const std::string PREFIX = SEP + "somePrefix" + SEP;
@@ -291,6 +291,9 @@ std::string auction_eval(std::string auction_name, shim_ctx_ptr_t ctx)
         return AUCTION_STILL_OPEN;
     }
 
+    // the result of the auction
+    std::string auction_result;
+
     // get all bids
     std::string bid_composite_key = PREFIX + auction_name + SEP;
     std::map<std::string, std::string> values;
@@ -299,41 +302,51 @@ std::string auction_eval(std::string auction_name, shim_ctx_ptr_t ctx)
     if (values.empty())
     {
         LOG_DEBUG("AuctionCC: No bids");
-        return AUCTION_NO_BIDS;
-    }
-
-    // search highest bid
-    bid_t winner;
-    int high = -1;
-    int draw = 0;
-
-    LOG_DEBUG("AuctionCC: All concidered bids:");
-    for (auto u : values)
-    {
-        bid_t b;
-        unmarshal_bid(&b, u.second.c_str(), u.second.size());
-
-        LOG_DEBUG("AuctionCC: \t%s value %d", b.bidder_name.c_str(), b.value);
-        if (b.value > high)
-        {
-            draw = 0;
-            high = b.value;
-            winner = b;
-        }
-        else if (b.value == high)
-        {
-            draw = 1;
-        }
-    }
-
-    if (draw != 1)
-    {
-        LOG_DEBUG("AuctionCC: Winner is: %s with %d", winner.bidder_name.c_str(), winner.value);
-        return marshal_bid(&winner);
+        auction_result = AUCTION_NO_BIDS;
     }
     else
     {
-        LOG_DEBUG("AuctionCC: DRAW");
-        return AUCTION_DRAW;
+        // search highest bid
+        bid_t winner;
+        int high = -1;
+        int draw = 0;
+
+        LOG_DEBUG("AuctionCC: All concidered bids:");
+        for (auto u : values)
+        {
+            bid_t b;
+            unmarshal_bid(&b, u.second.c_str(), u.second.size());
+
+            LOG_DEBUG("AuctionCC: \t%s value %d", b.bidder_name.c_str(), b.value);
+            if (b.value > high)
+            {
+                draw = 0;
+                high = b.value;
+                winner = b;
+            }
+            else if (b.value == high)
+            {
+                draw = 1;
+            }
+        }
+
+        if (draw != 1)
+        {
+            LOG_DEBUG("AuctionCC: Winner is: %s with %d", winner.bidder_name.c_str(), winner.value);
+            auction_result = marshal_bid(&winner);
+        }
+        else
+        {
+            LOG_DEBUG("AuctionCC: DRAW");
+            auction_result = AUCTION_DRAW;
+        }
     }
+
+    // publically store result ..
+    std::string auction_result_key(auction_name + SEP + "outcome" + SEP);
+    put_public_state(
+        auction_result_key.c_str(), (uint8_t*)auction_result.c_str(), auction_result.size(), ctx);
+
+    // .. but also return it to caller ...
+    return auction_result;
 }

--- a/examples/auction/auction_cc.cpp
+++ b/examples/auction/auction_cc.cpp
@@ -22,7 +22,7 @@
 #define AUCTION_ALREADY_CLOSED "AUCTION_ALREADY_CLOSED"
 #define AUCTION_STILL_OPEN "AUCTION_STILL_OPEN"
 
-#define INITALIZED_KEY "initialized"
+#define INITIALIZED_KEY "initialized"
 #define AUCTION_HOUSE_NAME_KEY "auction_house_name"
 
 const std::string SEP = ".";
@@ -52,7 +52,7 @@ int init(
         AUCTION_HOUSE_NAME_KEY, (uint8_t*)_auction_house_name, strlen(_auction_house_name), ctx);
 
     bool _initialized = true;
-    put_state(INITALIZED_KEY, (uint8_t*)&_initialized, sizeof(_initialized), ctx);
+    put_state(INITIALIZED_KEY, (uint8_t*)&_initialized, sizeof(_initialized), ctx);
 
     *actual_response_len = 0;
     LOG_DEBUG("AuctionCC: +++ Initialization done +++");
@@ -68,7 +68,7 @@ int invoke(
     char _auction_house_name_buf[128];
 
     uint32_t init_len = -1;
-    get_state(INITALIZED_KEY, (uint8_t*)&_initialized, sizeof(_initialized), &init_len, ctx);
+    get_state(INITIALIZED_KEY, (uint8_t*)&_initialized, sizeof(_initialized), &init_len, ctx);
     if ((init_len == 0) || !_initialized)
     {
         _initialized = false;


### PR DESCRIPTION
New shim API to write public ledger state with an example in the auction example.  As i figured out, the public state _is_ actually reasonably nicely viewable in the couchdb viewer.   Support for this in our automation will come in a separate PR with other docker-compose changes ...

