### PR TITLE
WIP: Docker-compose extensions

### DIFF
--- a/demo/chaincode/fpc/Makefile
+++ b/demo/chaincode/fpc/Makefile
@@ -30,7 +30,7 @@ clean:
 
 docker-build: clean
 	$(DOCKER) image inspect hyperledger/fabric-private-chaincode-cc-builder > /dev/null 2>&1 || { cd $(TOP)/utils/docker && make cc-builder; }
-	$(DOCKER) run -u $$(id -u):$$(id -g) -v ${PWD}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc -w /project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc hyperledger/fabric-private-chaincode-cc-builder sh -c make build
+	$(DOCKER) run -u $$(id -u):$$(id -g) -v ${PWD}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc -w /project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc hyperledger/fabric-private-chaincode-cc-builder sh -c 'make build'
 
 test: build
 	./test.sh

--- a/demo/client/scripting/scenario-run.sh
+++ b/demo/client/scripting/scenario-run.sh
@@ -91,7 +91,7 @@ fi
 
 # (optional) which also sets up the whole fabric network
 if ${bootstrap}; then
-    $START_CMD || die "could not bring up fpc network"
+    $START_CMD --build-cc || die "could not bring up fpc network"
     sleep 10 # give some time for the client infrastructure to start ...
 fi
 

--- a/utils/docker-compose/network-config/docker-compose-couchdb.yml
+++ b/utils/docker-compose/network-config/docker-compose-couchdb.yml
@@ -1,0 +1,36 @@
+# Copyright Intel Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# docker-compose-"delta" to docker-compose.yaml to run peer with couchdb
+
+version: '2'
+
+services:
+  couchdb0:
+    container_name: couchdb0
+    image: couchdb:2.3
+    # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
+    # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
+    environment:
+      - COUCHDB_USER=
+      - COUCHDB_PASSWORD=
+    # Comment/Uncomment the port mapping if you want to hide/expose the CouchDB service,
+    # for example map it to utilize Fauxton User Interface in dev environments.
+    ports:
+      - "5984:5984"
+    networks:
+      - basic
+
+  peer0.org1.example.com:
+    environment:
+      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=couchdb0:5984
+      # The CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME and CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD
+      # provide the credentials for ledger to connect to CouchDB.  The username and password must
+      # match the username and password set for the associated CouchDB.
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=
+    depends_on:
+      - couchdb0
+

--- a/utils/docker-compose/network-config/docker-compose-explorer.yml
+++ b/utils/docker-compose/network-config/docker-compose-explorer.yml
@@ -1,0 +1,51 @@
+# Copyright IBM Corp. All Rights Reserved.
+# Copyright Intel Corp. All Rights Reserved.
+
+# Note: this is a tweaked version of './docker-compose.yaml' in hyperledger/blockchain-explorer.git
+
+# SPDX-License-Identifier: Apache-2.0
+version: '2'
+
+volumes:
+  pgdata:
+  walletstore:
+
+networks:
+   basic:
+
+services:
+  explorerdb.example.com:
+    image: hyperledger/explorer-db:latest
+    container_name: explorerdb.example.com
+    hostname: explorerdb.example.com
+    environment:
+      - DATABASE_DATABASE=fabricexplorer
+      - DATABASE_USERNAME=hppoc
+      - DATABASE_PASSWORD=password
+    volumes:
+      # Note: below is a clone of 'app/persistence/fabric/postgreSQL/db/createdb.sh' from the blockchain-explorer repo
+      - ./explorer/createdb.sh:/docker-entrypoint-initdb.d/createdb.sh
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - basic
+
+  explorer.example.com:
+    image: hyperledger/explorer:latest
+    container_name: explorer.example.com
+    hostname: explorer.example.com
+    environment:
+      - DATABASE_HOST=explorerdb.example.com
+      - DATABASE_USERNAME=hppoc
+      - DATABASE_PASSWD=password
+      - DISCOVERY_AS_LOCALHOST=false
+    volumes:
+      - ./explorer/config.json:/opt/explorer/app/platform/fabric/config.json
+      - ./explorer/connection-profile:/opt/explorer/app/platform/fabric/connection-profile
+      - ./crypto-config:/tmp/crypto
+      - walletstore:/opt/wallet
+    # Note: below 30 sec sleep might be overly conservative but the original 16 was not enough in VirtualBox ...
+    command: sh -c "sleep 30 && node /opt/explorer/main.js && tail -f /dev/null"
+    ports:
+      - 8090:8080
+    networks:
+      - basic

