### PR TITLE
make mock-server safe for concurrent requests

### DIFF
--- a/demo/client/backend/mock/mock_stub_wrapper.go
+++ b/demo/client/backend/mock/mock_stub_wrapper.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/demo/client/backend/mock/api"
 
@@ -33,6 +34,7 @@ type Transaction struct {
 }
 
 type MockStubWrapper struct {
+	sync.RWMutex
 	MockStub     *shim.MockStub
 	Creator      string
 	Seq          int
@@ -46,7 +48,7 @@ func NewWrapper(name string, cc shim.Chaincode, notifier *Notifier) *MockStubWra
 	return &MockStubWrapper{MockStub: stub, Seq: 0, notifier: notifier, cc: cc}
 }
 
-func Destroy(m *MockStubWrapper) {
+func DestroyChaincode(m *MockStubWrapper) {
 	if e, ok := m.cc.(*ecc.EnclaveChaincode); ok {
 		e.Destroy()
 	}


### PR DESCRIPTION
Should address issue #227 

BTW: part of the tests i also tried to narrow down steps/clicks necessary for demo script.  If for C-mobile you just set qty of second territory from 5 to 4 but leave original prices and the qty of first one (contrary to what script currently suggests), the auction still will properly finish in round 4!  I.e., you need only one field modification and the two submits as actions to complete the demo in the ui ...