### PR TITLE
docker & script related improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ FPC_SDK = utils/fabric ecc_enclave ecc
 
 build : godeps
 
-build test clean :
+build test clean clobber:
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@ || exit;)
 
 checks: linter license

--- a/build.mk
+++ b/build.mk
@@ -17,6 +17,9 @@ test: build
 .PHONY: checks
 .PHONY: clean
 
+.PHONY: clobber
+clobber: clean
+
 .PHONY: docker
 .PHONY: docker-run
 .PHONY: docker-stop

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -7,7 +7,9 @@ include $(TOP)/build.mk
 
 SUB_DIRS = chaincode client
 
-build test clean :
+build test clean clobber:
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@ || exit;)
 
 
+clobber:
+	./scripts/teardown.sh --clean-slate

--- a/demo/chaincode/Makefile
+++ b/demo/chaincode/Makefile
@@ -7,7 +7,7 @@ include $(TOP)/build.mk
 
 SUB_DIRS = fpc # golang 
 
-build test clean :
+build test clean clobber:
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@ || exit;)
 
 

--- a/demo/chaincode/fpc/Makefile
+++ b/demo/chaincode/fpc/Makefile
@@ -3,7 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-TOP = $(FPC_PATH)
+#ifneq ($(FPC_PATH), '')
+ifdef FPC_PATH
+	TOP = $(FPC_PATH)
+else
+	TOP = ../../../
+	export FPC_PATH = $(abspath $(TOP))
+endif
+
 include $(TOP)/build.mk
 
 BUILD_DIR := _build

--- a/demo/chaincode/fpc/Makefile
+++ b/demo/chaincode/fpc/Makefile
@@ -29,7 +29,7 @@ clean:
 	-rm -rf $(BUILD_DIR)
 
 docker-build: clean
-	$(DOCKER) image inspect hyperledger/fabric-private-chaincode-cc-builder > /dev/null 1>&1 || { cd $(TOP)/utils/docker && make cc-builder; }
+	$(DOCKER) image inspect hyperledger/fabric-private-chaincode-cc-builder > /dev/null 2>&1 || { cd $(TOP)/utils/docker && make cc-builder; }
 	$(DOCKER) run -u $$(id -u):$$(id -g) -v ${PWD}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc -w /project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc hyperledger/fabric-private-chaincode-cc-builder sh -c make build
 
 test: build

--- a/demo/chaincode/fpc/README.md
+++ b/demo/chaincode/fpc/README.md
@@ -15,7 +15,7 @@ The chaincode implements a simple randomized version of the Assignment phase of 
 
 ## Build the code
 
-* make sure the the `FPC_PATH` environment variable is set to the root folder of the Fabric Private Chaincode project
+* below assumes you have set the `FPC_PATH` environment variable to the root folder of the Fabric Private Chaincode project
 
 ### Locally
 * run `make` to build locally

--- a/demo/client/Makefile
+++ b/demo/client/Makefile
@@ -7,6 +7,6 @@ include $(TOP)/build.mk
 
 SUB_DIRS = scripting frontend backend
 
-build test clean :
+build test clean clobber:
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@ || exit;)
 

--- a/demo/client/backend/Makefile
+++ b/demo/client/backend/Makefile
@@ -7,7 +7,7 @@ include $(TOP)/build.mk
 
 SUB_DIRS = fabric-gateway mock
 
-build test clean :
+build test clean clobber:
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@ || exit;)
 
 

--- a/demo/client/backend/fabric-gateway/Makefile
+++ b/demo/client/backend/fabric-gateway/Makefile
@@ -5,3 +5,29 @@
 TOP = ../../../..
 include $(TOP)/build.mk
 
