### PR TITLE
Support for SGX HW mode and proxies in docker(-compose) and related network-mgmt scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - SGX_MODE=SIM
     - SGX_SDK=/opt/intel/sgxsdk
     # SGX SSL
-    - OPENSSL=1.1.0j
+    - OPENSSL_VERSION=1.1.0j
     - SGXSSL_VERSION=v2.4.1
     - SGXSSL=/opt/intel/sgxssl
     # NANOPB
@@ -51,8 +51,8 @@ before_install:
   - chmod +x ${SGX_SDK_BIN}
   - sudo sh -c "echo 'yes' | ./${SGX_SDK_BIN}"; popd
   # SGX SSL
-  - pushd $HOME; git clone --branch $SGXSSL_VERSION https://github.com/intel/intel-sgx-ssl.git
-  - wget https://www.openssl.org/source/openssl-$OPENSSL.tar.gz; mv openssl-$OPENSSL.tar.gz intel-sgx-ssl/openssl_source
+  - pushd $HOME; git clone --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git
+  - wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz; mv openssl-${OPENSSL_VERSION}.tar.gz intel-sgx-ssl/openssl_source
   - cd intel-sgx-ssl/Linux; make SGX_MODE=SIM DESTDIR=$SGXSSL all test
   - cd intel-sgx-ssl/Linux; make install; popd
   # NANOPB

