### PR TITLE
make tput errors go away for docker execs ...

### DIFF
--- a/fabric/bin/lib/common_utils.sh
+++ b/fabric/bin/lib/common_utils.sh
@@ -2,17 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cred=`tput setaf 1`
-cgrn=`tput setaf 2`
-cblu=`tput setaf 4`
-cmag=`tput setaf 5`
-cwht=`tput setaf 7`
-cbld=`tput bold`
-bred=`tput setab 1`
-bgrn=`tput setab 2`
-bblu=`tput setab 4`
-bwht=`tput setab 7`
-crst=`tput sgr0`
+if [[ -z "$TERM" ]] || [[ "$TERM" == 'dumb' ]]; then
+    # to avoid 'tput: No value for $TERM and no -T specified' errors ..
+    cred=
+    cgrn=
+    cblu=
+    cmag=
+    cwht=
+    cbld=
+    bred=
+    bgrn=
+    bblu=
+    bwht=
+    crst=
+else
+    cred=$(tput setaf 1)
+    cgrn=$(tput setaf 2)
+    cblu=$(tput setaf 4)
+    cmag=$(tput setaf 5)
+    cwht=$(tput setaf 7)
+    cbld=$(tput bold)
+    bred=$(tput setab 1)
+    bgrn=$(tput setab 2)
+    bblu=$(tput setab 4)
+    bwht=$(tput setab 7)
+    crst=$(tput sgr0)
+fi
 
 function recho () {
     echo "${cbld}${cred}"$@"${crst}" >&2


### PR DESCRIPTION
Subject says it all.  

BTW: requires manually rebuilding the peer (`cd utils/docker; make peer`) to get the benefit ..