+DOCKER_IMAGE=auction_client_backend
+
+# Note:
+# - docker images are not necessarily rebuild if they exist but are outdated.
+#   To force rebuild you have two options
+#   - do a 'make clobber' first. This ensures you will have the uptodate images
+#     but is a broad and slow brush
+#   - to just fore rebuilding an image, call `make` with FORCE_REBUILD defined
+DOCKER_BUILD_OPTS ?=
+ifdef FORCE_REBUILD
+	DOCKER_BUILD_OPTS += --no-cache
+endif
+
+
+build: docker
+
+docker:
+	# this image is usually built by docker-compose but we still add a
+	# convenience target ere until proxy issues with docker-compose are resolved
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t ${DOCKER_IMAGE} .
+
+clobber:
+	IMAGE=$$(${DOCKER} images ${DOCKER_IMAGE} -q); \
+        if [ ! -z "$${IMAGE}" ]; then ${DOCKER} rmi ${IMAGE}; fi
+	# make clobber in demo/ also would take care but better safe than sorry
+

--- a/demo/client/frontend/Makefile
+++ b/demo/client/frontend/Makefile
@@ -8,8 +8,23 @@ include $(TOP)/build.mk
 DOCKER_IMAGE = auction_frontend
 APP_SRC = ${PWD}
 
-build:
-	$(DOCKER) build -t $(DOCKER_IMAGE) .
+# Note:
+# - docker images are not necessarily rebuild if they exist but are outdated.
+#   To force rebuild you have two options
+#   - do a 'make clobber' first. This ensures you will have the uptodate images
+#     but is a broad and slow brush
+#   - to just fore rebuilding an image, call `make` with FORCE_REBUILD defined
+DOCKER_BUILD_OPTS ?=
+ifdef FORCE_REBUILD
+	DOCKER_BUILD_OPTS += --no-cache
+endif
+
+build: docker
+
+docker:
+	# this image is usually built by docker-compose but we still add a
+	# convenience target ere until proxy issues with docker-compose are resolved
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_IMAGE) .
 
 run:
 	$(DOCKER) run \
@@ -25,3 +40,8 @@ cli:
 		-v ${APP_SRC}:/usr/src/app \
 		$(DOCKER_IMAGE) \
 		/bin/sh
+
+clobber:
+	IMAGE=$$(${DOCKER} images ${DOCKER_IMAGE} -q); \
+	if [ ! -z "$${IMAGE}" ]; then ${DOCKER} rmi ${IMAGE}; fi
+	# make clobber in demo/ also would take care but better safe than sorry

--- a/demo/client/scripting/lib/dsl.sh
+++ b/demo/client/scripting/lib/dsl.sh
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# assumes FPC_ROOT and DEMO_CLIENT_SCRIPTS_DIR is defined
+# assumes FPC_PATH and DEMO_CLIENT_SCRIPTS_DIR is defined
 
-. "${FPC_ROOT}"/fabric/bin/lib/common_utils.sh
+. "${FPC_PATH}"/fabric/bin/lib/common_utils.sh
 
 
 CLI="${DEMO_CLIENT_SCRIPTS_DIR}/cli"

--- a/demo/client/scripting/scenario-run.sh
+++ b/demo/client/scripting/scenario-run.sh
@@ -6,10 +6,10 @@
 #
 
 export DEMO_CLIENT_SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export FPC_ROOT="${DEMO_CLIENT_SCRIPTS_DIR}"/../../..
+export FPC_PATH="${FPC_PATH:-${DEMO_CLIENT_SCRIPTS_DIR}/../../..}"
 
-START_CMD="${FPC_ROOT}"/demo/scripts/startFPCAuctionNetwork.sh
-TEARDOWN_CMD="${FPC_ROOT}"/demo/scripts/teardown.sh
+START_CMD="${FPC_PATH}"/demo/scripts/startFPCAuctionNetwork.sh
+TEARDOWN_CMD="${FPC_PATH}"/demo/scripts/teardown.sh
 
 
 . "${DEMO_CLIENT_SCRIPTS_DIR}"/lib/dsl.sh
@@ -78,24 +78,6 @@ fi
 
 # (optional) which also sets up the whole fabric network
 if [ ${bootstrap} -eq 1 ]; then
