### PR TITLE
ID Remapping for Mock server

### DIFF
--- a/demo/client/backend/mock/Makefile
+++ b/demo/client/backend/mock/Makefile
@@ -10,8 +10,8 @@ DOCKER_IMAGE = auction_mock_backend
 APP_SRC = ${PWD}
 
 run-go:
-	$(GO) run .
+	env LD_LIBRARY_PATH=../../../../ecc_enclave/_build/lib:${LD_LIBRARY_PATH} $(GO) run .
 
 run-fpc:
 	$(GO) build -tags fpc
-	./mock --debug
+	env LD_LIBRARY_PATH=../../../../ecc_enclave/_build/lib:${LD_LIBRARY_PATH} ./mock --debug

--- a/demo/client/backend/mock/api/mock_data.go
+++ b/demo/client/backend/mock/api/mock_data.go
@@ -8,14 +8,28 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 )
 
+type MappedName struct {
+	User  string `json:"user"`
+	MspId string `json:"mspId"`
+	Org   string `json:"org"`
+}
+
 var MockData map[string]interface{}
+var MockNameMap map[string]MappedName
 
 func init() {
-	MockData, _ = loadMockData()
+	var err error
+	if MockData, err = loadMockData(); err != nil {
+		panic(fmt.Sprintf("Cannot read mock data: error=%v", err))
+	}
+	if MockNameMap, err = loadMockNameMap(); err != nil {
+		panic(fmt.Sprintf("Cannot read mock name mapping: error=%v", err))
+	}
 }
 
 func loadMockData() (map[string]interface{}, error) {
@@ -31,6 +45,27 @@ func loadMockData() (map[string]interface{}, error) {
 	}
 
 	var result map[string]interface{}
+	err = json.Unmarshal(byteValue, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func loadMockNameMap() (map[string]MappedName, error) {
+	jsonFile, err := os.Open("api/name-map.json")
+	defer jsonFile.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]MappedName
 	err = json.Unmarshal(byteValue, &result)
 	if err != nil {
 		return nil, err

--- a/demo/client/backend/mock/api/name-map.json
+++ b/demo/client/backend/mock/api/name-map.json
@@ -1,0 +1,23 @@
+{
+    "Auctioneer1": {
+	"user": "Auctioneer",
+        "mspId": "ELBMSP",
+        "org": "elbonia"
+    },
+    "A-Telecom": {
+	"user": "A-Telecom",
+        "mspId": "ATMSP",
+        "org": "at"
+    },
+    "B-Net": {
+	"user": "B-Net",
+        "mspId": "BNMSP",
+        "org": "B-N"
+    },
+    "C-Mobile": {
+	"user": "C-Mobile",
+        "mspId": "CMOMSP",
+        "org": "cmo"
+    }
+}
+

--- a/demo/client/backend/mock/mock_stub_wrapper.go
+++ b/demo/client/backend/mock/mock_stub_wrapper.go
@@ -12,6 +12,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hyperledger-labs/fabric-private-chaincode/demo/client/backend/mock/api"
+
 	"github.com/hyperledger-labs/fabric-private-chaincode/ecc"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/utils"
@@ -115,7 +117,19 @@ func (m *MockStubWrapper) saveTransaction(uuid string, resp peer.Response) {
 
 // Initialise this chaincode,  also starts and ends a transaction.
 func (m *MockStubWrapper) MockInit(uuid string, args [][]byte) pb.Response {
-	creator, _ := generateMockCreator(mspId, org, m.Creator)
+	var ok bool
+	var mappedName api.MappedName
+
+	if mappedName, ok = api.MockNameMap[m.Creator]; ok {
+		logger.Debugf("Mapping user '%s' to { MspId: '%s', Org: '%s', User: '%s'}",
+			m.Creator, mappedName.MspId, mappedName.Org, mappedName.User)
+	} else {
+		mappedName = api.MappedName{User: m.Creator, MspId: defaultMspId, Org: defaultOrg}
+		logger.Debugf("No name mapping found for user '%s', using default MspId '%s' and Org '%s'",
+			m.Creator, defaultMspId, defaultOrg)
+	}
+
+	creator, _ := generateMockCreator(mappedName.MspId, mappedName.Org, mappedName.User)
 	m.MockStub.Creator = creator
 
 	uuid = m.createUuid(uuid)
@@ -126,7 +140,19 @@ func (m *MockStubWrapper) MockInit(uuid string, args [][]byte) pb.Response {
 
 // Invoke this chaincode, also starts and ends a transaction.
 func (m *MockStubWrapper) MockInvoke(uuid string, args [][]byte) pb.Response {
-	creator, _ := generateMockCreator(mspId, org, m.Creator)
+	var ok bool
+	var mappedName api.MappedName
+
+	if mappedName, ok = api.MockNameMap[m.Creator]; ok {
+		logger.Debugf("Mapping user '%s' to { MspId: '%s', Org: '%s', User: '%s'}",
+			m.Creator, mappedName.MspId, mappedName.Org, mappedName.User)
+	} else {
+		mappedName = api.MappedName{User: m.Creator, MspId: defaultMspId, Org: defaultOrg}
+		logger.Debugf("No name mapping found for user '%s', using default MspId '%s' and Org '%s'",
+			m.Creator, defaultMspId, defaultOrg)
+	}
+
+	creator, _ := generateMockCreator(mappedName.MspId, mappedName.Org, mappedName.User)
 	m.MockStub.Creator = creator
 
 	uuid = m.createUuid(uuid)
@@ -137,11 +163,22 @@ func (m *MockStubWrapper) MockInvoke(uuid string, args [][]byte) pb.Response {
 
 // Invoke this chaincode, also starts and ends a transaction.
 func (m *MockStubWrapper) MockQuery(uuid string, args [][]byte) pb.Response {
-	creator, _ := generateMockCreator(mspId, org, m.Creator)
+	var ok bool
+	var mappedName api.MappedName
+
+	if mappedName, ok = api.MockNameMap[m.Creator]; ok {
+		logger.Debugf("Mapping user '{}' to { MspId: '{}', Org: '{}', User: '{}'}",
+			m.Creator, mappedName.MspId, mappedName.Org, mappedName.User)
+	} else {
+		mappedName = api.MappedName{User: m.Creator, MspId: defaultMspId, Org: defaultOrg}
+		logger.Debugf("No name mapping found for user '{}', using default MspId '{}' and Org '{}'",
+			m.Creator, defaultMspId, defaultOrg)
+	}
+
+	creator, _ := generateMockCreator(mappedName.MspId, mappedName.Org, mappedName.User)
 	m.MockStub.Creator = creator
 
 	// save state
-
 	s, err := json.Marshal(m.MockStub.State)
 	if err != nil {
 		panic("error storing state")


### PR DESCRIPTION
Using a mapping file (demo/client/backend/mock/api/name-map.json) the mock-server does now remap MSP-id and Orgs so we can simulate multi-org/multi-peer setups. Note the mapping happens both on getDefaultAuction and on createAuction requests for the backend. That way, the UI should work correctly ID-wise when the auction was created based on getDefault auction but also when it is created using the scenario (the template, though, is still duplicated in demo/scenario/Auctioneer1.createAuction and inside demo/client/backend/mock/api/serverapi.json).  However, in case you manually create an auction and/or edit the default auction in the UI, you should make sure that you either use/leave the translated names or use completely different names!
