### PR TITLE
Enable Mock server debug logging

### DIFF
--- a/demo/client/backend/mock/server.go
+++ b/demo/client/backend/mock/server.go
@@ -59,8 +59,11 @@ func main() {
 	flag.Parse()
 
 	if flagDebug {
-		// TODO find a way to set flogger log level to debug
-		//logger.SetLevel(shim.LogDebug)
+		// We activate our log level here, note that we can also directly control
+		// log level via FABRIC_LOGGING_SPEC. For more fine grained logging we could
+		// also use different log level for loggers.
+		// For example: FABRIC_LOGGING_SPEC=server=INFO:ecc=DEBUG:ecc_enclave=ERROR
+		flogging.ActivateSpec("DEBUG")
 	}
 
 	// deploy

--- a/ecc/cmd/main.go
+++ b/ecc/cmd/main.go
@@ -15,6 +15,11 @@ import (
 var logger = flogging.MustGetLogger("ecc")
 
 func main() {
+
+	// we can control logging via FABRIC_LOGGING_SPEC, the default is FABRIC_LOGGING_SPEC=INFO
+	// For more fine grained logging we could also use different log level for loggers.
+	// For example: FABRIC_LOGGING_SPEC=ecc=DEBUG:ecc_enclave=ERROR
+
 	// create enclave chaincode
 	t := ecc.NewEcc()
 	defer t.Destroy()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings back debug logging to the mock server.
As flogging comes with fabric we also it with FPC. The mock server, as
well as other components such as ERCC and ECC can be controlled through
FABRIC_LOGGING_SPEC env variable.

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #248

**Special notes for your reviewer**:
PR #88 can build on that one here.

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