-    # START_CMD does _not_ build the FPC peer and it is expensive to build it, 
-    # so let's look first whether we have it ...
-    if [ -z "$(docker images | grep hyperledger/fabric-peer-fpc )" ]; then
-        # .. and if not, build it
-    	pushd "${FPC_ROOT}/utils/docker" || die "can't go to peer build location"
-        make peer || die "can't build peer"
-	popd
-    fi
-    # START_CMD also does not call utils/docker-compose/scripts/bootstrap!
-    # as docker(-compose) will download images, we care only about binaries
-    # but download only if we do not have already executables installed and/or
-    # in path. We also assume that if you have cryptogen in path, you probably
-    # have the other needed, e.g., configtxgen, as well ...
-    if [ ! -d "${FPC_ROOT}/utils/docker-compose/bin" ] && [ -z "$(which cryptogen)" ]; then 
-        "${FPC_ROOT}/utils/docker-compose/scripts/bootstrap.sh" -d
-    fi
-    # Note: Above could eventually be moved to START_CMD once the various PRs
-    # are merged ...
     $START_CMD || die "could not bring up fpc network"
     sleep 10 # give some time for the client infrastructure to start ...
 fi

--- a/demo/client/scripting/scenario-run.sh
+++ b/demo/client/scripting/scenario-run.sh
@@ -84,6 +84,7 @@ if [ ${bootstrap} -eq 1 ]; then
         # .. and if not, build it
     	pushd "${FPC_ROOT}/utils/docker" || die "can't go to peer build location"
         make peer || die "can't build peer"
+	popd
     fi
     # START_CMD also does not call utils/docker-compose/scripts/bootstrap!
     # as docker(-compose) will download images, we care only about binaries
@@ -100,7 +101,7 @@ if [ ${bootstrap} -eq 1 ]; then
 fi
 
 # execute the script
-. "${scriptFile}"
+. "${scriptFile}" || die "executing script '${scriptFile}' failed ..."
 
 if [ ${bootstrap} -eq 1 ]; then
     $TEARDOWN_CMD || die "could not bring down fpc network"

--- a/demo/scripts/startFPCAuctionNetwork.sh
+++ b/demo/scripts/startFPCAuctionNetwork.sh
@@ -56,11 +56,11 @@ for var in "$@"; do
 done
 
 export DEMO_SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export FPC_ROOT=${DEMO_SCRIPTS_DIR}/../..
-export DEMO_ROOT=${DEMO_SCRIPTS_DIR}/..
+export FPC_PATH="${FPC_PATH:-${DEMO_SCRIPTS_DIR}/../..}"
+export DEMO_ROOT="${DEMO_SCRIPTS_DIR}/.."
 
 # SCRIPT_DIR is the docker compose script dir that needs to be defined to source environment variables from the FPC Network
-export SCRIPT_DIR=${FPC_ROOT}/utils/docker-compose/scripts
+export SCRIPT_DIR=${FPC_PATH}/utils/docker-compose/scripts
 . ${SCRIPT_DIR}/lib/common.sh
 
 # Cleanup any previous iterations of the demo
@@ -73,7 +73,7 @@ if $BUILD_CHAINCODE; then
     echo ""
     echo "Building FPC Auction Chaincode"
     pushd ${DEMO_ROOT}/chaincode/fpc
-        FPC_PATH=${FPC_ROOT} make docker-build
+        make docker-build
     popd
 fi
 

--- a/demo/scripts/teardown.sh
+++ b/demo/scripts/teardown.sh
@@ -46,8 +46,12 @@ DEMO_DOCKER_COMPOSE=${DEMO_SCRIPT_DIR}/../docker-compose.yml
 SCRIPT_DIR=${DEMO_SCRIPT_DIR}/../../utils/docker-compose/scripts
 . ${SCRIPT_DIR}/lib/common.sh
 
-
-COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} kill && COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} down
+if $CLEAN_SLATE; then
+	DOWN_OPT="--rmi all"
+else
+	DOWN_OPT=""
+fi
+COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} kill && COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} down ${DOWN_OPT}
 
 if $CLEAN_SLATE; then
     "${SCRIPT_DIR}/teardown.sh" --clean-slate

--- a/demo/scripts/teardown.sh
+++ b/demo/scripts/teardown.sh
@@ -57,15 +57,11 @@ if $CLEAN_SLATE; then
     "${SCRIPT_DIR}/teardown.sh" --clean-slate
 
     image=$(go run ${DEMO_SCRIPT_DIR}/../../utils/fabric/get-fabric-container-name.go --cc-name mockcc --peer-id peer0.org1.example.com --net-id dev_test --cc-version 1.0)
