### PR TITLE
chaincode bug fix, and small script update

### DIFF
--- a/demo/chaincode/fpc/evaluate.cpp
+++ b/demo/chaincode/fpc/evaluate.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <cmath>
 #include "auction-state.h"
 #include "common.h"
 #include "shim.h"  // get_random_bytes
@@ -215,8 +216,8 @@ void ClockAuction::DynamicAuctionState::processRegularRoundBids(
             // compute price point
             double minPrice = postedPrice_[clockRound_ - 1][eBid.territoryIndex];
             double clockPrice = clockPrice_[clockRound_][eBid.territoryIndex];
-            double pp = (eBid.demand.price_ - minPrice) / (clockPrice - minPrice);
-            eBid.pricePoint = (uint32_t)pp;
+            double pp = (eBid.demand.price_ - minPrice) / (clockPrice - minPrice) * (100.0);
+            eBid.pricePoint = std::lround(pp);
 
             // compute random value for breaking ties
             if (get_random_bytes((uint8_t*)&eBid.randomValue, sizeof(eBid.randomValue)) != 0)

--- a/demo/scenario/C-Mobile.submitClockBid.3.json
+++ b/demo/scenario/C-Mobile.submitClockBid.3.json
@@ -4,12 +4,12 @@
     "bids": [
 	{
 	    "terId": 1,
-	    "qty": 2,
-	    "price":14000
+	    "qty": 1,
+	    "price":12000
 	},{
 	    "terId": 2,
-	    "qty": 4,
-	    "price":5000
+	    "qty": 5,
+	    "price":4800
 	}
     ]
 }

--- a/demo/scenario/script
+++ b/demo/scenario/script
@@ -63,9 +63,9 @@ submit B-Net submitClockBid
 delay 2 randomized
 submit C-Mobile submitClockBid
 delay 2 randomized
-submit Auctioneer1 endRound
+submit_manual Auctioneer1 endRound
 
-wait "End Round 4 - Clock Phase Complete  (Hit any key to continue)"
+say "End Round 4 - Clock Phase Complete"
 
 # assignment rounds ...
 # bidding not yet implemented, add here once done and


### PR DESCRIPTION
Two contributions:
* bug fix: in the chaincode, the price-point was incorrectly computed as a `double` between 0-1 and rounded to an `integer`, so always `0`. This resulted in a non-deterministic order of the queue. In the case of multiple bids (say two) that decrease demand, the last bid that made demand match supply would have determined the posted price. Being in random order, the posted price could be set either to match the first or the second bid. In the current code base, this can later induce an error in the demo script when, once the lower posted price is randomly chosen (say the first one, and determines the lower clock price), a bidder makes a bid with a price that is higher than the clock price -- this was not a problem when the second (higher) posted price was the outcome of the random choice.
* script update: first, the manual bid of C-Mobile now only requires to set the quantity of the first territory to 1; second, the final `endRound` (which closes the auction) must now be performed manually. 