### PR TITLE
UI event-based updates auction status

### DIFF
--- a/demo/client/frontend/src/App.vue
+++ b/demo/client/frontend/src/App.vue
@@ -26,6 +26,7 @@ export default {
 
   methods: {
     ...mapActions({
+      updateAuction: "auction/UPDATE_STATUS",
       fetchState: "ledger/fetchState",
       newTransactionEvent: "ledger/newTransactionEvent"
     })
@@ -48,6 +49,7 @@ export default {
       } else {
         that.newTransactionEvent(event);
         that.fetchState();
+        that.updateAuction(1);
       }
     });
 

--- a/demo/client/frontend/src/components/AuctionDetails.vue
+++ b/demo/client/frontend/src/components/AuctionDetails.vue
@@ -251,6 +251,7 @@ export default {
   computed: {
     ...mapState({
       auction: state => state.auction,
+      auctionState: state => state.auction.state,
       isAuctioneer: state => state.auth.role === "auction.auctioneer",
       isOpen: state => state.auction.roundActive
     }),
@@ -330,6 +331,16 @@ export default {
         );
         return container;
       });
+    }
+  },
+
+  watch: {
+    // whenever question changes, this function will run
+    // eslint-disable-next-line no-unused-vars
+    auctionState: function(newState, oldState) {
+      if (newState === "done") {
+        this.fetchAssignmetresults(1).catch(err => console.log(err));
+      }
     }
   },
 

--- a/demo/client/frontend/src/components/Bidding/ClockBidding.vue
+++ b/demo/client/frontend/src/components/Bidding/ClockBidding.vue
@@ -134,6 +134,10 @@ SPDX-License-Identifier: Apache-2.0
                   {{ props.item.channels.length }}
                 </template>
 
+                <template v-slot:item.demand="props">
+                  {{ props.item.demand || 0 }}
+                </template>
+
                 <template v-slot:item.clockPrice="props">
                   $ {{ props.item.clockPrice }}
                 </template>
@@ -144,7 +148,7 @@ SPDX-License-Identifier: Apache-2.0
                     large
                     @save="save"
                   >
-                    <div>{{ props.item.price }}</div>
+                    <div>$ {{ props.item.price || 0 }}</div>
                     <template v-slot:input>
                       <div class="mt-4 title">Update bid price</div>
                     </template>

--- a/demo/client/frontend/src/store/modules/auction.js
+++ b/demo/client/frontend/src/store/modules/auction.js
@@ -58,6 +58,14 @@ const actions = {
       );
   },
 
+  UPDATE_STATUS({ commit }, auction_id) {
+    auction_id = { auctionId: auction_id };
+    return auction
+      .getAuctionStatus(auction_id)
+      .then(resp => helpers.checkStatus(resp.data))
+      .then(auctionStatus => commit("SET_STATUS", auctionStatus));
+  },
+
   END_ROUND({ commit }, auction_id) {
     auction_id = { auctionId: auction_id };
     return auction


### PR DESCRIPTION
When UI event receives event notification from background,
getAuctionStatus is triggered; also when the UI detects auction state
change to "done", getAssignmentResults is called.

In ClockBidding view missing values are now displayed as 0 value.

Signed-off-by: bur <bur@zurich.ibm.com>