-    if [ ! -z "${image}" ]; then
-        docker rmi "${image}"
-    fi
+    docker inspect $image > /dev/null 2>&1 && docker rmi "${image}" || echo "No mockcc images available to remove"
 
     image=$(go run ${DEMO_SCRIPT_DIR}/../../utils/fabric/get-fabric-container-name.go --cc-name ecc_auctioncc --peer-id peer0.org1.example.com --net-id dev_test --cc-version 1.0)
-    if [ ! -z "${image}" ]; then
-        docker rmi "${image}"
-    fi
-    exit
+    docker inspect $image > /dev/null 2>&1 && docker rmi "${image}" || echo "No auctioncc images available to remove"
 fi
+
 
 "${SCRIPT_DIR}/teardown.sh"

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -59,8 +59,19 @@ clean: docker-clean
 	$(GO) clean
 	rm -rf ecc enclave/ecc-enclave-lib enclave/ecc-enclave-include
 
+# Note:
+# - docker images are not necessarily rebuild if they exist but are outdated.
+#   To force rebuild you have two options
+#   - do a 'make clobber' first. This ensures you will have the uptodate images
+#     but is a broad and slow brush
+#   - to just fore rebuilding an image, call `make` with FORCE_REBUILD defined
+DOCKER_BUILD_OPTS ?=
+ifdef FORCE_REBUILD
+	DOCKER_BUILD_OPTS += --no-cache
+endif
+
 docker-boilerplate-ecc: ecc
-	$(DOCKER) build -t $(DOCKER_BOILERPLATE_ECC_IMAGE) -f Dockerfile.boilerplate-ecc ..
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_BOILERPLATE_ECC_IMAGE) -f Dockerfile.boilerplate-ecc ..
 
 docker-fpc-app: docker-boilerplate-ecc
 	if [ -z "$(DOCKER_IMAGE)" ]; then\
@@ -68,7 +79,7 @@ docker-fpc-app: docker-boilerplate-ecc
 		exit 1;\
 	fi
 	echo "\033[1;33mWARNING: overriding $(DOCKER_IMAGE) docker image\033[0m"
-	$(DOCKER) build -t $(DOCKER_IMAGE) -f Dockerfile.fpc-app --build-arg enclave_so_path=$(DOCKER_ENCLAVE_SO_PATH) ..
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_IMAGE) -f Dockerfile.fpc-app --build-arg enclave_so_path=$(DOCKER_ENCLAVE_SO_PATH) ..
 
 docker-run:
 	$(DOCKER) run \
@@ -90,3 +101,5 @@ docker-stop:
 docker-clean: docker-stop
 	-if [ ! -z "$(DOCKER_IMAGE)" ]; then docker rmi -f $(DOCKER_IMAGE); fi
 	-if [ ! -z "$(INSTALLED_DOCKER_BOILERPLATE_ECC_IMAGE)" ]; then echo "Remove boilerplate image"; docker rmi $(INSTALLED_DOCKER_BOILERPLATE_ECC_IMAGE); fi
+
+clobber: docker-clean

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -5,7 +5,7 @@
 TOP = ..
 include $(TOP)/build.mk
 
-SUB_DIRS = docker fabric
+SUB_DIRS = docker fabric docker-compose
 
-all build test clean :
+all build test clean clobber:
 	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@;)

--- a/utils/docker-compose/Makefile
+++ b/utils/docker-compose/Makefile
@@ -1,0 +1,19 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+TOP = ../..
+include $(TOP)/build.mk
+
+build:
+	# nothing to do, will all be done via docker-compose exercised by scripts ...
+
+test:
+	# we do nothing here. Note, though, that target test in demo/client/scripting
+	# causes the scripts here to be exercised/tested ...
+
+clobber:
+	# first clean-up docker-compose network and demo related artifacts
+	(cd ../../demo/; make clobber)
+	# above presumably does below, but better safe than sorry :-)
+	./scripts/teardown.sh --clean-slate

