### PR TITLE
Add (randomized) delay and mock-reset option to scenario script

### DIFF
--- a/demo/client/scripting/scenario-run.sh
+++ b/demo/client/scripting/scenario-run.sh
@@ -16,7 +16,7 @@ TEARDOWN_CMD="${FPC_PATH}"/demo/scripts/teardown.sh
 
 
 help() {
-    echo "$(basename $0) [--help|-h|-?] [--bootstrap|-b] [--dry-run|-d] [--non-interactive|-n] <script-file>
+    echo "$(basename $0) [--help|-h|-?] [--bootstrap|-b] [--dry-run|-d] [--non-interactive|-n] [--skip-delay|-s] [--mock-reset|-r] <script-file>
     Run the demo scenario codified in the passed script file.
     - If you pass option --bootstrap, it will also first bring up an FPC network
       and tear it down at the end; otherwise it assumes you have already
@@ -26,30 +26,39 @@ help() {
     - option --non-interactive/-n will case _all_ requests to be submited even
       requests from submit_manual.  This allows you to easily validate all
       json files, even when some steps would be manual in an actual scenario
+    - option --skip-delay/-s allows you ignore all delays to speed-up demo
+    - option --mock-reset/-r will try reset the mock-server at the beginning
+      (obviously, this won't work if you run against the fabric-gateway backend;
+       to achieve the equivalent for fabric-gateway, use option --bootstrap)
 "
 }
 
 # argument handling
 # - defaults
-typeset -i bootstrap=0
+bootstrap=false
+mock_reset=false
 while [[ $# > 0 ]] && [[ $1 =~ "-" ]];
 do
     opt=$1
     case $opt in
         --bootstrap|-b)
-	    bootstrap=1
+	    bootstrap=true
 	    ;;
 
-        --bootstrap|-b)
-	    bootstrap=1
+        --skip-delay|-s)
+	    skip_delay=true
 	    ;;
 
 	--dry-run|-d)
-	    dry_run=1
+	    dry_run=true
 	    ;;
 
 	--non-interactive|-n)
-	    non_interactive=1
+	    non_interactive=true
+	    ;;
+
+	--mock-reset|-r)
+	    mock_reset=true
 	    ;;
 
         --help|-h|-\?)
@@ -64,27 +73,35 @@ do
     shift # past argument or value
 done
 if [ $# -ne 1 ]; then
-            echo "ERROR: missing script file."
-	    help
-	    exit 1
+    echo "ERROR: missing script file."
+    help
+    exit 1
 fi
 scriptFile=$1
 if [ ! -f $scriptFile  ]; then
-            echo "ERROR: missing script file $scriptFile"
-	    help
-	    exit 1
+    echo "ERROR: missing script file $scriptFile"
+    help
+    exit 1
+fi
+if ${bootstrap} && ${mock_reset}; then
+    echo "ERROR: bootstrap and mock-reset options are mutually exclusive"
+    help
+    exit 1
 fi
 
-
 # (optional) which also sets up the whole fabric network
-if [ ${bootstrap} -eq 1 ]; then
+if ${bootstrap}; then
     $START_CMD || die "could not bring up fpc network"
     sleep 10 # give some time for the client infrastructure to start ...
+fi
+
+if ${mock_reset}; then
+    curl -X GET "http://localhost:3000/api/demo/start" || die "could not reset mock server"
 fi
 
 # execute the script
 . "${scriptFile}" || die "executing script '${scriptFile}' failed ..."
 
-if [ ${bootstrap} -eq 1 ]; then
+if ${bootstrap}; then
     $TEARDOWN_CMD || die "could not bring down fpc network"
 fi

--- a/demo/scenario/script
+++ b/demo/scenario/script
@@ -16,33 +16,53 @@ wait "Auction Created. Maybe show auctioneers auction view?  (Hit any key to con
 
 # clock-rounds ...
 submit Auctioneer1 startNextRound
+delay 2 randomized
+
 submit A-Telecom submitClockBid
+delay 2 randomized
 submit B-Net submitClockBid
+delay 2 randomized
 submit C-Mobile submitClockBid
+delay 2 randomized
 submit Auctioneer1 endRound
 
 say "End Round 1"
+delay 1 randomized
 
 submit Auctioneer1 startNextRound
+delay 2 randomized
 submit A-Telecom submitClockBid
+delay 2 randomized
 submit B-Net submitClockBid
+delay 2 randomized
 submit C-Mobile submitClockBid
+delay 2 randomized
 submit Auctioneer1 endRound
 
 yell "End Round 2"
+delay 1 randomized
 
 submit Auctioneer1 startNextRound
+delay 2 randomized
 submit_manual C-Mobile submitClockBid
+delay 2 randomized
 submit A-Telecom submitClockBid
+delay 2 randomized
 submit B-Net submitClockBid
+delay 2 randomized
 submit Auctioneer1 endRound
 
 say "End Round 3"
+delay 1 randomized
 
 submit Auctioneer1 startNextRound
+delay 2 randomized
 submit A-Telecom submitClockBid
+delay 2 randomized
 submit B-Net submitClockBid
+delay 2 randomized
 submit C-Mobile submitClockBid
+delay 2 randomized
 submit Auctioneer1 endRound
 
 wait "End Round 4 - Clock Phase Complete  (Hit any key to continue)"


### PR DESCRIPTION
- Adds a new verb `delay` to the demo scripting DSL which allows adding  (optionally randomized) sleeps to the script. These delays can be ignored with `--skip-delay` option for `scenario-run.sh`, e.g., to not add additionally slow-down when using with (slower) fabric-gateway.  Note, right now i just put randomized 2 sleep between sleeps, for good values with have to fine-tune in live test when running against the script (and best tuned by whom will do the demo)
- add a `--mock-reset` option to scenario-run which will reset the mock-server state before starting the scenario so the created auction id is guaranteed to be 1.  Note, though, the tx-viewer will _not_ reset the view/remove the transactions unless you refresh the whole browser window (that said, seeing tx from old sessions might not necessarily hurt?)