### PR TITLE
Run FPC CC via External Builders for FPC chaincode

### DIFF
--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -25,7 +25,7 @@ all: build
 # TODO test target disable because it requires revision
 #all: build test
 
-build: vscc-plugin sym-links
+build: ecc vscc-plugin sym-links
 
 ECC_ENCLAVE_BUILD = ../ecc_enclave/_build
 ERR_MSG = "ecc_enclave build does not exist!"

--- a/fabric/externalBuilder/bin/build
+++ b/fabric/externalBuilder/bin/build
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2020 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+
+. ${SCRIPTDIR}/lib/common.sh
+
+[ "$#" -eq 3 ] || die "Expected 3 directories got $#"
+
+CC_SOURCE_DIR="$1"
+CC_METADATA_DIR="$2"
+CC_BUILD_DIR="$3"
+
+check_pkg_meta || die "failed to check package meta-data"
+
+[ "${REQUEST_CC_TYPE}" == "${FPC_CC_TYPE}" ] || die "i've told you before in 'detect' that we do not support '${FPC_CC_TYPE}'?!"
+
+check_pkg_src || die "failed to check package source"
+
+cc_build || die "failed to build"
+
+exit 0

--- a/fabric/externalBuilder/bin/detect
+++ b/fabric/externalBuilder/bin/detect
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2020 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+
+. ${SCRIPTDIR}/lib/common.sh
+
+
+[ "$#" -eq 2 ] || die "Expected 2 directories got $#"
+
+CC_SOURCE_DIR="$1"
+CC_METADATA_DIR="$2"
+
+check_pkg_meta || die "failed to check package meta-data"
+
+if [ "${REQUEST_CC_TYPE}" != "${FPC_CC_TYPE}" ]; then
+    say "only '${FPC_CC_TYPE}' chaincode supported"
+    exit 1
+fi
+
+check_pkg_src || die "failed to check package source"
+
+say "found support '${FPC_CC_TYPE}' chaincode "
+exit 0
+