--- a/utils/docker-compose/README.md
+++ b/utils/docker-compose/README.md
@@ -24,7 +24,20 @@ is used. Otherwise it will use `core.yaml` and the regular peer image.
 `$PEER_CMD` must also be set to the location of binary or script that will start
  the peer.  **Docker version 17.06.2-ce or higher is needed**
 
-## Steps
+## Starting the network
+
+### Quick start
+   The quickest way to get up and running is to simply execute
+   ```
+   scripts/start.sh
+   ```
+   This will create all necessary installation artifacts and start the
+   network. For more information in the steps involved, continue
+   reading the following section. Otherwise, you can skip to the
+   Section on [Chaincode Installation](#deploying-your-fpc-chaincode).
+
+
+### Detailed Steps
 1. Build the peer image in `utils/docker/peer` directory which is defined by the
    peer [Dockerfile](../docker/peer/Dockerfile). This step
    assumes you have already built the [fabric-private-chaincode base image](../docker/base/Dockerfile).
@@ -91,10 +104,13 @@ is used. Otherwise it will use `core.yaml` and the regular peer image.
    ```
    scripts/start.sh
    ```
-   **Note** that the script returns to you an export statements with environment variables
-   which enable you to easily run `docker-compose` commands such as `ps`, `top`, `logs`
-   and alike. Just copy/paste the export statement into your shell and you can get,
-   e.g., the container status with `${DOCKER_COMPOSE} ps`.
+   **Note**
+   - if some of steps 1 to 3 were omitted before running start.sh, the
+     script will perform the missing steps in the default configuration
+   - the script returns to you an export statements with environment variables
+     which enable you to easily run `docker-compose` commands such as `ps`, `top`, `logs`
+     and alike. Just copy/paste the export statement into your shell and you can get,
+     e.g., the container status with `${DOCKER_COMPOSE} ps`.
 
 ## Deploying your FPC Chaincode
 The [examples](../../examples) and [demo](../../demo) directories has been

--- a/utils/docker-compose/scripts/generate.sh
+++ b/utils/docker-compose/scripts/generate.sh
@@ -8,6 +8,19 @@ export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && p
 
 . ${SCRIPT_DIR}/lib/common.sh
 
+# test pre-conditions and try to remediate
+#
+# - existances of docker binaries
+#   as docker(-compose) will download images, we care only about binaries
+#   but download only if we do not have already executables installed and/or
+#   in path. We also assume that if you have cryptogen in path, you probably
+#   have the others needed, e.g., configtxgen, as well ...
+FABRIC_BINARY_PATH="${FPC_PATH}/utils/docker-compose/bin"
+if [ ! -d "${FABRIC_BINARY_PATH}" ] && [ -z "$(which cryptogen)" ]; then
+    echo "Fabirc binaries not found in '${FABRIC_BINARY_PATH}' or in \$PATH, try to download them ..."
+    "${FPC_PATH}/utils/docker-compose/scripts/bootstrap.sh" -d
+fi
+
 # remove previous crypto material and config transactions
 rm -fr ${FABRIC_CFG_PATH}/config/*
 mkdir -p ${FABRIC_CFG_PATH}/config

--- a/utils/docker-compose/scripts/lib/common.sh
+++ b/utils/docker-compose/scripts/lib/common.sh
@@ -8,6 +8,7 @@
 
 export PATH=${SCRIPT_DIR}/../bin:${PWD}:$PATH
 export FABRIC_CFG_PATH=${SCRIPT_DIR}/../network-config
+export FPC_PATH="${FPC_PATH:-${SCRIPT_DIR}/../../..}"
 
 # Variables which we allow the caller override ..
 export FABRIC_VERSION=${FABRIC_VERSION:=1.4.3}

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -27,7 +27,7 @@ ifneq ($(SGX_DEVICE_PATH),)
 	DOCKER_DEV_RUN_OPTS += -v $(PWD)/../../config/ias/:$(DOKER_FPCPATH)/config/ias/ -v $(SGX_PSW_SOCKET):$(SGX_PSW_SOCKET) --device $(SGX_DEVICE_PATH)
 endif
 
-.PHONY: base ccenv dev peer cc-build
+.PHONY: base ccenv dev peer cc-builder
 
 # - overall targets
 # ------------------

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -27,32 +27,69 @@ ifneq ($(SGX_DEVICE_PATH),)
 	DOCKER_DEV_RUN_OPTS += -v $(PWD)/../../config/ias/:$(DOKER_FPCPATH)/config/ias/ -v $(SGX_PSW_SOCKET):$(SGX_PSW_SOCKET) --device $(SGX_DEVICE_PATH)
 endif
 
-.PHONY: base ccenv dev peer
+.PHONY: base ccenv dev peer cc-build
 
+# - overall targets
+# ------------------
 build: base ccenv cc-builder
 
+run: dev
+	$(DOCKER) run $(DOCKER_DEV_RUN_OPTS) -it $(FPC_DOCKER_NAMESPACE)-dev
+
+clobber:
+	# first clean-up dangling images as that might prevent some of the later cleans
+	docker system prune --force
+	# then clean-up docker-compose network and demo related artifacts
+	(cd ../docker-compose; ${MAKE} clobber)
+	# delete locally created docker images and left-over peer artifacts
+	for imgs in \
+		dev-* \
+		dev_test-* \
+	        ${FPC_PEER_DOCKER_NAMESPACE} \
+		$(FPC_DOCKER_NAMESPACE)-dev \
+		$(FPC_DOCKER_NAMESPACE)-ccenv \
+		$(FPC_DOCKER_NAMESPACE)-cc-builder \
+		$(FPC_DOCKER_NAMESPACE)-base \
+	; do \
+		IMAGES=$$(${DOCKER} images $${imgs} -q); \
+		if [ ! -z "$${IMAGES}" ]; then ${DOCKER} rmi -f $${IMAGES} || exit 1; fi \
+	done
+
+
+# - building individual docker images
+# ------------------------------------------------------
+# Note:
+# - docker images are not necessarily rebuild if they exist but are outdated.
+#   To force rebuild you have two options
+#   - do a 'make clobber' first. This ensures you will have the uptodate images
+#     but is a broad and slow brush
+#   - to just fore rebuilding an image, call `make` with FORCE_REBUILD defined
+DOCKER_BUILD_OPTS ?=
+ifdef FORCE_REBUILD
+	DOCKER_BUILD_OPTS += --no-cache
+endif
+
+
 base:
-	$(DOCKER) build -t $(FPC_DOCKER_NAMESPACE)-base base
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-base base
 
 ccenv: base
-	$(DOCKER) build -t $(FPC_DOCKER_NAMESPACE)-ccenv ccenv
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-ccenv ccenv
 
 # Note: for overall consistency reasons we want the FPC code from the current repo
 # as this will rebuild each time and take a while, we don't add a dependency
 # to the build target above ...
 peer: base
 	(cd ${TOP}; \
-         $(DOCKER) build -t ${FPC_PEER_DOCKER_NAMESPACE}\
+         $(DOCKER) build $(DOCKER_BUILD_OPTS) -t ${FPC_PEER_DOCKER_NAMESPACE}\
          -f utils/docker/peer/Dockerfile\
          --build-arg FPC_REPO_URL=file:///tmp/build-src/.git\
          --build-arg FPC_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD)\
          . )
 
 dev: base
-	$(DOCKER) build -t $(FPC_DOCKER_NAMESPACE)-dev $(DOCKER_DEV_BUILD_OPTS) dev
-
-run: dev
-	$(DOCKER) run $(DOCKER_DEV_RUN_OPTS) -it $(FPC_DOCKER_NAMESPACE)-dev
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-dev $(DOCKER_DEV_BUILD_OPTS) dev
 
 cc-builder: dev
-	$(DOCKER) build -t $(FPC_DOCKER_NAMESPACE)-cc-builder cc-builder
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-cc-builder cc-builder
+


### PR DESCRIPTION
Primarily, this pr adds 
- automates previously required manual fabric binary download and docker container building into our network scripts (as part of that also fixes a bug which so far prevented the scenario script in travis to properly execute the demo scenario and hence validate the chaincode ..
- make improvements which allow a "deep" clean (via target "clobber") removing also all self-built docker images and some options to force rebuilding docker images during make (define FORCE_REBUILD when calling make), also some proxy related temporary improvements