### PR TITLE
Bring up FPC Auction CC in demo

### DIFF
--- a/demo/chaincode/fpc/Makefile
+++ b/demo/chaincode/fpc/Makefile
@@ -20,3 +20,7 @@ build: $(BUILD_DIR)
 
 clean:
 	-rm -rf $(BUILD_DIR)
+
+docker-build: clean
+	$(DOCKER) image inspect hyperledger/fabric-private-chaincode-cc-builder > /dev/null 1>&1 || { cd $(TOP)/utils/docker && make cc-builder; }
+	$(DOCKER) run -u $$(id -u):$$(id -g) -v ${PWD}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc -w /project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc hyperledger/fabric-private-chaincode-cc-builder sh -c make build

--- a/demo/chaincode/fpc/README.md
+++ b/demo/chaincode/fpc/README.md
@@ -16,12 +16,26 @@ The chaincode implements a simple randomized version of the Assignment phase of 
 ## Build the code
 
 * make sure the the `FPC_PATH` environment variable is set to the root folder of the Fabric Private Chaincode project
-* run `make`
+
+### Locally
+* run `make` to build locally
+
+### Using docker
+* Build the Auction Chaincode
+```
+cd $FPC_PATH/demo/chaincode/fpc
+make docker-build
+```
+**NOTE** If you already built the `hyperledger/fabric-private-chaincode-cc-builder`
+image, it will use that image to build the chaincode. Otherwise it will build
+the [`cc-builder` image](../../../utils/cc-builder/Dockerfile) and the
+[`dev` image](../../../utils/dev/Dockerfile) before building the chaincode.
 
 ## Test the code
+**NOTE** If you used docker to build the chaincode, make sure you run the
+following using the [development docker image](../../../utils/docker/dev/Dockerfile).
 
 The auction chaincode can be conveniently developed and tested by using the [FPC Mock Server](../../client/backend/mock) as follows:
 * build the auction chaincode
 * follow the instruction in the Mock Server [Readme](../../client/backend/mock/README.md) file to build the server and make sure the server can access the compiled auction artifacts
 * run `./test.sh`
-

--- a/demo/client/backend/fabric-gateway/config.json
+++ b/demo/client/backend/fabric-gateway/config.json
@@ -1,7 +1,7 @@
 {
     "connection_profile_filename":"../gateway/localhost/connection_profile.json",
     "channel_name":"mychannel",
-    "chaincode_name":"mockcc",
+    "chaincode_name":"ecc_auctioncc",
     "wallet": "../gateway/localhost/wallet",
     "adminEnrollmentId":"org1admin",
     "enrollmentSecret":"adminpw",

--- a/demo/client/backend/fabric-gateway/registerUsers.sh
+++ b/demo/client/backend/fabric-gateway/registerUsers.sh
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set -ev
+set -e
 
 FABRIC_GATEWAY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export WAIT_TIME=5

--- a/demo/scripts/installCC.sh
+++ b/demo/scripts/installCC.sh
@@ -18,3 +18,9 @@ sleep ${WAIT_TIME}
 
 docker exec peer0.org1.example.com ${PEER_CMD} chaincode instantiate -n mockcc -v ${version} --channelID mychannel -c '{"Args":[]}'
 sleep ${WAIT_TIME}
+
+docker exec peer0.org1.example.com ${PEER_CMD} chaincode install -n auctioncc -v ${version} --path demo/chaincode/fpc/_build/lib -l fpc-c
+sleep ${WAIT_TIME}
+
+docker exec peer0.org1.example.com ${PEER_CMD} chaincode instantiate -n auctioncc -v ${version} --channelID mychannel -c '{"Args":[]}'
+sleep ${WAIT_TIME}

--- a/demo/scripts/startFPCAuctionNetwork.sh
+++ b/demo/scripts/startFPCAuctionNetwork.sh
@@ -6,6 +6,55 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -e
+
+help(){
+   echo "$(basename $0) [options]
+
+   This script, by default, will teardown possible previous iterations of this demo, generate new
+   crypto material for the network, start an FPC network as defined in \$FPC_PATH/utils/docker-compose,
+   install the mock golang auction chaincode(\$FPC_PATH/demo/chaincode/golang), install the FPC
+   compliant auction chaincode(\$FPC_PATH/demo/chaincode/fpc), register auction users, and bring up
+   both the fabric-gatway & frontend UI. If the fabric-gateway and frontend UI docker images have
+   not previously been built it will build them, otherwise the script will reuse the images already
+   existing. The FPC chaincode will not be built unless specified by the flag --build-cc.
+
+   options:
+       --build-cc:
+           As part of bringing up the demo components, the auction cc in demo/chaincode/fpc will
+           be rebuilt using the docker-build make target.
+       --build-client:
+           As part of bringing up the demo components, the Fabric Gateway and the UI docker images
+           will be built or rebuilt using current source code.
+       --help,-h:
+           Print this help screen.
+    "
+}
+
+
+BUILD_CHAINCODE=false
+BUILD_CLIENT=false
+for var in "$@"; do
+    case "$var" in
+        "--build-cc")
+            BUILD_CHAINCODE=true
+            ;;
+        "--build-client")
+            BUILD_CLIENT=true
+            ;;
+        "-h"|"--help")
+            help
+            exit
+            ;;
+        *)
+            echo "Invalid option passed: ${var}"
+            help
+            exit
+            ;;
+    esac
+    shift
+done
+
 export DEMO_SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export FPC_ROOT=${DEMO_SCRIPTS_DIR}/../..
 export DEMO_ROOT=${DEMO_SCRIPTS_DIR}/..
