### PR TITLE
Adapt to recent openssl download reorganization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - sudo sh -c "echo 'yes' | ./${SGX_SDK_BIN}"; popd
   # SGX SSL
   - pushd $HOME; git clone --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git
-  - OPENSSL_MAJOR_VERSION=$(echo ${OPENSSL_VERSION} | sed 's/\([^0-9.]\)*//g'); wget https://www.openssl.org/source/openssl/old/${OPENSSL_MAJOR_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz; mv openssl-${OPENSSL_VERSION}.tar.gz intel-sgx-ssl/openssl_source
+  - OPENSSL_MAJOR_VERSION=$(echo ${OPENSSL_VERSION} | sed 's/\([^0-9.]\)*//g'); wget https://www.openssl.org/source/old/${OPENSSL_MAJOR_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz; mv openssl-${OPENSSL_VERSION}.tar.gz intel-sgx-ssl/openssl_source
   - cd intel-sgx-ssl/Linux; make SGX_MODE=SIM DESTDIR=$SGXSSL all test
   - cd intel-sgx-ssl/Linux; make install; popd
   # NANOPB

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_install:
   - sudo sh -c "echo 'yes' | ./${SGX_SDK_BIN}"; popd
   # SGX SSL
   - pushd $HOME; git clone --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git
-  - wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz; mv openssl-${OPENSSL_VERSION}.tar.gz intel-sgx-ssl/openssl_source
+  - OPENSSL_MAJOR_VERSION=$(echo ${OPENSSL_VERSION} | sed 's/\([^0-9.]\)*//g'); wget https://www.openssl.org/source/openssl/old/${OPENSSL_MAJOR_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz; mv openssl-${OPENSSL_VERSION}.tar.gz intel-sgx-ssl/openssl_source
   - cd intel-sgx-ssl/Linux; make SGX_MODE=SIM DESTDIR=$SGXSSL all test
   - cd intel-sgx-ssl/Linux; make install; popd
   # NANOPB

--- a/utils/docker/dev/Dockerfile
+++ b/utils/docker/dev/Dockerfile
@@ -45,7 +45,9 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl
-RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+RUN \
+    OPENSSL_MAJOR_VERSION=$(echo ${OPENSSL_VERSION} | sed 's/\([^0-9.]\)*//g') \
+ && wget https://www.openssl.org/source/old/${OPENSSL_MAJOR_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \
  && git clone  --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git \
  && . $SGX_SDK/environment \
  && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-${OPENSSL_VERSION}.tar.gz . ) \

--- a/utils/docker/peer/Dockerfile
+++ b/utils/docker/peer/Dockerfile
@@ -46,7 +46,9 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl
-RUN wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+RUN \
+    OPENSSL_MAJOR_VERSION=$(echo ${OPENSSL_VERSION} | sed 's/\([^0-9.]\)*//g') \
+ && wget https://www.openssl.org/source/old/${OPENSSL_MAJOR_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz \
  && git clone  --branch ${SGXSSL_VERSION} https://github.com/intel/intel-sgx-ssl.git \
  && . $SGX_SDK/environment \
  && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-${OPENSSL_VERSION}.tar.gz . ) \


### PR DESCRIPTION
**What this PR does / why we need it**:

Subject says it all.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Note that travis will fail eventually but it should only be later in the docker build of cc-builder due to the known issue that dev image is built from master, not current branch (see #269).  Also note that the `peer` image currently still won't build but that should also be after the openssl build relevant part during the attempt to do a `make plugins` which is currently not yet working ...