--- a/utils/docker-compose/network-config/explorer/config.json
+++ b/utils/docker-compose/network-config/explorer/config.json
@@ -1,0 +1,9 @@
+{
+	"network-configs": {
+		"basic-network": {
+			"name": "basic-network",
+			"profile": "./connection-profile/basic-network.json"
+		}
+	},
+	"license": "Apache-2.0"
+}

--- a/utils/docker-compose/network-config/explorer/connection-profile/basic-network.json
+++ b/utils/docker-compose/network-config/explorer/connection-profile/basic-network.json
@@ -1,0 +1,59 @@
+{
+	"name": "first-network",
+	"version": "1.0.0",
+	"client": {
+		"tlsEnable": false,
+		"adminUser": "admin",
+		"adminPassword": "adminpw",
+		"enableAuthentication": false,
+		"organization": "Org1MSP",
+		"connection": {
+			"timeout": {
+				"peer": {
+					"endorser": "300"
+				},
+				"orderer": "300"
+			}
+		}
+	},
+	"channels": {
+		"mychannel": {
+			"peers": {
+				"peer0.org1.example.com": {}
+			},
+			"connection": {
+				"timeout": {
+					"peer": {
+						"endorser": "6000",
+						"eventHub": "6000",
+						"eventReg": "6000"
+					}
+				}
+			}
+		}
+	},
+	"organizations": {
+		"Org1MSP": {
+			"mspid": "Org1MSP",
+			"fullpath": true,
+			"adminPrivateKey": {
+				"path": "/tmp/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/admin_sk"
+			},
+			"signedCert": {
+				"path": "/tmp/crypto/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem"
+			}
+		}
+	},
+	"peers": {
+		"peer0.org1.example.com": {
+			"tlsCACerts": {
+				"path": "/tmp/crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt"
+			},
+			"url": "grpc://peer0.org1.example.com:7051",
+			"eventUrl": "grpc://peer0.org1.example.com:7053",
+			"grpcOptions": {
+				"ssl-target-name-override": "peer0.org1.example.com"
+			}
+		}
+	}
+}

--- a/utils/docker-compose/network-config/explorer/createdb.sh
+++ b/utils/docker-compose/network-config/explorer/createdb.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+
+echo "Copying ENV variables into temp file..."
+node processenv.js
+if [ $( jq .DATABASE_USERNAME /tmp/process.env.json) == null ]; then
+  export USER=$( jq .postgreSQL.username ../../../../explorerconfig.json )
+else
+  export USER=$( jq .DATABASE_USERNAME /tmp/process.env.json)
+fi
+if [ $(jq .DATABASE_DATABASE /tmp/process.env.json) == null ]; then
+  export DATABASE=$(jq .postgreSQL.database ../../../../explorerconfig.json )
+else
+  export DATABASE=$(jq .DATABASE_DATABASE /tmp/process.env.json)
+fi
+if [ $(jq .DATABASE_PASSWORD /tmp/process.env.json) == null ]; then
+  export PASSWD=$(jq .postgreSQL.passwd ../../../../explorerconfig.json | sed "y/\"/'/")
+else
+  export PASSWD=$(jq .DATABASE_PASSWORD /tmp/process.env.json |  sed "y/\"/'/")
+fi
+echo "USER=${USER}"
+echo "DATABASE=${DATABASE}"
+echo "PASSWD=${PASSWD}"
+if [ -f /tmp/process.env.json ] ; then
+    rm /tmp/process.env.json
+fi
+echo "Executing SQL scripts, OS="$OSTYPE
+
+#support for OS
+case $OSTYPE in
+darwin*) psql postgres -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
+psql postgres -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql ;;
+linux*)
+if [ $(id -un) = 'postgres' ]; then
+  PSQL="psql"
+else
+  PSQL="sudo -u postgres psql"
+fi;
+${PSQL} -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./explorerpg.sql ;
+${PSQL} -v dbname=$DATABASE -v user=$USER -v passwd=$PASSWD -f ./updatepg.sql ;;
+esac
+
+