@@ -15,10 +64,27 @@ export SCRIPT_DIR=${FPC_ROOT}/utils/docker-compose/scripts
 . ${SCRIPT_DIR}/lib/common.sh
 
 # Cleanup any previous iterations of the demo
-"${SCRIPT_DIR}/teardown.sh" --clean-slate
+"${SCRIPT_DIR}/teardown.sh"
 
 # Generate the necessary credentials and start the FPC network
 "${SCRIPT_DIR}/generate.sh"
+
+if $BUILD_CHAINCODE; then
+    echo ""
+    echo "Building FPC Auction Chaincode"
+    pushd ${DEMO_ROOT}/chaincode/fpc
+        FPC_PATH=${FPC_ROOT} make docker-build
+    popd
+fi
+
+if $BUILD_CLIENT; then
+    echo ""
+    echo "Building Fabric Gateway and Frontend UI"
+    COMPOSE_IGNORE_ORPHANS=true ${DOCKER_COMPOSE_CMD} -f ${DEMO_ROOT}/docker-compose.yml build
+fi
+
+# Start the FPC Network using utils/docker-compose scripts
+echo "Starting the FPC Network"
 "${SCRIPT_DIR}/start.sh"
 
 # Install and Instantiate Auction Chaincode

--- a/demo/scripts/teardown.sh
+++ b/demo/scripts/teardown.sh
@@ -7,6 +7,38 @@
 
 set -e
 
+help(){
+   echo "$(basename $0) [options]
+   This script, by default, will teardown all of the auction demo components, but will not prune
+   volumes or delete the chaincode images that have been created for the mockcc and the auctioncc
+   options:
+       --clean-slate:
+           As part of the teardown, prune all unused docker volumes and delete mockcc and auctioncc
+           images.
+       --help,-h:
+           Print this help screen.
+    "
+}
+
+CLEAN_SLATE=false
+for var in "$@"; do
+    case "$var" in
+        "--clean-slate")
+            CLEAN_SLATE=true
+            ;;
+        "-h"|"--help")
+            help
+            exit
+            ;;
+        *)
+            echo "Invalid option: ${var}"
+            help
+            exit
+            ;;
+    esac
+    shift
+done
+
 DEMO_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEMO_DOCKER_COMPOSE=${DEMO_SCRIPT_DIR}/../docker-compose.yml
 
@@ -14,15 +46,22 @@ DEMO_DOCKER_COMPOSE=${DEMO_SCRIPT_DIR}/../docker-compose.yml
 SCRIPT_DIR=${DEMO_SCRIPT_DIR}/../../utils/docker-compose/scripts
 . ${SCRIPT_DIR}/lib/common.sh
 
+
 COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} kill && COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} down
 
-
-if [ "$1" == '--clean-slate' ]; then
+if $CLEAN_SLATE; then
     "${SCRIPT_DIR}/teardown.sh" --clean-slate
-    images=$(docker images dev_*mockcc-* -q)
-    if [ ! -z "${images}" ]; then
-        docker rmi "${images}"
+
+    image=$(go run ${DEMO_SCRIPT_DIR}/../../utils/fabric/get-fabric-container-name.go --cc-name mockcc --peer-id peer0.org1.example.com --net-id dev_test --cc-version 1.0)
+    if [ ! -z "${image}" ]; then
+        docker rmi "${image}"
     fi
-else
-    "${SCRIPT_DIR}/teardown.sh"
+
+    image=$(go run ${DEMO_SCRIPT_DIR}/../../utils/fabric/get-fabric-container-name.go --cc-name ecc_auctioncc --peer-id peer0.org1.example.com --net-id dev_test --cc-version 1.0)
+    if [ ! -z "${image}" ]; then
+        docker rmi "${image}"
+    fi
+    exit
 fi
+
+"${SCRIPT_DIR}/teardown.sh"

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -29,7 +29,7 @@ endif
 
 .PHONY: base ccenv dev peer
 
-build: base ccenv
+build: base ccenv cc-builder
 
 base:
 	$(DOCKER) build -t $(FPC_DOCKER_NAMESPACE)-base base


### PR DESCRIPTION
 - fpc auction cc is brought up in end to end scripts as auctioncc
 - fabric-gateway is configured to talk with auction cc
 - add help text for demo start and teardown scripts
 - add flags for startFPCAuctionNetwork to allow flexibility in building
 chaincode and client images

Signed-off-by: Swetha Repakula <srepaku@us.ibm.com>

This PR is dependent on #207 being merged before