--- a/fabric/externalBuilder/bin/lib/common.sh
+++ b/fabric/externalBuilder/bin/lib/common.sh
@@ -1,0 +1,185 @@
+# Copyright 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# assumes SCRIPTDIR is defined ...
+
+FPC_TOP_DIR=$(readlink -f "${SCRIPTDIR}/../../../")
+FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
+. ${FABRIC_SCRIPTDIR}/lib/common_utils.sh
+
+FPC_CC_TYPE="fpc-c"
+
+: ${FPC_HOSTING_MODE:=host} # alternatives: host, docker (not yet implemented), kubernetes (not yet implemented)
+
+
+METADATA_FILE="metadata.json"
+ENCLAVE_FILE="enclave.signed.so"
+MRENCLAVE_FILE="mrenclave"
+
+
+# assumes CC_SOURCE_DIR & CC_METADATA_DIR: / provides: REQUEST_CC_TYPE
+check_pkg_meta(){
+    [ -f "${CC_METADATA_DIR}/${METADATA_FILE}" ] || die "no metadata file '${METADATA_FILE}'"
+    REQUEST_CC_TYPE="$(jq -r .type "${CC_METADATA_DIR}/metadata.json" | tr '[:upper:]' '[:lower:]')"
+}
+
+# assumes CC_SOURCE_DIR & CC_METADATA_DIR: / provides:SGX_MODE
+check_pkg_src(){
+    SGX_MODE="$(jq -r .sgx_mode "${CC_METADATA_DIR}/metadata.json")"
+    [ ! -z "${SGX_MODE}" ]                       || die "SGX mode not specified in metadata file"
+
+    [ -f "${CC_SOURCE_DIR}/${MRENCLAVE_FILE}" ]  || die "no enclave file '${ENCLAVE_FILE}'"
+    [ -f "${CC_SOURCE_DIR}/${ENCLAVE_FILE}" ]    || die "no MRENCLAVE file '${MRENCLAVE_FILE}'"
+}
+
+
+# run directly on host
+cc_build_for_host() {
+
+    # - just make sure we have in build-dir the chaincode binary, required libraries as well
+    #   as ${ENCLAVE_FILE} and ${MRENCLAVE_FILE} in the appropriate place that we can run
+    #   directly out of that directory
+
+    CC_PATH="${CC_BUILD_DIR}"
+    CC_LIB_PATH="${CC_PATH}/enclave/lib"
+
+    mkdir -p ${CC_LIB_PATH}
+
+    # - ecc shims
+    try ln -s "${FPC_TOP_DIR}/ecc/ecc" "${CC_PATH}/chaincode"
+    try ln -s "${FPC_TOP_DIR}/ecc_enclave/_build/lib/libsgxcc.so" "${CC_LIB_PATH}/"
+
+    # - chaincode specific stuff
+    try cp "${CC_SOURCE_DIR}/${MRENCLAVE_FILE}" "${CC_PATH}"
+    try cp "${CC_SOURCE_DIR}/${ENCLAVE_FILE}" "${CC_LIB_PATH}"
+
+    # - store also meta-data file
+    try cp "${CC_METADATA_DIR}/${METADATA_FILE}" "${CC_PATH}"
+}
+
+cc_build_for_docker() {
+    # TODO: Implement me
+    die "building FPC for docker is not yet implemented"
+
+    # Adapt old container switcheroo ...
+    # - DOCKER_IMAGE_NAME="some string" & remember it in CC_BUILD_DIR
+    # - try make SGX_MODE=${SGX_MODE} ENCLAVE_SO_PATH=${CC_ENCLAVESOPATH} DOCKER_IMAGE=${DOCKER_IMAGE_NAME} -C ${FPC_TOP_DIR}/ecc docker-fpc-app
+}
+
+# assumes CC_BUILD_DIR & CC_RT_METADATA_DIR
+# provides: SGX_MODE, PEER_ADDRESS, TLS_ARTIFACTS_DIR & all env-vars expected by shim
+process_runtime_metadata() {
+    # Note: while the sample scripts re-use ${CC_RT_METADATA_DIR} to extract the
+    # artifacts from chaincode.json, the docu explicitly says one should treat
+    # that dir as read-only. So we create a separate tmp directory to store
+    # extracted artifacts.
+
+    TLS_ARTIFACTS_DIR="/tmp/fpc-extbuilder.$$"
+    try mkdir -p "${TLS_ARTIFACTS_DIR}"
+
+
+    [ -f "${CC_BUILD_DIR}/${METADATA_FILE}" ] || die "no metadata file '${METADATA_FILE}'"
+    SGX_MODE="$(jq -r .sgx_mode "${CC_BUILD_DIR}/metadata.json")"
+    [ ! -z "${SGX_MODE}" ]                       || die "SGX mode not specified in metadata file"
+
+    [ -f "${CC_RT_METADATA_DIR}/chaincode.json" ] || die "chaincode.jsaon does not exist"
+    export CORE_CHAINCODE_ID_NAME="$(jq -r .chaincode_id "${CC_RT_METADATA_DIR}/chaincode.json")" || die "could not extract chaincode-id"
+    PEER_ADDRESS=$(jq -r .peer_address "${CC_RT_METADATA_DIR}/chaincode.json") || die "could not extract peer address"
+
+    export CORE_PEER_LOCALMSPID="$(jq -r .mspid "${CC_RT_METADATA_DIR}/chaincode.json")" || die "could not extract peer MSPID"
+
+    if [ -z "$(jq -r .client_cert "${CC_RT_METADATA_DIR}/chaincode.json")" ]; then
+	export CORE_PEER_TLS_ENABLED="false"
+    else
+	export CORE_PEER_TLS_ENABLED="true"
+	export CORE_TLS_CLIENT_CERT_FILE="${TLS_ARTIFACTS_DIR}/client.crt"
+	try jq -r .client_cert "${CC_RT_METADATA_DIR}/chaincode.json" > "${CORE_TLS_CLIENT_CERT_FILE}"
+	export CORE_TLS_CLIENT_KEY_FILE="${TLS_ARTIFACTS_DIR}/client.key"
+	try jq -r .client_key  "${CC_RT_METADATA_DIR}/chaincode.json" > "${CORE_TLS_CLIENT_KEY_FILE}"
+	export CORE_PEER_TLS_ROOTCERT_FILE="${TLS_ARTIFACTS_DIR}/root.crt"
+	try jq -r .root_cert   "${CC_RT_METADATA_DIR}/chaincode.json" > "${CORE_PEER_TLS_ROOTCERT_FILE}"
+    fi
+
+    # For debugging purposes, we also symlink the source metadata & build artifacts
+    try ln -s "${CC_BUILD_DIR}/" "${TLS_ARTIFACTS_DIR}/build"
+    try ln -s "${CC_RT_METADATA_DIR}/" "${TLS_ARTIFACTS_DIR}/rt-metadata"
+}
+
+# expects CC_BUILD_DIR and variables set in 'process_runtime_metadata'
+# provides CC_PID, process id of chaincode
+cc_run_on_host() {
+    # get SGX SDK environment variables
+    export SGX_SDK="/opt/intel/sgxsdk"
+    if [ -z ${PKG_CONFIG_PATH+x} ]; then PKG_CONFIG_PATH=""; fi # Hack necessary as below otherwise uses undefined var
+    . "${SGX_SDK}/environment"
+
+    CC_LIB_PATH="${CC_BUILD_DIR}/enclave/lib"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${CC_LIB_PATH}"
+
+    # Notes on starting chaincode
+    # - cd is necessary so (relatively linked) enclave is found
+    # - we start here in background as we also have to do setup but
+    #   later have to block on the termination of the chaincode,
+    #   hence remembering the CC_PID
+    try cd "${CC_BUILD_DIR}"
+    ./chaincode -peer.address="${PEER_ADDRESS}" 2>&1 | tee "${TLS_ARTIFACTS_DIR}/chaincode.log" &
+    CC_PID=$!
+    sleep 1
+    kill -0 ${CC_PID} || die "Chaincode quit too quickly: (for log see '${TLS_ARTIFACTS_DIR}/chaincode.log')"
+}
+
+# expects CC_BUILD_DIR and variables set in 'process_runtime_metadata'
+# provides CC_PID, process id of chaincode (container)
+cc_run_on_docker() {
+    # TODO: Implement me
+    # - get docker image name from CC_BUILD_DIR
+    # - start docker all CORE_.. env-variables explicitly passed and
+    #   with any TLS artifacts mounted via a volume (using some path
+    #   is externally, so we don't have to do path renaming ..)
+    # - depending on sgx-mode, we also have to pass the SGX device & socket
+    die "running FPC inside docker is not yet implemented"
+}
+
+# assumes CC_SOURCE_DIR & CC_METADATA_DIR are set
+cc_build() {
+    case "${FPC_HOSTING_MODE}" in
+	host)
+	    cc_build_for_host || die "failed to build for host"
+	    ;;
+	docker)
+	    cc_build_for_docker || die "failed to build for docker"
+	    ;;
+	*)
+	    die "unsupported hosting mode '${FPC_HOSTING_MODE}'"
+    esac
+}
+
+# assumes CC_BUILD_DIR & CC_RT_METADATA_DIR are set
+cc_run() {
+    # - process inputs
+    process_runtime_metadata || die "could not process runtime metadata"
+
+    # - start the actual chaincode (in background)
+    case "${FPC_HOSTING_MODE}" in
+	host)
+	    cc_run_on_host || die "failed to run on host"
+	    ;;
+	docker)
+	    cc_run_on_docker || die "failed to run on docker"
+	    ;;
+	*)
+	    die "unsupported hosting mode '${FPC_HOSTING_MODE}'"
+    esac
+
+    # Here we might eventually do additional setup functionality, e.g.,
+    # managing sealed state. Note, though, that we do have information such as
+    # channel id or alike so we can _not_ do normal peer cli chaincode
+    # invocations to call "__setup" or alike! Hence we do that stil in peer.sh
+    # for now ...
+
+    # external builder interface asks us to return from script only once
+    # chaincode process terminats
+    wait ${CC_PID}
+}
+

