### PR TITLE
Remove init chaincode API and enables auction and echo tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ include $(TOP)/build.mk
 
 # TODO bring TLCC back
 # TODO bring back demo
-# TODO bring back Integration test with #256
 # SUB_DIRS = utils ercc ecc_enclave ecc tlcc_enclave tlcc examples integration demo # docs
-SUB_DIRS = utils ercc ecc_enclave ecc plugins examples
+SUB_DIRS = utils ercc ecc_enclave ecc plugins examples integration
 FPC_SDK = utils/fabric ecc_enclave ecc
 
 .PHONY: license

--- a/demo/chaincode/fpc/entry.cpp
+++ b/demo/chaincode/fpc/entry.cpp
@@ -9,12 +9,6 @@
 #include "dispatcher.h"
 #include "json/parson.h"
 
-int init(
-    uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)
-{
-    return 0;
-}
-
 int invoke(
     uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)
 {

--- a/ecc_enclave/enclave/enclave.cpp
+++ b/ecc_enclave/enclave/enclave.cpp
@@ -81,7 +81,7 @@ int gen_response(const char* txType,
     // - ecc/crypto/ecdsa.go::Verify (for VSCC)
     // - tlcc_enclave/enclave/ledger.cpp::int parse_endorser_transaction (for TLCC)
 
-    // create Hash <- H(txType in {"init", "invoke"} || encoded_args || result || read set || write
+    // create Hash <- H(txType in {"invoke"} || encoded_args || result || read set || write
     // set)
     // TODO: we should encode the hash below in an unambiguous fashion (which is not true with
     //    simple concatenation as done below!)
@@ -143,37 +143,6 @@ int gen_response(const char* txType,
     std::string base64_pk =
         base64_encode((const unsigned char*)&enclave_pk, sizeof(sgx_ec256_public_t));
     LOG_DEBUG("ecc sig pk (base64): %s", base64_pk.c_str());
-
-    return ret;
-}
-
-// chaincode initialization
-// output, response <- F(args, input)
-// signature <- sign (hash,sk)
-int ecall_cc_init(const char* encoded_args,
-    uint8_t* response,
-    uint32_t response_len_in,
-    uint32_t* response_len_out,
-    sgx_ec256_signature_t* signature,
-    void* u_shim_ctx)
-{
-    LOG_DEBUG("ecall_cc_init: \tArgs: %s", encoded_args);
-
-    t_shim_ctx_t ctx;
-    ctx.u_shim_ctx = u_shim_ctx;
-    ctx.encoded_args = encoded_args;
-    ctx.json_args = encoded_args;  // no encryption involved, so same as encoded_args ..
-
-    // call chaincode invoke logic: creates output and response
-    // output, response <- F(args, input)
-    int ret;
-    ret = init(response, response_len_in, response_len_out, &ctx);
-    if (ret != 0)
-    {
-        return SGX_ERROR_UNEXPECTED;
-    }
-
-    ret = gen_response("init", response, response_len_out, signature, &ctx);
 
     return ret;
 }

--- a/ecc_enclave/enclave/enclave.edl
+++ b/ecc_enclave/enclave/enclave.edl
@@ -13,13 +13,6 @@ enclave {
                 [in] const sgx_report_t *report,
                 [in, size=64] const uint8_t *pubkey);
 
-        public int ecall_cc_init(
-                [in, string] const char *encoded_args,
-                [out, size=response_len_in] uint8_t *response, uint32_t response_len_in,
-                [out] uint32_t *response_len_out,
-                [out] sgx_ec256_signature_t *signature,
-                [user_check] void *u_shim_ctx);
-
         public int ecall_cc_invoke(
                 [in, string] const char *encoded_args,
                 [in, string] const char *pk,

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -15,12 +15,6 @@ typedef struct t_shim_ctx* shim_ctx_ptr_t;
 
 // Function which FPC chaincode has to implement
 // ==================================================
-// - init, called when the chaincode is instantiated
-int init(uint8_t* response,
-    uint32_t max_response_len,
-    uint32_t* actual_response_len,
-    shim_ctx_ptr_t ctx);
-
 // - invoke, called when a transaction query or invocation is executed
 int invoke(uint8_t* response,
     uint32_t max_response_len,
@@ -148,7 +142,7 @@ int get_func_and_params(
     std::string& func_name, std::vector<std::string>& params, shim_ctx_ptr_t ctx);
 // Note: both functions should work interchangely, also regardless whether used
 // the '{ "args": [ ..] }' or the '{ "function": "name", "args": [ ..] }' syntax  with
-// the '--ctor'/'-c' parameter of peer cli command for option 'chaincode [instantiate|invoke|query].
+// the '--ctor'/'-c' parameter of peer cli command for option 'chaincode [invoke|query].
 // Behind the scenes the two variants are always treated as a list of args, with the first
 // one being the function.
 

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -50,26 +50,6 @@ int sgxcc_bind(enclave_id_t eid, report_t* report, ec256_public_t* pubkey)
     return SGX_SUCCESS;
 }
 
-int sgxcc_init(enclave_id_t eid,
-    const char* encoded_args,
-    uint8_t* response,
-    uint32_t response_len_in,
-    uint32_t* response_len_out,
-    ec256_signature_t* signature,
-    void* ctx)
-{
-    int enclave_ret = SGX_ERROR_UNEXPECTED;
-    int ret = ecall_cc_init(eid, &enclave_ret,
-        encoded_args,                                 // args (encoded and potentially encrypted)
-        response, response_len_in, response_len_out,  // response
-        (sgx_ec256_signature_t*)signature,            // signature
-        ctx);                                         // context for callback
-
-    CHECK_SGX_ERROR_AND_RETURN_ON_ERROR(ret)
-    CHECK_SGX_ERROR_AND_RETURN_ON_ERROR(enclave_ret)
-    return SGX_SUCCESS;
-}
-
 int sgxcc_invoke(enclave_id_t eid,
     const char* encoded_args,
     const char* pk,

--- a/ecc_enclave/sgxcclib/sgxcclib.h
+++ b/ecc_enclave/sgxcclib/sgxcclib.h
@@ -16,16 +16,6 @@ extern "C" {
 
 int sgxcc_bind(enclave_id_t eid, report_t* report, ec256_public_t* pubkey);
 
-int sgxcc_init(enclave_id_t eid,
-    const char* args,
-    // Note: no PK, init only/mainly useful iff it involves explicit org-approval and then should be
-    // public
-    uint8_t* response,
-    uint32_t response_len_in,
-    uint32_t* response_len_out,
-    ec256_signature_t* signature,
-    void* ctx);
-
 int sgxcc_invoke(enclave_id_t eid,
     const char* args,
     const char* pk,  // client pk used for args encryption, if null

--- a/examples/README.md
+++ b/examples/README.md
@@ -360,19 +360,20 @@ Add the following content to the function, `helloworld_test()` in test.sh.  Plea
 ```
 helloworld_test() {
     say "- do hello world"
-    # install and instantiate helloworld  chaincode
 
-    # builds the docker image; creates the docker container and enclave;
+    # install helloworld  chaincode
     # input:  CC_ID:chaincode name; CC_VERS:chaincode version;
     #         ENCLAVE_SO_PATH:path to build artifacts
     say "- install helloworld chaincode"
-    try ${PEER_CMD} chaincode install -l fpc-c -n ${CC_ID} -v ${CC_VERS} -p ${ENCLAVE_SO_PATH}
-    sleep 3
+    PKG=/tmp/${CC_ID}.tar.gz
+    try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label ${CC_ID} --path ${CC_PATH} ${PKG}
+    try ${PEER_CMD} lifecycle chaincode install ${PKG}
 
-    # instantiate helloworld chaincode
-    say "- instantiate helloworld chaincode"
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"args":[]}' -V ecc-vscc
-    sleep 3
+    PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: ${CC_ID}/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
+
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VERS}
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS}
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS}
 
     # store the value of 100 in asset1
     say "- invoke storeAsset transaction to store value 100 in asset1"
@@ -402,26 +403,26 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 CC_ID=helloworld_test
 
 #this is the path that will be used for the docker build of the chaincode enclave
-ENCLAVE_SO_PATH=examples/helloworld/_build/lib/
+CC_PATH=examples/helloworld/_build/lib/
 
 CC_VERS=0
 
 helloworld_test() {
     say "- do hello world"
-    # install and instantiate helloworld  chaincode
 
-    # builds the docker image; creates the docker container and enclave;
+    # install helloworld  chaincode
     # input:  CC_ID:chaincode name; CC_VERS:chaincode version;
     #         ENCLAVE_SO_PATH:path to build artifacts
-
     say "- install helloworld chaincode"
-    try ${PEER_CMD} chaincode install -l fpc-c -n ${CC_ID} -v ${CC_VERS} -p ${ENCLAVE_SO_PATH}
-    sleep 3
+    PKG=/tmp/${CC_ID}.tar.gz
+    try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label ${CC_ID} --path ${CC_PATH} ${PKG}
+    try ${PEER_CMD} lifecycle chaincode install ${PKG}
 
-    # instantiate helloworld chaincode
-    say "- instantiate helloworld chaincode"
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"args":[""]}' -V ecc-vscc
-    sleep 3
+    PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: ${CC_ID}/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
+
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VERS}
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS}
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS}
 
     # store the value of 100 in asset1
     say "- invoke storeAsset transaction to store value 100 in asset1"

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,6 @@ This example illustrates a simple usecase where the chaincode is used to store a
 * Develop chaincode
 * Launch Fabric network
 * Install and instantiate chaincode on the peer
-* Init transaction
 * Invoke transactions (`storeAsset` and `retrieveAsset`)
 * Shut down the network
 
@@ -28,31 +27,11 @@ cd helloworld
 touch helloworld_cc.cpp
 ```
 
-* Add the necessary includes and a preliminary version of `init` function.  A chaincode has to implement the `init` method which the peer calls when the chaincode is instantiated. The result of the transaction is returned in `response`.  `ctx` represents the transaction context.  The function body also illustrates the use of context, e.g., it allows us to retrieve the invocation arguments as defined, e.g., with `--ctor` parameter of `chaincode instantiate` peer cli command.
-
+* Add the necessary includes and a preliminary version of `invoke` function. The result of the transaction is returned in `response`. `ctx` represents the transaction context. The function body illustrates another way to get invocation parameters, similar to functions provided in go shim.
 ```
 #include "shim.h"
 #include "logging.h"
 #include <string>
-
-// implements chaincode logic for init
-int init(
-    uint8_t* response,
-    uint32_t max_response_len,
-    uint32_t* actual_response_len,
-    shim_ctx_ptr_t ctx)
-{
-    std::vector<std::string> argss;
-    get_string_args(argss, ctx);
-
-    return 0;
-}
-```
-
-* Add preliminary version of `invoke` function.  The arguments have the same semantics as for `init`. The function body illustrates another way to get invocation parameters, similar to functions provided in go shim.
-
-
-```
 
 // implements chaincode logic for invoke
 int invoke(
@@ -174,27 +153,6 @@ int invoke(
 }
 ```
 
-Let us also modify `init` method to retrieve and log who triggered the transaction.
-```
-// implements chaincode logic for init
-int init(
-    uint8_t* response,
-    uint32_t max_response_len,
-    uint32_t* actual_response_len,
-    shim_ctx_ptr_t ctx)
-{
-    char real_bidder_name_msp_id[1024];
-    char real_bidder_name_dn[1024];
-    get_creator_name(real_bidder_name_msp_id, sizeof(real_bidder_name_msp_id),
-        real_bidder_name_dn, sizeof(real_bidder_name_dn), ctx);
-
-    LOG_DEBUG("HelloworldCC: +++ Chaincode is initialized by (msp_id: %s, dn: %s) +++",
-        real_bidder_name_msp_id, real_bidder_name_dn);
-
-    return 0;
-}
-```
-
 Here is the complete file, `helloworld_cc.cpp`:
 ```
 #include "shim.h"
@@ -205,25 +163,6 @@ Here is the complete file, `helloworld_cc.cpp`:
 #define NOT_FOUND "Asset not found"
 
 #define MAX_VALUE_SIZE 1024
-
-
-// implements chaincode logic for init
-int init(
-    uint8_t* response,
-    uint32_t max_response_len,
-    uint32_t* actual_response_len,
-    shim_ctx_ptr_t ctx)
-{
-    char real_bidder_name_msp_id[1024];
-    char real_bidder_name_dn[1024];
-    get_creator_name(real_bidder_name_msp_id, sizeof(real_bidder_name_msp_id),
-        real_bidder_name_dn, sizeof(real_bidder_name_dn), ctx);
-
-    LOG_DEBUG("HelloworldCC: +++ Chaincode is initialized by (msp_id: %s, dn: %s) +++",
-        real_bidder_name_msp_id, real_bidder_name_dn);
-
-    return 0;
-}
 
 //  Add asset_name, value to ledger
 std::string storeAsset(std::string asset_name, int value, shim_ctx_ptr_t ctx)
@@ -432,7 +371,7 @@ helloworld_test() {
 
     # instantiate helloworld chaincode
     say "- instantiate helloworld chaincode"
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"args":["init"]}' -V ecc-vscc
+    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"args":[]}' -V ecc-vscc
     sleep 3
 
     # store the value of 100 in asset1
@@ -481,7 +420,7 @@ helloworld_test() {
 
     # instantiate helloworld chaincode
     say "- instantiate helloworld chaincode"
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"args":["init"]}' -V ecc-vscc
+    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"args":[""]}' -V ecc-vscc
     sleep 3
 
     # store the value of 100 in asset1

--- a/examples/auction/auction_cc.h
+++ b/examples/auction/auction_cc.h
@@ -9,6 +9,7 @@
 #include <string>
 #include "shim.h"
 
+std::string init_auction_house(std::string auction_house_name, shim_ctx_ptr_t ctx);
 std::string auction_create(std::string auction_name, shim_ctx_ptr_t ctx);
 std::string auction_submit(
     std::string auction_name, std::string bidder_name, int value, shim_ctx_ptr_t ctx);

--- a/examples/echo/echo_cc.cpp
+++ b/examples/echo/echo_cc.cpp
@@ -13,27 +13,6 @@
 
 #define MAX_VALUE_SIZE 1024
 
-int init(
-    uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)
-{
-    LOG_DEBUG("EchoCC: +++ Executing chaincode init +++");
-
-    std::vector<std::string> argss;
-    // parse json args
-    get_string_args(argss, ctx);
-
-    LOG_DEBUG("EchoCC: Args: %s",
-        (argss.size() < 1
-                ? "(none)"
-                : std::accumulate(std::next(argss.begin()), argss.end(), argss[0],
-                      [](std::string a, std::string b) { return (a + std::string(", ") + b); })
-                      .c_str()));
-
-    *actual_response_len = 0;
-    LOG_DEBUG("EchoCC: +++ Initialization done +++");
-    return 0;
-}
-
 // implements chaincode logic for invoke
 int invoke(
     uint8_t* response, uint32_t max_response_len, uint32_t* actual_response_len, shim_ctx_ptr_t ctx)

--- a/integration/auction_test.sh
+++ b/integration/auction_test.sh
@@ -28,11 +28,13 @@ auction_test() {
     try ${PEER_CMD} chaincode install -l fpc-c -n ${CC_ID} -v ${CC_VERS} -p ${ENCLAVE_SO_PATH}
     sleep 3
 
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"Args":["My Auction"]}' -V ecc-vscc
+    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"Args":[]}' -V ecc-vscc
     sleep 3
 
     # Scenario 1
     becho ">>>> Close and evaluate non existing auction. Response should be AUCTION_NOT_EXISTING"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"init", "Args": ["MyAuctionHouse"]}' --waitForEvent
+    check_result "OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"close", "Args": ["MyAuction"]}' --waitForEvent
     check_result "AUCTION_NOT_EXISTING"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"eval", "Args": ["MyAuction0"]}' # Don't do --waitForEvent, so potentially there is some parallelism here ..
@@ -40,6 +42,8 @@ auction_test() {
 
     # Scenario 2
     becho ">>>> Create an auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"init", "Args": ["MyAuctionHouse"]}' --waitForEvent
+    check_result "OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"create", "Args": ["MyAuction1"]}' --waitForEvent
     check_result "OK"
     becho ">>>> Create two equivalent bids. Response should be OK"
@@ -59,6 +63,8 @@ auction_test() {
 
     # Scenario 3
     becho ">>>> Create an auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"init", "Args": ["MyAuctionHouse"]}' --waitForEvent
+    check_result "OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"create", "Args": ["MyAuction2"]}' --waitForEvent
     check_result "OK"
     for (( i=0; i<=$num_rounds; i++ ))
@@ -77,6 +83,8 @@ auction_test() {
 
     # Scenario 4
     becho ">>>> Create a new auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"init", "Args": ["MyAuctionHouse"]}' --waitForEvent
+    check_result "OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"create", "Args": ["MyAuction3"]}' --waitForEvent
     check_result "OK"
     becho  ">>>> Create a duplicate auction. Response should be AUCTION_ALREADY_EXISTING"
@@ -94,6 +102,8 @@ auction_test() {
 
     # Code below is used to test bug in issue #42
     becho ">>>> Create a new auction. Response should be OK"
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"init", "Args": ["MyAuctionHouse"]}' --waitForEvent
+    check_result "OK"
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"create", "Args": ["MyAuction4"]}' --waitForEvent
     check_result "OK"
 }

--- a/integration/deployment_test.sh
+++ b/integration/deployment_test.sh
@@ -24,7 +24,11 @@ run_test() {
 
     try ${PEER_CMD} chaincode install -l golang -n example02 -v ${CC_VERS} -p github.com/hyperledger/fabric/examples/chaincode/go/example02/cmd
 
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -v ${CC_VERS} -c '{"Args":["My Auction"]}' -V ecc-vscc
+    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -v ${CC_VERS} -c '{"Args":[]}' -V ecc-vscc
+    sleep 3
+
+    try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -c '{"Function":"init", "Args": ["MyAuctionHouse"]}' --waitForEvent
+    check_result "OK"
     sleep 3
 
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args":["create", "MyAuction"]}' --waitForEvent

--- a/integration/echo_test.sh
+++ b/integration/echo_test.sh
@@ -14,21 +14,26 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
 CC_ID=echo_test
+CC_PATH=${FPC_TOP_DIR}/examples/echo/_build/lib/
+CC_LANG=fpc-c
+CC_VER=0
 
-#this is the path that will be used for the docker build of the chaincode enclave
-ENCLAVE_SO_PATH=examples/echo/_build/lib/
-
-CC_VERS=0
 num_rounds=10
 FAILURES=0
 
 echo_test() {
-    # install, init, and register (auction) chaincode
-    try ${PEER_CMD} chaincode install -l fpc-c -n ${CC_ID} -v ${CC_VERS} -p ${ENCLAVE_SO_PATH}
-    sleep 3
+    PKG=/tmp/${CC_ID}.tar.gz
 
-    try ${PEER_CMD} chaincode instantiate -o ${ORDERER_ADDR} -C ${CHAN_ID} -n ${CC_ID} -v ${CC_VERS} -c '{"Args":[]}' -V ecc-vscc
-    sleep 3
+    try ${PEER_CMD} lifecycle chaincode package --lang ${CC_LANG} --label ${CC_ID} --path ${CC_PATH} ${PKG}
+    try ${PEER_CMD} lifecycle chaincode install ${PKG}
+
+    PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: ${CC_ID}/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
+
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VER}
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER}
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER}
+
+    try ${PEER_CMD} lifecycle chaincode querycommitted -C ${CHAN_ID}
 
     say "do echos"
     for (( i=1; i<=$num_rounds; i++ ))
@@ -44,7 +49,6 @@ para
 say "Preparing Echo Test ..."
 # - clean up relevant docker images
 docker_clean ${ERCC_ID}
-docker_clean ${CC_ID}
 
 trap ledger_shutdown EXIT
 


### PR DESCRIPTION
Signed-off-by: bur <bur@zurich.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CONTRIBUTING.md
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

- Remove init in echo example
- Refactor init in auction example and make normal invokable function
- Remove init in demo chaincode
- Remove init in hell world tutorial
- Remove init from shim.h; ecc and ecc_enclave components
- Enable auction and echo tests
- Deployment test still disabled until #327 is merged

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #326 and partially addresses #165

**Special notes for your reviewer**:

```
cd integration
make
```

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
Remove init interface from FPC Chaincode; This breaks compatibility with concept-release-v1 chaincodes. 
