### PR TITLE
Modified intergration/config files to fabric 2.0

### DIFF
--- a/fabric/bin/lib/common_ledger.sh
+++ b/fabric/bin/lib/common_ledger.sh
@@ -48,6 +48,7 @@ define_common_vars() {
     : ${CHAN_ID:="mychannel"}
     : ${ERCC_ID:="ercc"}
     : ${ERCC_VERSION:="0"}
+    : ${ERCC_SEQUENCE:="1"}
 
     ORDERER_PID_FILE="${FABRIC_STATE_DIR}/orderer.pid"
     ORDERER_LOG_OUT="${FABRIC_STATE_DIR}/orderer.out"
@@ -112,6 +113,9 @@ ledger_init() {
     try rm -rf ${FABRIC_STATE_DIR}/*
 
     # 2. start orderer
+    # - Creating a genesisblock for orderer-system-channel......."
+    try ${CONFIGTXGEN_CMD} -outputBlock ${FABRIC_STATE_DIR}/genesisblock -profile SampleDevModeSolo -channelID orderer-system-channel
+    sleep 1
     ORDERER_GENERAL_GENESISPROFILE=SampleDevModeSolo ${ORDERER_CMD} 1>${ORDERER_LOG_OUT} 2>${ORDERER_LOG_ERR} &
     export ORDERER_PID=$!
     echo "${ORDERER_PID}" > ${ORDERER_PID_FILE}

--- a/integration/config/configtx.yaml
+++ b/integration/config/configtx.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
+# Based on hyperledger/fabric/sampleconfig
 ---
 ################################################################################
 #
@@ -22,6 +22,14 @@ Organizations:
         # configuration transactions.
         # Name can include alphanumeric characters as well as dots and dashes.
         Name: SampleOrg
+
+        # SkipAsForeign can be set to true for org definitions which are to be
+        # inherited from the orderer system channel during channel creation.  This
+        # is especially useful when an admin of a single org without access to the
+        # MSP directories of the other orgs wishes to create a channel.  Note
+        # this property must always be set to false for orgs included in block
+        # creation.
+        SkipAsForeign: false
 
         # ID is the key by which this org's MSP definition will be referenced.
         # ID can include alphanumeric characters as well as dots and dashes.
@@ -49,6 +57,9 @@ Organizations:
             Admins:
                 Type: Signature
                 Rule: "OR('SampleOrg.admin')"
+            Endorsement:
+                Type: Signature
+                Rule: "OR('SampleOrg.member')"
 
         # OrdererEndpoints is a list of all orderers this org runs which clients
         # and peers may to connect to to push transactions and receive blocks respectively.
@@ -86,52 +97,34 @@ Capabilities:
     # supported by both.
     # Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        # V1.4.3 for Channel is a catchall flag for behavior which has been
-        # determined to be desired for all orderers and peers running at the v1.4.3
+        # V2.0 for Channel is a catchall flag for behavior which has been
+        # determined to be desired for all orderers and peers running at the v2.0.0
         # level, but which would be incompatible with orderers and peers from
         # prior releases.
-        # Prior to enabling V1.4.3 channel capabilities, ensure that all
-        # orderers and peers on a channel are at v1.4.3 or later.
-        V1_4_3: true
-        # V1.3 for Channel enables the new non-backwards compatible
-        # features and fixes of fabric v1.3
-        V1_3: false
-        # V1.1 for Channel enables the new non-backwards compatible
-        # features and fixes of fabric v1.1
-        V1_1: false
+        # Prior to enabling V2.0 channel capabilities, ensure that all
+        # orderers and peers on a channel are at v2.0.0 or later.
+        V2_0: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
     # used with prior release peers.
     # Set the value of the capability to true to require it.
     Orderer: &OrdererCapabilities
-        # V1.4.2 for Orderer is a catchall flag for behavior which has been
-        # determined to be desired for all orderers running at the v1.4.2
+        # V1.1 for Orderer is a catchall flag for behavior which has been
+        # determined to be desired for all orderers running at the v1.1.x
         # level, but which would be incompatible with orderers from prior releases.
-        # Prior to enabling V1.4.2 orderer capabilities, ensure that all
-        # orderers on a channel are at v1.4.2 or later.
-        V1_4_2: true
-        # V1.1 for Orderer enables the new non-backwards compatible
-        # features and fixes of fabric v1.1
-        V1_1: false
+        # Prior to enabling V2.0 orderer capabilities, ensure that all
+        # orderers on a channel are at v2.0.0 or later.
+        V2_0: true
 
     # Application capabilities apply only to the peer network, and may be safely
     # used with prior release orderers.
     # Set the value of the capability to true to require it.
     Application: &ApplicationCapabilities
-        # V1.4.2 for Application enables the new non-backwards compatible
-        # features and fixes of fabric v1.4.2
-        V1_4_2: true
-        # V1.3 for Application enables the new non-backwards compatible
-        # features and fixes of fabric v1.3.
-        V1_3: false
-        # V1.2 for Application enables the new non-backwards compatible
-        # features and fixes of fabric v1.2 (note, this need not be set if
-        # later version capabilities are set)
-        V1_2: false
-        # V1.1 for Application enables the new non-backwards compatible
-        # features and fixes of fabric v1.1 (note, this need not be set if
-        # later version capabilities are set).
-        V1_1: false
+        # V2.0 for Application enables the new non-backwards compatible
+        # features and fixes of fabric v2.0.
+        # Prior to enabling V2.0 orderer capabilities, ensure that all
+        # orderers on a channel are at v2.0.0 or later.
+        V2_0: true
 
 ################################################################################
 #
@@ -149,8 +142,22 @@ Application: &ApplicationDefaults
         # (e.g.,who can receive Block events). This section does NOT specify the resource's
         # definition or API, but just the ACL policy for it.
         #
-        # User's can override these defaults with their own policy mapping by defining the
+        # Users can override these defaults with their own policy mapping by defining the
         # mapping under ACLs in their channel definition
+
+        #---New Lifecycle System Chaincode (_lifecycle) function to policy mapping for access control--#
+
+        # ACL policy for _lifecycle's "CheckCommitReadiness" function
+        _lifecycle/CheckCommitReadiness: /Channel/Application/Writers
+
+        # ACL policy for _lifecycle's "CommitChaincodeDefinition" function
+        _lifecycle/CommitChaincodeDefinition: /Channel/Application/Writers
+
+        # ACL policy for _lifecycle's "QueryChaincodeDefinition" function
+        _lifecycle/QueryChaincodeDefinition: /Channel/Application/Readers
+
+        # ACL policy for _lifecycle's "QueryChaincodeDefinitions" function
+        _lifecycle/QueryChaincodeDefinitions: /Channel/Application/Readers
 
         #---Lifecycle System Chaincode (lscc) function to policy mapping for access control---#
 
@@ -218,6 +225,12 @@ Application: &ApplicationDefaults
     # For Application policies, their canonical path is
     #   /Channel/Application/<PolicyName>
     Policies: &ApplicationDefaultPolicies
+        LifecycleEndorsement:
+            Type: ImplicitMeta
+            Rule: "MAJORITY Endorsement"
+        Endorsement:
+            Type: ImplicitMeta
+            Rule: "MAJORITY Endorsement"
         Readers:
             Type: ImplicitMeta
             Rule: "ANY Readers"
@@ -351,7 +364,7 @@ Orderer: &OrdererDefaults
             MaxInflightBlocks: 5
 
             # SnapshotIntervalSize defines number of bytes per which a snapshot is taken
-            SnapshotIntervalSize: 20 MB
+            SnapshotIntervalSize: 16 MB
 
     # Organizations lists the orgs participating on the orderer side of the
     # network.
@@ -553,11 +566,12 @@ Profiles:
     # profiles, only the 'Application' section and consortium # name are
     # considered.
     SampleSingleMSPChannel:
+        <<: *ChannelDefaults
         Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:
-                - *SampleOrg
+                - <<: *SampleOrg
 
     # SampleDevModeEtcdRaft defines a configuration that differs from the
     # SampleDevModeSolo one only in that it uses the etcd/raft-based orderer.

--- a/integration/config/core.yaml
+++ b/integration/config/core.yaml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+# Based on hyperledger/fabric/sampleconfig
 
 ###############################################################################
 #
@@ -11,15 +12,18 @@
 ###############################################################################
 peer:
 
-    # The Peer id is used for identifying this Peer instance.
+    # The peer id provides a name for this peer instance and is used when
+    # naming docker resources.
     id: jdoe_test
 
-    # The networkId allows for logical seperation of networks
+    # The networkId allows for logical separation of networks and is used when
+    # naming docker resources.
     networkId: dev_test
 
     # The Address at local network interface this Peer will listen on.
     # By default, it will listen on all network interfaces
-    listenAddress: 0.0.0.0:7051
+    # FPC change: the original 0.0.0.0 didn't always work in some settings and we need it only for localhost
+    listenAddress: 127.0.0.1:7051
 
     # The endpoint this peer uses to listen for inbound chaincode connections.
     # If this is commented-out, the listen address is selected to be
@@ -36,18 +40,21 @@ peer:
     # in the same organization. For peers in other organization, see
     # gossip.externalEndpoint for more info.
     # When used as CLI config, this means the peer's endpoint to interact with
-    address: 127.0.0.1:7051 # Note: setting to 127.0.0.1 restricts to localhost but does make it work behind proxies
+    # FPC change: see comment above listenAddress above ..
+    address: 127.0.0.1:7051
 
     # Whether the Peer should programmatically determine its address
     # This case is useful for docker containers.
     addressAutoDetect: false
 
-    # Setting for runtime.GOMAXPROCS(n). If n < 1, it does not change the
-    # current setting
-    gomaxprocs: -1
-
     # Keepalive settings for peer server and clients
     keepalive:
+        # Interval is the duration after which if the server does not see
+        # any activity from the client it pings the client to see if it's alive
+        interval: 7200s
+        # Timeout is the duration the server waits for a response
+        # from the client after sending a ping before closing the connection
+        timeout: 20s
         # MinInterval is the minimum permitted time between client pings.
         # If clients send pings more frequently, the peer server will
         # disconnect them
@@ -217,18 +224,16 @@ peer:
             responseTimeout: 3s
             # batchSize the number of blocks to request via state transfer from another peer
             batchSize: 10
-            # blockBufferSize reflect the maximum distance between lowest and
-            # highest block sequence number state buffer to avoid holes.
-            # In order to ensure absence of the holes actual buffer size
-            # is twice of this distance
+            # blockBufferSize reflects the size of the re-ordering buffer
+            # which captures blocks and takes care to deliver them in order
+            # down to the ledger layer. The actually buffer size is bounded between
+            # 0 and 2*blockBufferSize, each channel maintains its own buffer
             blockBufferSize: 100
             # maxRetries maximum number of re-tries to ask
             # for single state transfer request
             maxRetries: 3
 
     # TLS Settings
-    # Note that peer-chaincode connections through chaincodeListenAddress is
-    # not mutual TLS auth. See comments on chaincodeListenAddress for more info
     tls:
         # Require server-side TLS
         enabled:  false
@@ -296,8 +301,6 @@ peer:
             Pin:
             Hash:
             Security:
-            FileKeyStore:
-                KeyStore:
 
     # Path on the file system where peer will find MSP local configurations
     mspConfigPath: msp
@@ -328,6 +331,16 @@ peer:
         # It sets the delivery service maximal delay between consecutive retries
         reConnectBackoffThreshold: 3600s
 
+        # A list of orderer endpoint addresses which should be overridden
+        # when found in channel configurations.
+        addressOverrides:
+        #  - from:
+        #    to:
+        #    caCertsFile:
+        #  - from:
+        #    to:
+        #    caCertsFile:
+
     # Type for the local MSP - by default it's of type bccsp
     localMspType: bccsp
 
@@ -336,16 +349,6 @@ peer:
     profile:
         enabled:     false
         listenAddress: 0.0.0.0:6060
-
-    # The admin service is used for administrative operations such as
-    # control over logger levels, etc.
-    # Only peer administrators can use the service.
-    adminService:
-        # The interface and port on which the admin server will listen on.
-        # If this is commented out, or the port number is equal to the port
-        # of the peer listen address - the admin service is attached to the
-        # peer's service (defaults to 7051).
-        #listenAddress: 0.0.0.0:7055
 
     # Handlers defines custom handlers that can filter and mutate
     # objects passing within the peer, such as:
@@ -379,6 +382,8 @@ peer:
     #   escc:
     #     name: DefaultESCC
     #     library: /etc/hyperledger/fabric/plugin/escc.so
+    #
+    #TODO: Enable FPC Additions once tlcc and plugins are intergrated
     handlers:
         authFilters:
           -
@@ -388,10 +393,10 @@ peer:
         decorators:
           -
             name: DefaultDecorator
-          -
+          #  -
           # FPC Addition:1
-            name: ERCCDecorator
-            library: ../../ercc/ercc-decorator.so
+          #  name: ERCCDecorator
+          #  library: ../../ercc/ercc-decorator.so
         endorsers:
           escc:
             name: DefaultEndorsement
@@ -401,13 +406,13 @@ peer:
             name: DefaultValidation
             library:
           # FPC Addition:2
-          ercc-vscc:
-            name: ercc-vscc
-            library: ../../ercc/ercc-vscc.so
-          # FPC Addition:3 
-          ecc-vscc:
-            name: ecc-vscc
-            library: ../../ecc/ecc-vscc.so
+          # ercc-vscc:
+          #   name: ercc-vscc
+          #   library: ../../ercc/ercc-vscc.so
+          # # FPC Addition:3 
+          # ecc-vscc:
+          #   name: ecc-vscc
+          #   library: ../../ecc/ecc-vscc.so
 
     #    library: /etc/hyperledger/fabric/plugin/escc.so
     # Number of goroutines that will execute transaction validation in parallel.
@@ -432,6 +437,14 @@ peer:
         # Whether to allow non-admins to perform non channel scoped queries.
         # When this is false, it means that only peer admins can perform non channel scoped queries.
         orgMembersAllowedAccess: false
+
+    # Limits is used to configure some internal resource limits.
+    limits:
+      # Concurrency limits the number of concurrently running system chaincode requests.
+      # This option is only supported for qscc at this time.
+      concurrency:
+        qscc: 5000
+
 ###############################################################################
 #
 #    VM section
@@ -498,7 +511,7 @@ chaincode:
         name:
 
     # Generic builder environment, suitable for most chaincode types
-    builder: $(DOCKER_NS)/fabric-ccenv:latest
+    builder: $(DOCKER_NS)/fabric-ccenv:$(TWO_DIGIT_VERSION)
 
     # Enables/disables force pulling of the base docker images (listed below)
     # during user chaincode instantiation.
@@ -507,30 +520,38 @@ chaincode:
 
     golang:
         # golang will never need more than baseos
-        runtime: $(BASE_DOCKER_NS)/fabric-baseos:$(ARCH)-$(BASE_VERSION)
+        runtime: $(DOCKER_NS)/fabric-baseos:$(TWO_DIGIT_VERSION)
 
         # whether or not golang chaincode should be linked dynamically
         dynamicLink: false
-
-    car:
-        # car may need more facilities (JVM, etc) in the future as the catalog
-        # of platforms are expanded.  For now, we can just use baseos
-        runtime: $(BASE_DOCKER_NS)/fabric-baseos:$(ARCH)-$(BASE_VERSION)
 
     java:
         # This is an image based on java:openjdk-8 with addition compiler
         # tools added for java shim layer packaging.
         # This image is packed with shim layer libraries that are necessary
         # for Java chaincode runtime.
-        runtime: $(DOCKER_NS)/fabric-javaenv:$(ARCH)-$(PROJECT_VERSION)
+        runtime: $(DOCKER_NS)/fabric-javaenv:$(TWO_DIGIT_VERSION)
 
     node:
-        # need node.js engine at runtime, currently available in baseimage
-        # but not in baseos
-        runtime: $(BASE_DOCKER_NS)/fabric-baseimage:$(ARCH)-$(BASE_VERSION)
+        # This is an image based on node:$(NODE_VER)-alpine
+        runtime: $(DOCKER_NS)/fabric-nodeenv:$(TWO_DIGIT_VERSION)
+
+    # List of directories to treat as external builders and launchers for
+    # chaincode. The external builder detection processing will iterate over the
+    # builders in the order specified below.
+    externalBuilders: []
+        # - path: /path/to/directory
+        #   name: descriptive-builder-name
+        #   environmentWhitelist:
+        #      - ENVVAR_NAME_TO_PROPAGATE_FROM_PEER
+        #      - GOPROXY
+
+    # The maximum duration to wait for the chaincode build and install process
+    # to complete.
+    installTimeout: 300s
 
     # Timeout duration for starting up a container and waiting for Register
-    # to come through. 1sec should be plenty for chaincode unit tests
+    # to come through.
     startuptimeout: 300s
 
     # Timeout duration for Invoke and Init calls to prevent runaway.
@@ -559,31 +580,13 @@ chaincode:
     # whitelist, add "myscc: enable" to the list below, and register in
     # chaincode/importsysccs.go
     system:
+        _lifecycle: enable
         cscc: enable
         lscc: enable
         escc: enable
         vscc: enable
         qscc: enable
-        tlcc: enable  # FPC Addition:4
-
-    # System chaincode plugins:
-    # System chaincodes can be loaded as shared objects compiled as Go plugins.
-    # See examples/plugins/scc for an example.
-    # Plugins must be white listed in the chaincode.system section above.
-    systemPlugins:
-      # example configuration:
-      # - enabled: true
-      #   name: myscc
-      #   path: /opt/lib/myscc.so
-      #   invokableExternal: true
-      #   invokableCC2CC: true
-      #
-      # FPC Addition:5  
-      - enabled: true
-        name: tlcc
-        path: ../../tlcc/tlcc.so
-        invokableExternal: true
-        invokableCC2CC: true
+        #tlcc: enable  # FPC Addition:4
 
     # Logging section for the chaincode container
     logging:
@@ -596,7 +599,7 @@ chaincode:
 
 ###############################################################################
 #
-#    Ledger section - ledger configuration encompases both the blockchain
+#    Ledger section - ledger configuration encompasses both the blockchain
 #    and the state
 #
 ###############################################################################
@@ -649,6 +652,11 @@ ledger:
        # This is optional.  Creating the global changes database will require
        # additional system resources to track changes and maintain the database
        createGlobalChangesDB: false
+       # CacheSize denotes the maximum mega bytes (MB) to be allocated for the in-memory state
+       # cache. Note that CacheSize needs to be a multiple of 32 MB. If it is not a multiple
+       # of 32 MB, the peer would round the size to the next multiple of 32 MB.
+       # To disable the cache, 0 MB needs to be assigned to the cacheSize.
+       cacheSize: 64
 
   history:
     # enableHistoryDatabase - options are true or false
@@ -656,6 +664,14 @@ ledger:
     # All history 'index' will be stored in goleveldb, regardless if using
     # CouchDB or alternate database for the state.
     enableHistoryDatabase: true
+
+  pvtdataStore:
+    # the maximum db batch size for converting
+    # the ineligible missing data entries to eligible missing data entries
+    collElgProcMaxDbBatchSize: 5000
+    # the minimum duration (in milliseconds) between writing
+    # two consecutive db batches for converting the ineligible missing data entries to eligible missing data entries
+    collElgProcDbBatchesInterval: 1000
 
 ###############################################################################
 #

--- a/integration/config/msp/config.yaml
+++ b/integration/config/msp/config.yaml
@@ -2,6 +2,8 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
+#
+# Based on hyperledger/fabric/sampleconfig/msp
 
 OrganizationalUnitIdentifiers:
   - Certificate: "cacerts/cacert.pem"
@@ -9,10 +11,22 @@ OrganizationalUnitIdentifiers:
 
 NodeOUs:
   Enable: false
+  # For each identity classification that you would like to utilize, specify
+  # an OU identifier.
+  # You can optionally configure that the OU identifier must be issued by a specific CA
+  # or intermediate certificate from your organization. However, it is typical to NOT
+  # configure a specific Certificate. By not configuring a specific Certificate, you will be
+  # able to add other CA or intermediate certs later, without having to reissue all credentials.
+  # For this reason, the sample below comments out the Certificate field.
   ClientOUIdentifier:
-    # if Certificate is empty, then the certifier identifier will not be enforced
-    Certificate: "cacerts/cacert.pem"
+    # Certificate: "cacerts/cacert.pem"
     OrganizationalUnitIdentifier: "OU_client"
   PeerOUIdentifier:
-    Certificate: "cacerts/cacert.pem"
+    # Certificate: "cacerts/cacert.pem"
     OrganizationalUnitIdentifier: "OU_peer"
+  AdminOUIdentifier:
+    # Certificate: "cacerts/cacert.pem"
+    OrganizationalUnitIdentifier: "OU_admin"
+  OrdererOUIdentifier:
+    # Certificate: "cacerts/cacert.pem"
+    OrganizationalUnitIdentifier: "OU_orderer"

--- a/integration/config/orderer.yaml
+++ b/integration/config/orderer.yaml
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+# Based on hyperledger/fabric/sampleconfig
 
 ---
 ################################################################################
@@ -13,14 +14,6 @@
 #
 ################################################################################
 General:
-
-    # Ledger Type: The ledger type to provide to the orderer.
-    # Two non-production ledger types are provided for test purposes only:
-    #  - ram: An in-memory ledger whose contents are lost on restart.
-    #  - json: A simple file ledger that writes blocks to disk in JSON format.
-    # Only one production ledger type is provided:
-    #  - file: A production file-based ledger.
-    LedgerType: file
 
     # Listen address: The IP on which to bind to listen.
     ListenAddress: 127.0.0.1
@@ -77,24 +70,21 @@ General:
         ServerCertificate:
         # ServerPrivateKey defines the file location of the private key of the TLS certificate.
         ServerPrivateKey:
-    # Genesis method: The method by which the genesis block for the orderer
-    # system channel is specified. Available options are "provisional", "file":
-    #  - provisional: Utilizes a genesis profile, specified by GenesisProfile,
-    #                 to dynamically generate a new genesis block.
-    #  - file: Uses the file provided by GenesisFile as the genesis block.
-    GenesisMethod: provisional
 
-    # Genesis profile: The profile to use to dynamically generate the genesis
-    # block to use when initializing the orderer system channel and
-    # GenesisMethod is set to "provisional". See the configtx.yaml file for the
-    # descriptions of the available profiles. Ignored if GenesisMethod is set to
-    # "file".
-    GenesisProfile: SampleInsecureSolo
+    # Bootstrap method: The method by which to obtain the bootstrap block
+    # system channel is specified. The option can be one of:
+    #   "file" - path to a faile containing the genesis block or config block of system channel
+    #   "none" - allows an orderer to start without a system channel configuration
+    BootstrapMethod: file
 
-    # Genesis file: The file containing the genesis block to use when
-    # initializing the orderer system channel and GenesisMethod is set to
-    # "file". Ignored if GenesisMethod is set to "provisional".
-    GenesisFile: genesisblock
+    # Bootstrap file: The file containing the bootstrap block to use when
+    # initializing the orderer system channel and BootstrapMethod is set to
+    # "file".  The bootstrap file can be the genesis block, and it can also be
+    # a config block for late bootstrap of some consensus methods like Raft.
+    # Generate a genesis block by updating $FABRIC_CFG_PATH/configtx.yaml and
+    # using configtxgen command with "-outputBlock" option.
+    # Defaults to file "genesisblock" (in $FABRIC_CFG_PATH directory) if not specified.
+    BootstrapFile: /tmp/hyperledger/test/genesisblock
 
     # LocalMSPDir is where to find the private crypto material needed by the
     # orderer. It is set relative here as a default for dev environments but
@@ -136,6 +126,19 @@ General:
             FileKeyStore:
                 KeyStore:
 
+        # Settings for the PKCS#11 crypto provider (i.e. when DEFAULT: PKCS11)
+        PKCS11:
+            # Location of the PKCS11 module library
+            Library:
+            # Token Label
+            Label:
+            # User PIN
+            Pin:
+            Hash:
+            Security:
+            FileKeyStore:
+                KeyStore:
+
     # Authentication contains configuration parameters related to authenticating
     # client messages
     Authentication:
@@ -160,22 +163,6 @@ FileLedger:
     # The prefix to use when generating a ledger directory in temporary space.
     # Otherwise, this value is ignored.
     Prefix: hyperledger-fabric-ordererledger
-
-################################################################################
-#
-#   SECTION: RAM Ledger
-#
-#   - This section applies to the configuration of the RAM ledger.
-#
-################################################################################
-RAMLedger:
-
-    # History Size: The number of blocks that the RAM ledger is set to retain.
-    # WARNING: Appending a block to the ledger might cause the oldest block in
-    # the ledger to be dropped in order to limit the number total number blocks
-    # to HistorySize. For example, if history size is 10, when appending block
-    # 10, block 0 (the genesis block!) will be dropped to make room for block 10.
-    HistorySize: 1000
 
 ################################################################################
 #


### PR DESCRIPTION
Config files have been updated to fabric 2.0. However FPC Additions from 1 to 5 have been disabled (commented out)

TODO:
enable decorator , validation plugins and tlcc

Purpose of this PR:
This PR contains changes that make fabric/bin/ledger_init.sh and fabric/bin/ledger_shutdown.sh work with the new lifecycle. 
In this PR ercc.go chaincode is installed using the new fabric 2.0 lifecycle.

To test use:
env FABRIC_LOGGING_SPEC=debug FABRIC_CFG_PATH=$(/bin/pwd)/integration/config/ ./fabric/bin/ledger_init.sh

env FABRIC_LOGGING_SPEC=debug FABRIC_CFG_PATH=$(/bin/pwd)/integration/config/ ./fabric/bin/ledger_shutdown.sh

Signed-off-by: Jordan Karaze <jordan.karaze@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->
 

**What this PR does / why we need it**:
This PR addresses some of the components of PR #254 by upgrading config files
```