--- a/README.md
+++ b/README.md
@@ -110,34 +110,41 @@ your [development environment](https://hyperledger-fabric.readthedocs.io/en/rele
 
 Moreover, we assume that you are familiar with the Intel SGX SDK.
 
-### Intel SGX SDK and SSL
+### Intel SGX
 
-Fabric Private Chaincode requires the Intel [SGX SDK](https://github.com/intel/linux-sgx) and
-[SGX SSL](https://github.com/intel/intel-sgx-ssl) to build the main components of our framework and to develop and build
-your first private chaincode.     
+To run Fabric Private Chaincode in secure mode, you need an SGX-enabled
+hardware as well corresponding OS support.  However, even if you don't
+have SGX hardware available, you still can run FPC in simulation mode by
+setting `SGX_MODE=SIM` in your environment.
 
-Install the Intel SGX software stack for Linux (including the SGX driver, the SGX SDK, and the SGX Platform Software
-(PSW)) by following the official [documentation](https://github.com/intel/linux-sgx). Please make sure that you use the
-SDK version as denoted above in the list of requirements. 
-
-Moreover, if you don't have SGX hardware available you can also install the SGX SDK only and use simulation mode by
-setting `SGX_MODE=SIM` in your environment. In this case, also make sure that simulation mode is set when building
-and installing [SGX SSL](https://github.com/intel/intel-sgx-ssl#available-make-flags). Note that the simulation mode is
-for developing purpose only and does not provide any security guarantees. 
-
-Once you have installed the SGX SDK and SSL for SGX SDK please double check that ``SGX_SDK`` and ``SGX_SSL`` variables
-are set correctly in your environment. 
+Note that the simulation mode is for developing purpose only and does
+not provide any security guarantees.
 
 Notice: by default the project builds in hardware-mode SGX, ``SGX_MODE=HW`` as defined in `<absolute-project-path>/fabric-private-chaincode/config.mk` and you can
 explicitly opt for building in simulation-mode SGX, ``SGX_MODE=SIM``. In order to set non-default values for install
 location, or for building in simulation-mode SGX, you can create the file `<absolute-project-path>/fabric-private-chaincode/config.override.mk` and override the default
 values by defining the corresponding environment variable.
 
-#### Register with Intel Attestation Service (IAS) if using SGX_MODE=HW
+If you run SGX in __simulation mode only__, you can skip below
+sections and jump right away to [Setup your Development
+Environment](#setup-your-development-environment).
 
-We use Intel's Attestation Service to perform attestation with chaincode enclaves. If you run SGX in __simulation mode__
-only, you can skip this section and come back when you want setup with SGX hardware-mode.
- 
+Note that you can always come back here when you want a setup with SGX
+hardware-mode later after having tested with simulation mode.
+
+
+#### Install SGX Operation System Support
+
+Install the Intel SGX software stack for Linux (including the SGX
+driver and the SGX Platform Software (PSW)) by following the official
+[documentation](https://github.com/intel/linux-sgx).
+
+
+#### Register with Intel Attestation Service (IAS)
+
+We currently support EPID-based attestation and  use the Intel's
+Attestation Service to perform attestation with chaincode enclaves.
+
 What you need:
 
 * a Service Provider ID (SPID)
@@ -213,7 +220,7 @@ Optional: to do a clean build do the following within the container
 <docker-root>:project/src/github.com/hyperledger-labs/fabric-private-chaincode# make build
 ```
 Now you are ready to start development.  Go to the [Develop Your First Private Chaincode
-](#developing-your-first-private-chaincode) section.
+](#your-first-private-chaincode) section.
 
 ### Option 2: Setting up your system to do local development
 
@@ -242,6 +249,26 @@ Make sure that you have the following required dependencies installed:
 * Clang-format 6.x or higher
 
 * [PlantUML](http://plantuml.com/) including Graphviz (for building documentation only) 
+
+#### Intel SGX SDK and SSL
+
+Fabric Private Chaincode requires the Intel [SGX SDK](https://github.com/intel/linux-sgx) and
+[SGX SSL](https://github.com/intel/intel-sgx-ssl) to build the main components of our framework and to develop and build
+your first private chaincode.     
+
+Install the Intel SGX software stack for Linux by following the
+official [documentation](https://github.com/intel/linux-sgx). Please make sure that you use the
+SDK version as denoted above in the list of requirements. 
+
+For SGX SSL, just follow the instructions on the [corresponding
+github page](https://github.com/intel/intel-sgx-Sal). In case you are
+building for simulation mode only and do not have HW support, you
+might also want to make sure that [simulation mode is set](https://github.com/intel/intel-sgx-ssl#available-make-flags)
+when building and installing it.
+
+Once you have installed the SGX SDK and SSL for SGX SDK please double check that ``SGX_SDK`` and ``SGX_SSL`` variables
+are set correctly in your environment. 
+
 
 #### Protocol Buffers
 
@@ -330,14 +357,23 @@ Building the project requires docker. We do not recommend to run `sudo make`
 to resolve issues with mis-configured docker environments as this also changes your `$GOPATH`. Please see hints on
 [docker](#docker) installation above.
 
+The makefiles do not ensure that docker files are always rebuild to
+match the latest version of the code in the repo.  If you suspect you
+have an issue with outdated docker images, you can run `make clobber
+build` which forces a rebuild.  It also ensures that all other
+downlad, build or test artifacts are scrubbed from your repo and might
+help overcoming other problems. Be advised that that the rebuild can
+take a fair amount of time.
+
 ##### Working from behind a proxy
 
 The current code should work behind a proxy assuming
   * you have defined the corresponding environment variables (i.e.,
-  `http_proxy`, `https_proxy` and, potentially, `no_proxy`) properly
-  defined
+    `http_proxy`, `https_proxy` and, potentially, `no_proxy`) properly, and
   * docker (daemon & client) is properly set up for proxies as
-    outlined in the Docker documentation for [clients](https://docs.docker.com/network/proxy/) and the [daemon](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy).
+    outlined in the Docker documentation for
+    [clients](https://docs.docker.com/network/proxy/) and the
+    [daemon](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy).
 If you run Ubuntu 18.04, make sure you run docker 18.09 or later. Otherwise you will run into problems with DNS resolution inside the container.
 
 You will also require a recent version of docker-compose. In particular, the docker-compose from ubuntu 18.04
@@ -412,12 +448,14 @@ will create dummy files. In case you switch later to HW mode without
 configuring these files correctly for HW mode, this will result in
 above error.
 
-## Developing your first private chaincode
+## Developing with Fabric Private Chaincode
 
+### Your first private chaincode
 Create, build and test your first private chaincode with this [tutorial](examples/README.md).
 
 ### A Complete Application
 For an end-to-end application demonstrating the potential of FPC, check out our [Clock Auction Demo Application](demo/README.md).
+
 
 ## Documentation
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -53,15 +53,20 @@ Below is the script's help text.
 ```
 startFPCAuctionNetwork.sh [options]
 
-   This script, by default, will teardown possible previous iterations of this demo, generate new
-   crypto material for the network, start an FPC network as defined in $FPC_PATH/utils/docker-compose,
-   install the mock golang auction chaincode($FPC_PATH/demo/chaincode/golang), install the FPC
-   compliant auction chaincode($FPC_PATH/demo/chaincode/fpc), register auction users, and bring up
-   both the fabric-gatway & frontend UI. If the fabric-gateway and frontend UI docker images have
-   not previously been built it will build them, otherwise the script will reuse the images already
-   existing. The FPC chaincode will not be built unless specified by the flag --build-cc.  
-   By calling the script with both build options, you will be able to run the demo without having
-   to build the whole FPC project (e.g., by calling `make` in $FPC_PATH).
+   This script, by default, will teardown possible previous iterations of this
+   demo, generate new crypto material for the network, start an FPC network as
+   defined in \$FPC_PATH/utils/docker-compose, install the mock golang auction
+   chaincode(\$FPC_PATH/demo/chaincode/golang), install the FPC compliant
+   auction chaincode(\$FPC_PATH/demo/chaincode/fpc), register auction users,
+   and bring up both the fabric-gatway & frontend UI.
+
+   If the fabric-gateway and frontend UI docker images have not previously been
+   built it will build them, otherwise the script will reuse the images already
+   existing.  You can force a rebuild, though, by specifying the flag
+   --build-client.  The FPC chaincode will not be built unless specified by the
+   flag --build-cc.  By calling the script with both build options, you will be
+   able to run the demo without having to build the whole FPC project (e.g., by
+   calling `make` in $FPC_PATH).
 
    options:
        --build-cc:
@@ -95,8 +100,10 @@ will delete all the unused volumes and chaincode images.
 
 ### Scripting
 
-To facilitate  demonstrations and also to help in testing, you can specify a scenario script defining the
-actions of the different parties and execute it using the command [scenario-run.sh](client/scripting/scenario-run.sh).  
+To facilitate demonstrations and also to help in testing, you can specify with a simple
+[DSL](client/scripting/lib/dsl.sh) a scenario script defining the
+actions of the different parties and execute it using the command
+[scenario-run.sh](client/scripting/scenario-run.sh).  
 Below is the script's help text.
 ```
 scenario-run.sh [--help|-h|-?] [--bootstrap|-b] [--dry-run|-d] [--non-interactive|-n] [--skip-delay|-s] [--mock-reset|-r] <script-file>

--- a/demo/README.md
+++ b/demo/README.md
@@ -45,8 +45,8 @@ FPC peer cli hides this name mapping, you will have to manually prefix the
 chaincode name in `config.json`, hence the default `ecc_auctioncc`.
 
 Both the frontend and fabric-gateway [expose ports](docker-compose.yml) and are
-accessible on the host machine. The frontend can be accessed at `localhost:5000`
-and the fabric-gateway can be accessed at `localhost:3000`.
+accessible on the host machine. The frontend can be accessed at [localhost:5000](http://localhost:5000)
+and the fabric-gateway can be accessed at [localhost:3000](http://localhost:3000).
 
 Below is the script's help text.
 
@@ -59,7 +59,9 @@ startFPCAuctionNetwork.sh [options]
    compliant auction chaincode($FPC_PATH/demo/chaincode/fpc), register auction users, and bring up
    both the fabric-gatway & frontend UI. If the fabric-gateway and frontend UI docker images have
    not previously been built it will build them, otherwise the script will reuse the images already
-   existing. The FPC chaincode will not be built unless specified by the flag --build-cc.
+   existing. The FPC chaincode will not be built unless specified by the flag --build-cc.  
+   By calling the script with both build options, you will be able to run the demo without having
+   to build the whole FPC project (e.g., by calling `make` in $FPC_PATH).
 
    options:
        --build-cc:
@@ -89,6 +91,31 @@ scripts/teardown.sh
 **NOTE** The script will run the [teardown script](../utils/docker-compose/scripts/teardown.sh)
 in the FPC Network scripts. If you run it with the `--clean-slate` flag the script
 will delete all the unused volumes and chaincode images.
+
+
+### Scripting
+
+To facilitate  demonstrations and also to help in testing, you can specify a scenario script defining the
+actions of the different parties and execute it using the command [scenario-run.sh](client/scripting/scenario-run.sh).  
+Below is the script's help text.
+```
+scenario-run.sh [--help|-h|-?] [--bootstrap|-b] [--dry-run|-d] [--non-interactive|-n] [--skip-delay|-s] [--mock-reset|-r] <script-file>
+    Run the demo scenario codified in the passed script file.
+    - If you pass option --bootstrap, it will also first bring up an FPC network
+      and tear it down at the end; otherwise it assumes you have already
+      a running setup ...
+    - option --dry-run/-d will just display all requests but not execute/submit
+      any of them
+    - option --non-interactive/-n will case _all_ requests to be submited even
+      requests from submit_manual.  This allows you to easily validate all
+      json files, even when some steps would be manual in an actual scenario
+    - option --skip-delay/-s allows you ignore all delays to speed-up demo
+    - option --mock-reset/-r will try reset the mock-server at the beginning
+      (obviously, this won't work if you run against the fabric-gateway backend;
+       to achieve the equivalent for fabric-gateway, use option --bootstrap)
+```
+
+An example of a scenario can be found in [demo/scenario](scenario).
 
 ## Manually Bring Up The Components
 

--- a/demo/chaincode/fpc/Makefile
+++ b/demo/chaincode/fpc/Makefile
@@ -28,9 +28,21 @@ build: $(BUILD_DIR)
 clean:
 	-rm -rf $(BUILD_DIR)
 
+
+HW_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)
+
+FPC_DOCKER_NAMESPACE := hyperledger/fabric-private-chaincode
+FPC_DOCKER_CC_BUILDER_NAME = $(FPC_DOCKER_NAMESPACE)-cc-builder$(HW_EXTENSION)
+
 docker-build: clean
-	$(DOCKER) image inspect hyperledger/fabric-private-chaincode-cc-builder > /dev/null 2>&1 || { cd $(TOP)/utils/docker && make cc-builder; }
-	$(DOCKER) run -u $$(id -u):$$(id -g) -v ${PWD}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc -w /project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc hyperledger/fabric-private-chaincode-cc-builder sh -c 'make build'
+	$(DOCKER) image inspect $(FPC_DOCKER_CC_BUILDER_NAME) > /dev/null 2>&1 \
+		|| { cd $(TOP)/utils/docker && make cc-builder; }
+	$(DOCKER) run \
+		-u $$(id -u):$$(id -g)\
+		-v ${PWD}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc\
+		-w /project/src/github.com/hyperledger-labs/fabric-private-chaincode/demo/chaincode/fpc\
+		$(FPC_DOCKER_CC_BUILDER_NAME)\
+		sh -c 'make build'
 
 test: build
 	./test.sh

--- a/demo/client/frontend/Makefile
+++ b/demo/client/frontend/Makefile
@@ -66,7 +66,9 @@ public/img/users/c-mobile.svg:
 
 
 clobber:
+	RUNNING_IMAGE=$$(${DOCKER} ps -q --filter ancestor=${DOCKER_IMAGE}); \
+	if [ ! -z "$${RUNNING_IMAGE}" ]; then ${DOCKER} kill $${RUNNING_IMAGE}; fi
 	IMAGE=$$(${DOCKER} images ${DOCKER_IMAGE} -q); \
-	if [ ! -z "$${IMAGE}" ]; then ${DOCKER} rmi ${IMAGE}; fi
+	if [ ! -z "$${IMAGE}" ]; then ${DOCKER} rmi -f $${IMAGE}; fi
 	# make clobber in demo/ also would take care but better safe than sorry
 	-$(RM) $(AVATAR_FILES)

--- a/demo/client/scripting/Makefile
+++ b/demo/client/scripting/Makefile
@@ -14,7 +14,7 @@ ${GO_CMDS}: ${GO_CMDS:=.go}
 	$(GO) build $@.go
 
 test: build
-	./scenario-run.sh	--bootstrap --non-interactive ../../scenario/script
+	./scenario-run.sh --bootstrap --non-interactive ../../scenario/script
 
 clean: 
 	$(GO) $@

--- a/demo/client/scripting/lib/dsl.sh
+++ b/demo/client/scripting/lib/dsl.sh
@@ -12,7 +12,10 @@
 
 CLI="${DEMO_CLIENT_SCRIPTS_DIR}/cli"
 
-
+if [ ! -x ${CLI} ]; then
+    # cli does not exist, try to build it
+    make -C ${DEMO_CLIENT_SCRIPTS_DIR} cli || die "command $LCI did not exist and could not be built"
+fi
 
 
 #  Simple "DSL" to script auction scenarios

--- a/demo/scripts/startFPCAuctionNetwork.sh
+++ b/demo/scripts/startFPCAuctionNetwork.sh
@@ -55,16 +55,18 @@ for var in "$@"; do
     shift
 done
 
-export DEMO_SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export FPC_PATH="${FPC_PATH:-${DEMO_SCRIPTS_DIR}/../..}"
-export DEMO_ROOT="${DEMO_SCRIPTS_DIR}/.."
+export DEMO_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export DEMO_ROOT="${DEMO_SCRIPT_DIR}/.."
+DEMO_DOCKER_COMPOSE=${DEMO_SCRIPT_DIR}/../docker-compose.yml
+
+export FPC_PATH="${FPC_PATH:-${DEMO_SCRIPT_DIR}/../..}"
 
 # SCRIPT_DIR is the docker compose script dir that needs to be defined to source environment variables from the FPC Network
 export SCRIPT_DIR=${FPC_PATH}/utils/docker-compose/scripts
 . ${SCRIPT_DIR}/lib/common.sh
 
 # Cleanup any previous iterations of the demo
-"${SCRIPT_DIR}/teardown.sh"
+"${DEMO_SCRIPT_DIR}/teardown.sh"
 
 # Generate the necessary credentials and start the FPC network
 "${SCRIPT_DIR}/generate.sh"
@@ -80,7 +82,7 @@ fi
 if $BUILD_CLIENT; then
     echo ""
     echo "Building Fabric Gateway and Frontend UI"
-    COMPOSE_IGNORE_ORPHANS=true ${DOCKER_COMPOSE_CMD} -f ${DEMO_ROOT}/docker-compose.yml build
+    COMPOSE_IGNORE_ORPHANS=true ${DOCKER_COMPOSE_CMD} -f ${DEMO_DOCKER_COMPOSE} build
 fi
 
 # Start the FPC Network using utils/docker-compose scripts
@@ -88,7 +90,7 @@ echo "Starting the FPC Network"
 "${SCRIPT_DIR}/start.sh"
 
 # Install and Instantiate Auction Chaincode
-"${DEMO_SCRIPTS_DIR}/installCC.sh"
+"${DEMO_SCRIPT_DIR}/installCC.sh"
 
 # Register Users
 "${DEMO_ROOT}/client/backend/fabric-gateway/registerUsers.sh"
@@ -97,4 +99,4 @@ echo "Starting the FPC Network"
 # Since the new containers are going to use the same network as the FPC network, docker-compose
 # typically throws a warning as it sees containers using the network. To quiet the warning set
 # COMPOSE_IGNORE_ORPHANS to true.
-COMPOSE_IGNORE_ORPHANS=true ${DOCKER_COMPOSE_CMD} -f ${DEMO_ROOT}/docker-compose.yml up -d auction_client auction_frontend
+COMPOSE_IGNORE_ORPHANS=true ${DOCKER_COMPOSE_CMD} -f ${DEMO_DOCKER_COMPOSE} up -d auction_client auction_frontend

--- a/demo/scripts/startFPCAuctionNetwork.sh
+++ b/demo/scripts/startFPCAuctionNetwork.sh
@@ -11,24 +11,32 @@ set -e
 help(){
    echo "$(basename $0) [options]
 
-   This script, by default, will teardown possible previous iterations of this demo, generate new
-   crypto material for the network, start an FPC network as defined in \$FPC_PATH/utils/docker-compose,
-   install the mock golang auction chaincode(\$FPC_PATH/demo/chaincode/golang), install the FPC
-   compliant auction chaincode(\$FPC_PATH/demo/chaincode/fpc), register auction users, and bring up
-   both the fabric-gatway & frontend UI. If the fabric-gateway and frontend UI docker images have
-   not previously been built it will build them, otherwise the script will reuse the images already
-   existing. The FPC chaincode will not be built unless specified by the flag --build-cc.
+   This script, by default, will teardown possible previous iterations of this
+   demo, generate new crypto material for the network, start an FPC network as
+   defined in \$FPC_PATH/utils/docker-compose, install the mock golang auction
+   chaincode(\$FPC_PATH/demo/chaincode/golang), install the FPC compliant
+   auction chaincode(\$FPC_PATH/demo/chaincode/fpc), register auction users,
+   and bring up both the fabric-gatway & frontend UI.
+
+   If the fabric-gateway and frontend UI docker images have not previously been
+   built it will build them, otherwise the script will reuse the images already
+   existing.  You can force a rebuild, though, by specifying the flag
+   --build-client.  The FPC chaincode will not be built unless specified by the
+   flag --build-cc.  By calling the script with both build options, you will be
+   able to run the demo without having to build the whole FPC project (e.g., by
+   calling 'make' in \$FPC_PATH).
 
    options:
        --build-cc:
-           As part of bringing up the demo components, the auction cc in demo/chaincode/fpc will
-           be rebuilt using the docker-build make target.
+           As part of bringing up the demo components, the auction cc in
+           demo/chaincode/fpc will be rebuilt using the docker-build make target.
        --build-client:
-           As part of bringing up the demo components, the Fabric Gateway and the UI docker images
-           will be built or rebuilt using current source code.
+           As part of bringing up the demo components, the Fabric Gateway and
+           the UI docker images will be built or rebuilt using current source
+           code.
        --help,-h:
            Print this help screen.
-    "
+"
 }
 
 
@@ -75,7 +83,7 @@ if $BUILD_CHAINCODE; then
     echo ""
     echo "Building FPC Auction Chaincode"
     pushd ${DEMO_ROOT}/chaincode/fpc
-        make docker-build
+        make SGX_MODE=${SGX_MODE} docker-build
     popd
 fi
 

--- a/demo/scripts/teardown.sh
+++ b/demo/scripts/teardown.sh
@@ -51,7 +51,7 @@ if $CLEAN_SLATE; then
 else
 	DOWN_OPT=""
 fi
-COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} kill && COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} down ${DOWN_OPT}
+COMPOSE_IGNORE_ORPHANS=true ${DOCKER_COMPOSE_CMD} -f ${DEMO_DOCKER_COMPOSE} kill && COMPOSE_IGNORE_ORPHANS=true docker-compose -f ${DEMO_DOCKER_COMPOSE} down ${DOWN_OPT}
 
 if $CLEAN_SLATE; then
     "${SCRIPT_DIR}/teardown.sh" --clean-slate

--- a/ecc/Dockerfile.boilerplate-ecc
+++ b/ecc/Dockerfile.boilerplate-ecc
@@ -8,6 +8,14 @@ ARG CC_NAME="ecc"
 ARG CC_PATH="/usr/local/bin"
 ARG CC_LIB_PATH=${CC_PATH}"/enclave/lib"
 
+ARG SGX_MODE
+ENV SGX_MODE=${SGX_MODE}
+# Note: the library copied below is SGX_MODE dependent, so we
+# define here a env which makes it easy recognizable which mode
+# the container is. No default, though, as we do not control
+# the build and rely on a proper value provided from outside.
+
+
 RUN mkdir -p ${CC_LIB_PATH}
 
 ENV SGX_SDK=/opt/intel/sgxsdk

--- a/ecc/Dockerfile.fpc-app
+++ b/ecc/Dockerfile.fpc-app
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM hyperledger/fabric-private-chaincode-boilerplate-ecc
+ARG BOILERPLATE_EXTENSION
+
+FROM hyperledger/fabric-private-chaincode-boilerplate-ecc${BOILERPLATE_EXTENSION}
 
 ARG enclave_so_path
 ARG CC_PATH="/usr/local/bin"

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -16,7 +16,8 @@ VSCC_OUT = ecc-vscc.so
 DOCKER_CONTAINER_ID?=$$(docker ps | grep -- ${NET_ID}-${PEER_ID}-$(CC_NAME)- | awk '{print $$1;}')
 # the following are the required docker build parameters
 DOCKER_IMAGE ?= $$(docker images | grep -- ${NET_ID}-${PEER_ID}-$(CC_NAME)- | awk '{print $$1;}')
-DOCKER_BOILERPLATE_ECC_IMAGE ?= hyperledger/$(PROJECT_NAME)-boilerplate-ecc
+BOILERPLATE_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)
+DOCKER_BOILERPLATE_ECC_IMAGE ?= hyperledger/$(PROJECT_NAME)-boilerplate-ecc$(BOILERPLATE_EXTENSION)
 INSTALLED_DOCKER_BOILERPLATE_ECC_IMAGE ?= $$(docker images | grep -- ${DOCKER_BOILERPLATE_ECC_IMAGE} | awk '{print $$1;}')
 DOCKER_ENCLAVE_SO_PATH ?= $(ENCLAVE_SO_PATH)
 
@@ -71,7 +72,9 @@ ifdef FORCE_REBUILD
 endif
 
 docker-boilerplate-ecc: ecc
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_BOILERPLATE_ECC_IMAGE) -f Dockerfile.boilerplate-ecc ..
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_BOILERPLATE_ECC_IMAGE) -f Dockerfile.boilerplate-ecc\
+		--build-arg SGX_MODE=$(SGX_MODE)\
+		..
 
 docker-fpc-app: docker-boilerplate-ecc
 	if [ -z "$(DOCKER_IMAGE)" ]; then\
@@ -79,13 +82,19 @@ docker-fpc-app: docker-boilerplate-ecc
 		exit 1;\
 	fi
 	echo "\033[1;33mWARNING: overriding $(DOCKER_IMAGE) docker image\033[0m"
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_IMAGE) -f Dockerfile.fpc-app --build-arg enclave_so_path=$(DOCKER_ENCLAVE_SO_PATH) ..
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_IMAGE) -f Dockerfile.fpc-app \
+		--build-arg BOILERPLATE_EXTENSION=$(BOILERPLATE_EXTENSION)\
+		--build-arg enclave_so_path=$(DOCKER_ENCLAVE_SO_PATH)\
+		..
 
 docker-run:
+	if [ "$(SGX_MODE)" = "HW" ]; then \
+		SGX_DEVICE_PATH=$(if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx" ]; then echo "/dev/sgx"; else echo "ERROR: NO SGX DEVICE FOUND"; fi);\
+		DOCKER_SGX_ARGS="--device $${SGX_DEVICE_PATH} -v /var/run/aesmd:/var/run/aesmd";\
+	fi;\
 	$(DOCKER) run \
 		-it \
-		--device /dev/isgx \
-		-v /var/run/aesmd:/var/run/aesmd \
+		$${DOCKER_SGX_ARGS} \	
 		--name $(CC_NAME) \
 		-e "CORE_CHAINCODE_LOGGING_LEVEL=DEBUG" \
 		-e "CORE_CHAINCODE_LOGGING_SHIM=INFO" \

--- a/fabric/bin/peer.sh
+++ b/fabric/bin/peer.sh
@@ -10,6 +10,7 @@ FPC_TOP_DIR="${SCRIPTDIR}/../../"
 FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 
 : ${FABRIC_CFG_PATH:=$(pwd)}
+: ${SGX_MODE:=SIM}
 
 . ${FABRIC_SCRIPTDIR}/lib/common_utils.sh
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
@@ -69,7 +70,7 @@ handle_chaincode_install() {
 	DOCKER_IMAGE_NAME=$(${FPC_DOCKER_NAME_CMD} --cc-name ${FPC_NAME} --cc-version ${CC_VERSION} --net-id ${NET_ID} --peer-id ${PEER_ID}) || die "could not get docker image name"
 
 	# install docker
-	try make ENCLAVE_SO_PATH=${CC_ENCLAVESOPATH} DOCKER_IMAGE=${DOCKER_IMAGE_NAME} -C ${FPC_TOP_DIR}/ecc docker-fpc-app
+	try make SGX_MODE=${SGX_MODE} ENCLAVE_SO_PATH=${CC_ENCLAVESOPATH} DOCKER_IMAGE=${DOCKER_IMAGE_NAME} -C ${FPC_TOP_DIR}/ecc docker-fpc-app
 
 	# eplace path and lang arg with dummy go chaincode
 	ARGS_EXEC=( 'chaincode' 'install' '-n' "${FPC_NAME}" '-v' "${CC_VERSION}" '-p' 'github.com/hyperledger/fabric/examples/chaincode/go/example02/cmd' "${OTHER_ARGS[@]}" )

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -8,4 +8,4 @@ include $(TOP)/build.mk
 SUB_DIRS = docker fabric docker-compose
 
 all build test clean clobber:
-	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@;)
+	$(foreach DIR, $(SUB_DIRS), $(MAKE) -C $(DIR) $@ || exit ;)

--- a/utils/docker-compose/README.md
+++ b/utils/docker-compose/README.md
@@ -32,7 +32,16 @@ is used. Otherwise it will use `core.yaml` and the regular peer image.
    scripts/start.sh
    ```
    This will create all necessary installation artifacts and start the
-   network. For more information in the steps involved, continue
+   network. 
+   If you set the environment variable `USE_EXPLORER` to `true`, the network will include
+   and start the [Hyperledger Explorer](https://www.hyperledger.org/projects/explorer) on 
+   [port 8090](http://localhost:8090). This will enable you to inspect the networks, 
+    e.g., processed transactions.
+   If you set the environment variable `USE_COUCHDB` to `true`, the peer will use couchdb
+   to store the local version of the ledger and you can inspect the peer's ledger state
+   on [port 5984](http://localhost:5984) (login as user `admin` with password `adminPassword`).
+
+   For more information in the steps involved, continue
    reading the following section. Otherwise, you can skip to the
    Section on [Chaincode Installation](#deploying-your-fpc-chaincode).
 

--- a/utils/docker-compose/README.md
+++ b/utils/docker-compose/README.md
@@ -33,6 +33,8 @@ is used. Otherwise it will use `core.yaml` and the regular peer image.
    ```
    This will create all necessary installation artifacts and start the
    network. 
+   If your environment variable `SGX_MODE` is set to hardware, the network will run
+   the peer also with SGX hardware mode enabled, otherwise it will run in SGX simulation mode.
    If you set the environment variable `USE_EXPLORER` to `true`, the network will include
    and start the [Hyperledger Explorer](https://www.hyperledger.org/projects/explorer) on 
    [port 8090](http://localhost:8090). This will enable you to inspect the networks, 

--- a/utils/docker-compose/network-config/base/base.yaml
+++ b/utils/docker-compose/network-config/base/base.yaml
@@ -16,7 +16,7 @@
 #                          `/project/src/github.com/hyperledger-labs/fabric-private-chaincode/fabric/bin/peer.sh`
 
 #
-version: '2'
+version: '2.1'
 
 services:
   peer-base:

--- a/utils/docker-compose/network-config/docker-compose-couchdb.yml
+++ b/utils/docker-compose/network-config/docker-compose-couchdb.yml
@@ -4,7 +4,7 @@
 #
 # docker-compose-"delta" to docker-compose.yaml to run peer with couchdb
 
-version: '2'
+version: '2.1'
 
 services:
   couchdb0.org1.example.com:

--- a/utils/docker-compose/network-config/docker-compose-couchdb.yml
+++ b/utils/docker-compose/network-config/docker-compose-couchdb.yml
@@ -7,8 +7,7 @@
 version: '2'
 
 services:
-  couchdb0:
-    container_name: couchdb0
+  couchdb0.org1.example.com:
     image: couchdb:2.3
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
@@ -25,12 +24,12 @@ services:
   peer0.org1.example.com:
     environment:
       - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=couchdb0:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=couchdb0.org1.example.com:5984
       # The CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME and CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD
       # provide the credentials for ledger to connect to CouchDB.  The username and password must
       # match the username and password set for the associated CouchDB.
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=
     depends_on:
-      - couchdb0
+      - couchdb0.org1.example.com
 

--- a/utils/docker-compose/network-config/docker-compose-explorer.yml
+++ b/utils/docker-compose/network-config/docker-compose-explorer.yml
@@ -4,7 +4,7 @@
 # Note: this is a tweaked version of './docker-compose.yaml' in hyperledger/blockchain-explorer.git
 
 # SPDX-License-Identifier: Apache-2.0
-version: '2'
+version: '2.1'
 
 volumes:
   pgdata:

--- a/utils/docker-compose/network-config/docker-compose-sgx-hw.yml
+++ b/utils/docker-compose/network-config/docker-compose-sgx-hw.yml
@@ -1,0 +1,24 @@
+# Copyright Intel Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# docker-compose-"delta" to docker-compose.yaml to run peer with SGX in HW Mode
+
+version: '2.1'
+
+services:
+  peer0.org1.example.com:
+  # ideally we would extend the definition of 'peer-base:' but alas docker-compose
+  # doesn't propagate this to services which 'extend' from peer-base :-(
+    image: hyperledger/fabric-peer-fpc-hw
+    # build:
+    #   args:
+    #     SGX_MODE: HW
+    volumes:
+      - ${SGX_CONFIG_ROOT:-../../../config/ias/}:/project/src/github.com/hyperledger-labs/fabric-private-chaincode/config/ias/
+      - /var/run/aesmd:/var/run/aesmd
+    devices:
+      - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
+    environment:
+      - SGX_MODE=HW
+

--- a/utils/docker-compose/network-config/docker-compose.yml
+++ b/utils/docker-compose/network-config/docker-compose.yml
@@ -20,7 +20,7 @@
 #
 #
 #
-version: '2'
+version: '2.1'
 
 networks:
   basic:

--- a/utils/docker-compose/scripts/start.sh
+++ b/utils/docker-compose/scripts/start.sh
@@ -16,26 +16,26 @@ export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && p
 #
 if [[ ! $USE_FPC = false ]]; then
     # - existance of FPC peer
-    FPC_PEER_NAME="hyperledger/fabric-peer-fpc"
+    FPC_PEER_NAME="hyperledger/fabric-peer-fpc$(if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)" 
     if [ -z "$(docker images | grep ${FPC_PEER_NAME})" ]; then
 	echo "FPC peer container image '${FPC_PEER_NAME}' does not exist, try to build it ..."
 	# if it doesn't exist, build it: note this can take quite some time!!
 	pushd "${FPC_PATH}/utils/docker" || die "can't go to peer build location"
-	make peer || die "can't build peer"
+	make SGX_MODE=${SGX_MODE} peer || die "can't build peer"
 	popd
     fi
     # - existance of boilerplate
-    BOILERPLATE_NAME="hyperledger/fabric-private-chaincode-boilerplate-ecc"
+    BOILERPLATE_NAME="hyperledger/fabric-private-chaincode-boilerplate-ecc$(if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)"
     if [ -z "$(docker images | grep ${BOILERPLATE_NAME})" ]; then
 	echo "FPC boilerplate container image '${BOILERPLATE_NAME}' does not exist, try to build it ..."
 	pushd "${FPC_PATH}/" || die "can't go to fpc-sdk and boilerplate build location"
-	make fpc-sdk || die "can't build fpc sdk"
+	make SGX_MODE=${SGX_MODE} fpc-sdk || die "can't build fpc sdk"
 	popd
 	pushd "${FPC_PATH}/utils/docker" || die "can't go to docker build location"
-	make || die "can't build docker base images"
+	make SGX_MODE=${SGX_MODE} || die "can't build docker base images"
 	popd
 	pushd "${FPC_PATH}/ecc" || die "can't go to fpc-sdk and boilerplate build location"
-	make docker-boilerplate-ecc || die "can't build boilerplate"
+	make SGX_MODE=${SGX_MODE} docker-boilerplate-ecc || die "can't build boilerplate"
 	popd
     fi
 fi

--- a/utils/docker-compose/scripts/start.sh
+++ b/utils/docker-compose/scripts/start.sh
@@ -14,14 +14,28 @@ export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && p
 
 # test pre-conditions and try to remediate
 #
-# - existance of FPC peer
 if [[ ! $USE_FPC = false ]]; then
+    # - existance of FPC peer
     FPC_PEER_NAME="hyperledger/fabric-peer-fpc"
     if [ -z "$(docker images | grep ${FPC_PEER_NAME})" ]; then
 	echo "FPC peer container image '${FPC_PEER_NAME}' does not exist, try to build it ..."
 	# if it doesn't exist, build it: note this can take quite some time!!
 	pushd "${FPC_PATH}/utils/docker" || die "can't go to peer build location"
 	make peer || die "can't build peer"
+	popd
+    fi
+    # - existance of boilerplate
+    BOILERPLATE_NAME="hyperledger/fabric-private-chaincode-boilerplate-ecc"
+    if [ -z "$(docker images | grep ${BOILERPLATE_NAME})" ]; then
+	echo "FPC boilerplate container image '${BOILERPLATE_NAME}' does not exist, try to build it ..."
+	pushd "${FPC_PATH}/" || die "can't go to fpc-sdk and boilerplate build location"
+	make fpc-sdk || die "can't build fpc sdk"
+	popd
+	pushd "${FPC_PATH}/utils/docker" || die "can't go to docker build location"
+	make || die "can't build docker base images"
+	popd
+	pushd "${FPC_PATH}/ecc" || die "can't go to fpc-sdk and boilerplate build location"
+	make docker-boilerplate-ecc || die "can't build boilerplate"
 	popd
     fi
 fi

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -5,8 +5,16 @@
 TOP = ../..
 include $(TOP)/build.mk
 
+HW_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)
+
 FPC_DOCKER_NAMESPACE := hyperledger/fabric-private-chaincode
-FPC_PEER_DOCKER_NAMESPACE := hyperledger/fabric-peer-fpc
+FPC_DOCKER_CC_BUILDER_NAME = $(FPC_DOCKER_NAMESPACE)-cc-builder$(HW_EXTENSION)
+FPC_DOCKER_DEV_NAME = $(FPC_DOCKER_NAMESPACE)-dev
+FPC_DOCKER_CCENV_NAME = $(FPC_DOCKER_NAMESPACE)-ccenv
+FPC_DOCKER_BASE_NAME = $(FPC_DOCKER_NAMESPACE)-base
+
+FPC_DOCKER_PEER_NAMESPACE := hyperledger/fabric-peer-fpc
+FPC_DOCKER_PEER_NAME = $(FPC_DOCKER_PEER_NAMESPACE)$(HW_EXTENSION)
 
 DOCKER_DAEMON_SOCKET ?= /var/run/docker.sock
 FABRIC_PEER_DAEMON_CHAINCODE_PORT ?= 7052
@@ -45,11 +53,11 @@ clobber:
 	for imgs in \
 		dev-* \
 		dev_test-* \
-	        ${FPC_PEER_DOCKER_NAMESPACE} \
-		$(FPC_DOCKER_NAMESPACE)-cc-builder \
-		$(FPC_DOCKER_NAMESPACE)-dev \
-		$(FPC_DOCKER_NAMESPACE)-ccenv \
-		$(FPC_DOCKER_NAMESPACE)-base \
+	        ${FPC_DOCKER_PEER_NAME} \
+		$(FPC_DOCKER_CC_BUILDER_NAME) \
+		$(FPC_DOCKER_DEV_NAME) \
+		$(FPC_DOCKER_CCENV_NAME) \
+		$(FPC_DOCKER_BASE_NAME) \
 	; do \
 		IMAGES=$$(${DOCKER} images $${imgs} -q); \
 		if [ ! -z "$${IMAGES}" ]; then ${DOCKER} rmi -f $${IMAGES} || exit 1; fi \
@@ -71,25 +79,29 @@ endif
 
 
 base:
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-base base
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_BASE_NAME) base
 
 ccenv: base
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-ccenv ccenv
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_CCENV_NAME) ccenv
 
 # Note: for overall consistency reasons we want the FPC code from the current repo
 # as this will rebuild each time and take a while, we don't add a dependency
 # to the build target above ...
 peer: base
 	(cd ${TOP}; \
-         $(DOCKER) build $(DOCKER_BUILD_OPTS) -t ${FPC_PEER_DOCKER_NAMESPACE}\
+         $(DOCKER) build $(DOCKER_BUILD_OPTS) -t ${FPC_DOCKER_PEER_NAME}\
          -f utils/docker/peer/Dockerfile\
          --build-arg FPC_REPO_URL=file:///tmp/build-src/.git\
          --build-arg FPC_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD)\
+         --build-arg SGX_MODE=${SGX_MODE}\
          . )
 
 dev: base
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-dev $(DOCKER_DEV_BUILD_OPTS) dev
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_DEV_NAME) $(DOCKER_DEV_BUILD_OPTS) dev
 
 cc-builder: dev
-	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(FPC_DOCKER_NAMESPACE)-cc-builder cc-builder
+	$(DOCKER) build $(DOCKER_BUILD_OPTS) \
+		-t $(FPC_DOCKER_CC_BUILDER_NAME)\
+		--build-arg SGX_MODE=${SGX_MODE}\
+		cc-builder
 

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -46,9 +46,9 @@ clobber:
 		dev-* \
 		dev_test-* \
 	        ${FPC_PEER_DOCKER_NAMESPACE} \
+		$(FPC_DOCKER_NAMESPACE)-cc-builder \
 		$(FPC_DOCKER_NAMESPACE)-dev \
 		$(FPC_DOCKER_NAMESPACE)-ccenv \
-		$(FPC_DOCKER_NAMESPACE)-cc-builder \
 		$(FPC_DOCKER_NAMESPACE)-base \
 	; do \
 		IMAGES=$$(${DOCKER} images $${imgs} -q); \

--- a/utils/docker/base/Dockerfile
+++ b/utils/docker/base/Dockerfile
@@ -47,6 +47,3 @@ ENV SGX_SDK=/opt/intel/sgxsdk
 ENV PATH=$PATH:$SGX_SDK/bin:$SGX_SDK/bin/x64
 ENV PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$SGX_SDK/pkgconfig
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SGX_SDK/sdk_libs
-
-# We set our default mode to SIM
-ENV SGX_MODE=SIM

--- a/utils/docker/cc-builder/Dockerfile
+++ b/utils/docker/cc-builder/Dockerfile
@@ -4,6 +4,9 @@
 
 FROM hyperledger/fabric-private-chaincode-dev:latest
 
+ARG SGX_MODE=SIM
+ENV SGX_MODE=${SGX_MODE}
+
 RUN cd $FPC_PATH
 RUN make fpc-sdk
 

--- a/utils/docker/dev/Dockerfile
+++ b/utils/docker/dev/Dockerfile
@@ -6,15 +6,21 @@ FROM hyperledger/fabric-private-chaincode-base:latest
 
 ARG GO_VERSION=go1.13
 ARG GO_TAR=$GO_VERSION.linux-amd64.tar.gz
-ARG OPENSSL=1.1.0j
-ARG SGXSSL=v2.4.1
 ARG NANOPB_VERSION=0.3.9.2
 ARG FABRIC_REPO=https://github.com/hyperledger/fabric.git
 ARG FABRIC_VERSION=v1.4.3
-ARG FPC_REPO=https://github.com/hyperledger-labs/fabric-private-chaincode
-ARG FPC_VERSION=master
+ARG FPC_REPO_URL=https://github.com/hyperledger-labs/fabric-private-chaincode.git
+ARG FPC_REPO_BRANCH=master
+ARG OPENSSL_VERSION=1.1.0j
+ARG SGXSSL_VERSION=v2.4.1
 
 ARG APT_ADD_PKGS=
+
+ENV NANOPB_VERSION=${NANOPB_VERSION}
+ENV FABRIC_VERSION=${FABRIC_VERSION}
+ENV OPENSSL_VERSION=${OPENSSL_VERSION}
+ENV SGXSSL_VERSION=${SGXSSL_VERSION}
+
 
 WORKDIR /tmp
 
@@ -39,11 +45,13 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl
-RUN wget https://www.openssl.org/source/openssl-$OPENSSL.tar.gz \
- && git clone  --branch $SGXSSL https://github.com/intel/intel-sgx-ssl.git \
+RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+ && git clone  --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git \
  && . $SGX_SDK/environment \
- && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-$OPENSSL.tar.gz . ) \
+ && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-${OPENSSL_VERSION}.tar.gz . ) \
  && (cd intel-sgx-ssl/Linux; make SGX_MODE=SIM DESTDIR=$SGX_SSL all test ) \
+ # Note: in docker build we cannot run with SGX_MODE=HW, so run as SIM.
+ # However, compiled libraries can still be used in both modes!
  && (cd intel-sgx-ssl/Linux; make install ) \
  && rm -rf /tmp/intel-sgx-ssl
 
@@ -55,18 +63,27 @@ RUN git clone https://github.com/nanopb/nanopb.git $NANOPB_PATH \
  && cd generator/proto \
  && make
 
+# Go repos we need (and pre-load them here rather than later in make)
+RUN go get github.com/golang/protobuf/proto \
+ && go get github.com/pkg/errors \
+ && go get golang.org/x/tools/cmd/goimports \
+ && go get golang.org/x/sync/semaphore \
+ && go get github.com/spf13/viper
+
+# Get Fabric
+ENV FABRIC_PATH=$GOPATH/src/github.com/hyperledger/fabric
+RUN git clone --branch $FABRIC_VERSION $FABRIC_REPO $FABRIC_PATH
+# Note: could add --single-branch to below to speed-up and keep size smaller. But for now for a dev-image better keep complete repo
+
 # Get FPC
 ENV FPC_PATH=$GOPATH/src/github.com/hyperledger-labs/fabric-private-chaincode
+RUN git clone --branch $FPC_REPO_BRANCH $FPC_REPO_URL $FPC_PATH
 # Note: could add --single-branch to below to speed-up and keep size smaller. But for now for a dev-image better keep complete repo
-RUN git clone --branch $FPC_VERSION $FPC_REPO $FPC_PATH
 
-# Get Fabric (after FPC as we need the FPC patches!)
-ENV FABRIC_PATH=$GOPATH/src/github.com/hyperledger/fabric
-# Note: could add --single-branch to below to speed-up and keep size smaller. But for now for a dev-image better keep complete repo
+# Build Fabric (after FPC as we need the FPC patches!)
 # Note: the git config shouldn't really be necessary for a git am but that fails without it.
 #   To not commit an id, just do it only temporarily and only locally ...
-RUN git clone --branch $FABRIC_VERSION $FABRIC_REPO $FABRIC_PATH \
- && cd $FABRIC_PATH \
+RUN cd $FABRIC_PATH \
  && git config user.email "FPC" \
  && git am $FPC_PATH/fabric/*patch \
  && git config --unset user.email \

--- a/utils/docker/peer/Dockerfile
+++ b/utils/docker/peer/Dockerfile
@@ -6,13 +6,22 @@ FROM hyperledger/fabric-private-chaincode-base:latest
 
 ARG GO_VERSION=go1.13
 ARG GO_TAR=$GO_VERSION.linux-amd64.tar.gz
-ARG OPENSSL=1.1.0j
-ARG SGXSSL=v2.4.1
 ARG NANOPB_VERSION=0.3.9.2
 ARG FABRIC_REPO=https://github.com/hyperledger/fabric.git
 ARG FABRIC_VERSION=v1.4.3
+ARG FPC_REPO_URL=https://github.com/hyperledger-labs/fabric-private-chaincode.git
+ARG FPC_REPO_BRANCH=master
+ARG OPENSSL_VERSION=1.1.0j
+ARG SGXSSL_VERSION=v2.4.1
+ARG SGX_MODE=SIM
 
 ARG APT_ADD_PKGS=
+
+ENV NANOPB_VERSION=${NANOPB_VERSION}
+ENV FABRIC_VERSION=${FABRIC_VERSION}
+ENV OPENSSL_VERSION=${OPENSSL_VERSION}
+ENV SGXSSL_VERSION=${SGXSSL_VERSION}
+ENV SGX_MODE=${SGX_MODE}
 
 
 WORKDIR /tmp
@@ -37,11 +46,13 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl
-RUN wget https://www.openssl.org/source/openssl-$OPENSSL.tar.gz \
- && git clone  --branch $SGXSSL https://github.com/intel/intel-sgx-ssl.git \
+RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+ && git clone  --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git \
  && . $SGX_SDK/environment \
- && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-$OPENSSL.tar.gz . ) \
+ && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-${OPENSSL_VERSION}.tar.gz . ) \
  && (cd intel-sgx-ssl/Linux; make SGX_MODE=SIM DESTDIR=$SGX_SSL all test ) \
+ # Note: in docker build we cannot run with SGX_MODE=HW, so run as SIM.
+ # However, compiled libraries can still be used in both modes!
  && (cd intel-sgx-ssl/Linux; make install ) \
  && rm -rf /tmp/intel-sgx-ssl
 
@@ -53,48 +64,42 @@ RUN git clone https://github.com/nanopb/nanopb.git $NANOPB_PATH \
  && cd generator/proto \
  && make
 
-# Get Fabric (after FPC as we need the FPC patches!)
+# Go repos we need (and pre-load them here rather than later in make)
+RUN go get github.com/golang/protobuf/proto \
+ && go get github.com/pkg/errors \
+ && go get golang.org/x/tools/cmd/goimports \
+ && go get golang.org/x/sync/semaphore \
+ && go get github.com/spf13/viper
+
+# Get Fabric
 ENV FABRIC_PATH=$GOPATH/src/github.com/hyperledger/fabric
+RUN git clone --branch $FABRIC_VERSION $FABRIC_REPO $FABRIC_PATH
 # Note: could add --single-branch to below to speed-up and keep size smaller. But for now for a dev-image better keep complete repo
-# Note: the git config shouldn't really be necessary for a git am but that fails without it.
-#   To not commit an id, just do it only temporarily and only locally ...
-RUN git clone --branch $FABRIC_VERSION $FABRIC_REPO $FABRIC_PATH \
- && cd $FABRIC_PATH \
- && git config user.email "FPC"
-
-# Go repos needed to build plugins
-RUN go get github.com/golang/protobuf/proto
-
-RUN go get github.com/pkg/errors
-
-RUN go get golang.org/x/tools/cmd/goimports
-
-RUN go get golang.org/x/sync/semaphore
 
 # Get FPC
 ENV FPC_PATH=$GOPATH/src/github.com/hyperledger-labs/fabric-private-chaincode
-ARG FPC_REPO_URL=https://github.com/hyperledger-labs/fabric-private-chaincode.git
-ARG FPC_REPO_BRANCH=master
-
+# We copy context so we can use that to potentially get local .git as repo ...
 RUN mkdir /tmp/build-src
 COPY . /tmp/build-src
-# Note: could add --single-branch to below to speed-up and keep size smaller. But for now for a dev-image better keep complete repo
 # RUN mkdir -p $FPC_PATH
 RUN git clone --branch $FPC_REPO_BRANCH $FPC_REPO_URL $FPC_PATH
-# COPY ./ /project/src/github.com/hyperledger-labs/fabric-private-chaincode
+# Note: could add --single-branch to below to speed-up and keep size smaller. But for now for a dev-image better keep complete repo
 
+# Build Fabric (after FPC as we need the FPC patches!)
+# Note: the git config shouldn't really be necessary for a git am but that fails without it.
+#   To not commit an id, just do it only temporarily and only locally ...
 RUN cd $FABRIC_PATH \
+ && git config user.email "FPC" \
  && git am $FPC_PATH/fabric/*patch \
  && git config --unset user.email \
- && GO_TAGS=pluginsenabled make peer orderer configtxgen
+ && GO_TAGS=pluginsenabled make peer orderer cryptogen configtxgen
 
+# Build FPC plugins for peer
 RUN cd $FPC_PATH \
- && make plugins
-
-RUN cd $FPC_PATH/utils/fabric \
- && make
-# RUN apt-get install libtool
+ && make plugins \
+ && make -C $FPC_PATH/utils/fabric 
 
 ENV FABRIC_BIN_DIR=$FABRIC_PATH/.build/bin
 ENV FPC_CMDS=/project/src/github.com/hyperledger-labs/fabric-private-chaincode/fabric/bin
+
 CMD [$FPC_CMDS/peer.sh node start]


### PR DESCRIPTION
- HW mode is essentially enabled when SGX_MODE is set to HW.  Containers which are SGX-MODE sensitive (e.g., peer, boilerplate, cc-builder) will have an "-hw" extension to distinguish from their SIM-mode sibling
- proxy support is mostly documentation (in short, you need a new docker-compose version). That said, it will also work with the standard ubuntu docker-compose iff you start with make; The new one you mainly need if you start from a fresh repo without build and start right away with the scripts (e.g., `./demo/client/scripting/scenario-run --bootstrap ...`)
- besides above, there is also some docker file cleanup and some small extensions of the demo docu and a reference thereof in the top README