--- a/fabric/externalBuilder/bin/release
+++ b/fabric/externalBuilder/bin/release
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright Intel Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+
+. ${SCRIPTDIR}/lib/common.sh
+
+
+[ "$#" -eq 2 ] || die "Expected 2 directories got $#"
+
+CC_BUILD_DIR="$1"
+CC_RELEASE_DIR="$2"
+
+if [ -d "${CC_BUILD_DIR}/META-INF" ] ; then
+   cp -a "${CC_BUILD_DIR}/META-INF"/* "$RELEASE"
+fi
+
+# TODO (eventually): figure out what has to change (if at all) for CCaaS to work
+yell "release/CCaaS is not yet a supported/tested version for FPC" 
+exit 0
+
+
+

--- a/fabric/externalBuilder/bin/run
+++ b/fabric/externalBuilder/bin/run
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright Intel Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -uo pipefail
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+
+. ${SCRIPTDIR}/lib/common.sh
+
+
+[ "$#" -eq 2 ] || die "Expected 2 directories got $#"
+
+CC_BUILD_DIR="$1"
+CC_RT_METADATA_DIR="$2"
+
+cc_run

--- a/integration/config/configtx.yaml
+++ b/integration/config/configtx.yaml
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Based on hyperledger/fabric/sampleconfig
+# Based on sampleconfig from github.com/hyperledger/fabric.git tagged with v2.0.1
+
 ---
 ################################################################################
 #

--- a/integration/config/core.yaml.orig
+++ b/integration/config/core.yaml.orig
@@ -1,9 +1,9 @@
 # Copyright IBM Corp. All Rights Reserved.
-# Copyright 2020 Intel Corporation
+# Copyright Intel Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Based on sampleconfig from github.com/hyperledger/fabric.git tagged with v2.0.1 
+# Based on sampleconfig from github.com/hyperledger/fabric.git tagged with v2.0.1
 
 ###############################################################################
 #
@@ -22,12 +22,12 @@ peer:
 
     # The Address at local network interface this Peer will listen on.
     # By default, it will listen on all network interfaces
-    # FPC change: the original 0.0.0.0 didn't always work in some settings and we need it only for localhost
-    listenAddress: 127.0.0.1:7051
+    listenAddress: 0.0.0.0:7051
 
     # The endpoint this peer uses to listen for inbound chaincode connections.
     # If this is commented-out, the listen address is selected to be
     # the peer's address (see below) with port 7052
+    # chaincodeListenAddress: 0.0.0.0:7052
     chaincodeListenAddress: 0.0.0.0:7052 # Note: we uncommented it to make working with our dev docker image
 
     # The endpoint the chaincode for this peer uses to connect to the peer.
@@ -40,8 +40,7 @@ peer:
     # in the same organization. For peers in other organization, see
     # gossip.externalEndpoint for more info.
     # When used as CLI config, this means the peer's endpoint to interact with
-    # FPC change: see comment above listenAddress above ..
-    address: 127.0.0.1:7051
+    address: 0.0.0.0:7051
 
     # Whether the Peer should programmatically determine its address
     # This case is useful for docker containers.
@@ -539,28 +538,12 @@ chaincode:
     # List of directories to treat as external builders and launchers for
     # chaincode. The external builder detection processing will iterate over the
     # builders in the order specified below.
-    # externalBuilders: []
+    externalBuilders: []
         # - path: /path/to/directory
         #   name: descriptive-builder-name
         #   environmentWhitelist:
         #      - ENVVAR_NAME_TO_PROPAGATE_FROM_PEER
         #      - GOPROXY
-    externalBuilders:
-        # FPC Addition 0: external builder for fpc-c chaincode
-        - path: ../../fabric/externalBuilder
-          name: fpc-c
-          environmentWhitelist:
-              - FPC_HOSTING_MODE
-              - FABRIC_LOGGING_SPEC
-              - ftp_proxy
-              - http_proxy
-              - https_proxy
-              - no_proxy
-              # Notes:
-              # - FPC_HOSTING_MODE will determine whether chaincode is executed
-              #   directly on host or inside a container
-              # - for go builds, we also would have to define HOME and/or GOCACHE
-
 
     # The maximum duration to wait for the chaincode build and install process
     # to complete.
@@ -607,9 +590,11 @@ chaincode:
     # Logging section for the chaincode container
     logging:
       # Default level for all loggers within the chaincode container
+      #level:  info
       level:  debug
       # Override default level for the 'shim' logger
-      shim:   info
+      #shim:   warning
+      shim:  info 
       # Format for the chaincode container logs
       format: '%{color}%{time:2006-01-02 15:04:05.000 MST} [%{module}] %{shortfunc} -> %{level:.4s} %{id:03x}%{color:reset} %{message}'
 
@@ -747,7 +732,7 @@ metrics:
 ###############################################################################
 #
 #    SGX section - includes configuration for the Intel Attestation service
-#    FPC Addition:5
+#    FPC Addition:6  (FPC Addition:5 no longer supported)
 #
 ###############################################################################
 sgx:

--- a/integration/config/msp/config.yaml
+++ b/integration/config/msp/config.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Based on hyperledger/fabric/sampleconfig/msp
+# Based on sampleconfig from github.com/hyperledger/fabric.git tagged with v2.0.1
 
 OrganizationalUnitIdentifiers:
   - Certificate: "cacerts/cacert.pem"

--- a/integration/config/orderer.yaml
+++ b/integration/config/orderer.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Based on hyperledger/fabric/sampleconfig
+# Based on sampleconfig from github.com/hyperledger/fabric.git tagged with v2.0.1
 
 ---
 ################################################################################


### PR DESCRIPTION
**What this PR does / why we need it**:
- enable external builders in integration test config
- modify peer.sh to remove install/instantiate wrapping for fpc-CC but add a wrapper for lifecycle chaincode package
- create the external builder scripts, currently just doing essentially what the wrapper has done before, although not yet vi docker but directly on host ..

**Which issue(s) this PR fixes**:
Fixes #249, also addresses parts of #254 

**Special notes for your reviewer**:
As we do not yet have decorators and tlcc, 
- ercc registration will fail (but corresponding error is currently ignored, so corresponding TODO in peer.sh)
- stateful transactions do not work (or more precisely, transaction which want to read state; the initial write seems to work).


Also, right now there are three (potential) limitations:
- I haven't tested yet with SGX HW mode but before we have at least the decorator sorted out, it didn't make sense to already spend time on that. However, i don't think it should require changes to the external builder itself in host-run mode (docker would be a different story, see comments in `common.sh`
- the chaincode runs directly on the host. the scaffolding for running it on docker is there but getting that done does not seem to be on the critical patch and can be done later
- the peer currently does not work for non-fpc CC.  What would have to be done is described in TODOs in peer.sh but not yet implemented. Right now i don't think any of our examples or the demo was using the peer wrapper also for non-fpc cc and with the ercc refactoring, the whole ercc setup process during channel join will have to modified any way, so there didn't seem a point in implementing this now only to be thrown out soon ..

None of the integration tests are yet converted/tested and i just tested manually.  To get you a quick start with manual testing, see below what i was using as template for testing:
```
export FABRIC_LOGGING_SPEC=debug
export FABRIC_CFG_PATH=$(/bin/pwd)/integration/config/ 
export FABRIC_BIN_DIR=$(readlink -f "../../hyperledger/fabric/build/bin")
export PATH=${FABRIC_BIN_DIR}:${PATH}

./fabric/bin/ledger_shutdown.sh

CHAN_ID=mychannel
PEER=./fabric/bin/peer.sh

./fabric/bin/ledger_init.sh

# example chaincode to use ..
# - echo
LBL=echo
VER=0
CC_LANG=fpc-c
CC_PATH=examples/echo/_build/lib/
#
# - Auction
LBL=auction
VER=0
CC_LANG=fpc-c
CC_PATH=examples/auction/_build/lib/

PKG=/tmp/${LBL}.tar.gz

${PEER} lifecycle chaincode package --lang ${CC_LANG} --label ${LBL} --path ${CC_PATH} ${PKG}
${PEER} lifecycle chaincode install ${PKG}

${PEER} lifecycle chaincode queryinstalled

PKG_ID=$(${PEER} lifecycle chaincode queryinstalled | awk "/Package ID: ${LBL}/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')

${PEER} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${LBL} --version ${VER} # --init-required # extra flag required for auction test
${PEER} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${LBL} --version ${VER}

${PEER} lifecycle chaincode commit -C ${CHAN_ID} --name ${LBL} --version ${VER}  # --init-required # extra flag required for auction test

${PEER} lifecycle chaincode querycommitted -C ${CHAN_ID}

# - echo
${PEER} chaincode invoke -C ${CHAN_ID} -n ${LBL} -c '{"Args": ["echo-1"]}'
#  should work ..

# - auction
${PEER} chaincode invoke -C ${CHAN_ID} -n ${LBL} --isInit -c '{"Args":["My Auction"]}'
# should succeed
${PEER} chaincode invoke -C ${CHAN_ID} -n ${LBL} -c '{"Function":"create", "Args": ["MyAuction1"]}' --waitForEvent
# will fail due to tlcc not being there ...

./fabric/bin/ledger_shutdown.sh

```

 
**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:

The peer wrapper does not work with multiple peers anymore (strictly speaking, we never tested multi-peer in old version and the lack of support is already since #307,  but just spelling it here explicitly) 