--- a/utils/docker-compose/scripts/generate.sh
+++ b/utils/docker-compose/scripts/generate.sh
@@ -34,6 +34,7 @@ if [ "$?" -ne 0 ]; then
 fi
 
 mv ${FABRIC_CFG_PATH}/crypto-config/peerOrganizations/org1.example.com/ca/*_sk ${FABRIC_CFG_PATH}/crypto-config/peerOrganizations/org1.example.com/ca/ca.org1.example.com_sk
+mv ${FABRIC_CFG_PATH}/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/*_sk ${FABRIC_CFG_PATH}/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/admin_sk
 
 #generate channel configuration transaction
 configtxgen -profile OneOrgChannel -outputCreateChannelTx ${FABRIC_CFG_PATH}/config/channel.tx -channelID ${CHANNEL_NAME}

--- a/utils/docker-compose/scripts/lib/common.sh
+++ b/utils/docker-compose/scripts/lib/common.sh
@@ -19,9 +19,10 @@ export DOCKER_COMPOSE_OPTS=${DOCKER_COMPOSE_OPTS:=}
 # don't rewrite paths for Windows Git Bash users
 export MSYS_NO_PATHCONV=1
 
-# default configs
+# defaults for services used
 export USE_FPC=${USE_FPC:=true} 
 export USE_COUCHDB=${USE_COUCHDB:=false} 
+export USE_EXPLORER=${USE_EXPLORER:=false} 
 
 if [[ $USE_FPC = false ]]; then
     export FPC_CONFIG=""
@@ -41,5 +42,8 @@ export DOCKER_COMPOSE_CMD="docker-compose"
 export DOCKER_COMPOSE_OPTS="${DOCKER_COMPOSE_OPTS:+${DOCKER_COMPOSE_OPTS} }-f ${NETWORK_CONFIG}/docker-compose.yml"
 if $USE_COUCHDB; then
 	export DOCKER_COMPOSE_OPTS="${DOCKER_COMPOSE_OPTS} -f ${NETWORK_CONFIG}/docker-compose-couchdb.yml"
+fi
+if $USE_EXPLORER; then
+	export DOCKER_COMPOSE_OPTS="${DOCKER_COMPOSE_OPTS} -f ${NETWORK_CONFIG}/docker-compose-explorer.yml"
 fi
 export DOCKER_COMPOSE="${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTS}"

--- a/utils/docker-compose/scripts/lib/common.sh
+++ b/utils/docker-compose/scripts/lib/common.sh
@@ -19,6 +19,10 @@ export DOCKER_COMPOSE_OPTS=${DOCKER_COMPOSE_OPTS:=}
 # don't rewrite paths for Windows Git Bash users
 export MSYS_NO_PATHCONV=1
 
+# default configs
+export USE_FPC=${USE_FPC:=true} 
+export USE_COUCHDB=${USE_COUCHDB:=false} 
+
 if [[ $USE_FPC = false ]]; then
     export FPC_CONFIG=""
     export PEER_CMD="peer"
@@ -35,4 +39,7 @@ export COMPOSE_PROJECT_NAME="fabric$(echo ${FPC_CONFIG} | sed 's/[^a-zA-Z0-9]//g
 
 export DOCKER_COMPOSE_CMD="docker-compose"
 export DOCKER_COMPOSE_OPTS="${DOCKER_COMPOSE_OPTS:+${DOCKER_COMPOSE_OPTS} }-f ${NETWORK_CONFIG}/docker-compose.yml"
+if $USE_COUCHDB; then
+	export DOCKER_COMPOSE_OPTS="${DOCKER_COMPOSE_OPTS} -f ${NETWORK_CONFIG}/docker-compose-couchdb.yml"
+fi
 export DOCKER_COMPOSE="${DOCKER_COMPOSE_CMD} ${DOCKER_COMPOSE_OPTS}"

--- a/utils/docker-compose/scripts/start.sh
+++ b/utils/docker-compose/scripts/start.sh
@@ -53,7 +53,7 @@ export \\
 EOF
 
 ${DOCKER_COMPOSE} down
-${DOCKER_COMPOSE} up -d orderer.example.com peer0.org1.example.com ca.example.com
+${DOCKER_COMPOSE} up -d
 ${DOCKER_COMPOSE} ps
 
 # wait for Hyperledger Fabric to start


### PR DESCRIPTION
This PR adds following additions to the fabric network scripts in `utils/docker-compose/scripts` (and transitively to the scripts in `demo/scripts`):
- running the peer using CouchDB and its graphical (state) viewer on http://localhost:5984/  when the environment variable `USE_COUCHDB` is defined.  Note: all state has mime-type octet-string, so you will have to download first the state (via "download attachment" menu) and then open that file in an editor to show the cleartext  or base64-encoded encrypted data.
- run explorer on http://localhost:8090/ when the environment variable `USE_EXPLORER` is defined.
- small bug-fix in cc-builder and a bit more robust `scenario-run.sh --bootstrap` ..