### PR TITLE
Add Docker Chaincode Builder Script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ include $(TOP)/build.mk
 
 SUB_DIRS = utils ercc ecc_enclave ecc tlcc_enclave tlcc examples integration # docs
 PLUGINS = ercc ecc_enclave ecc tlcc_enclave tlcc
+FPC_SDK = utils/fabric ecc_enclave ecc
 
 .PHONY: license
 
@@ -45,3 +46,6 @@ godeps: gotools
 
 plugins:
 	$(foreach DIR, $(PLUGINS), $(MAKE) -C $(DIR) build || exit;)
+
+fpc-sdk: godeps
+	$(foreach DIR, $(FPC_SDK), $(MAKE) -C $(DIR) build || exit;)

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -53,3 +53,6 @@ dev: base
 
 run: dev
 	$(DOCKER) run $(DOCKER_DEV_RUN_OPTS) -it $(FPC_DOCKER_NAMESPACE)-dev
+
+cc-builder: dev
+	$(DOCKER) build -t $(FPC_DOCKER_NAMESPACE)-cc-builder cc-builder

--- a/utils/docker/cc-builder/Dockerfile
+++ b/utils/docker/cc-builder/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM hyperledger/fabric-private-chaincode-dev:latest
+
+RUN cd $FPC_PATH
+RUN make fpc-sdk
+
+WORKDIR $FPC_PATH


### PR DESCRIPTION
 - add minimum build to make file to only build components needed to
 build FPC chaincodes
 - add cc-builder image
 - add make target to utils/docker to build the cc-builder

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>

