### PR TITLE
plantuml versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Make sure that you have the following required dependencies installed:
 
 * Clang-format 6.x or higher
 
-* [PlantUML](http://plantuml.com/) including Graphviz (for building documentation only) 
+* A recent version of [PlantUML](http://plantuml.com/), including Graphviz, for building documentation. See [Documentation](#Documentation) for our recommendations on installing. The version available in common package repositories may be out of date.
 
 #### Intel SGX SDK and SSL
 


### PR DESCRIPTION
glancing through #333 I remembered my difficulty in getting started. I'm wondering if instead of linking to the documentation section, we totally remove plantuml from this requirements section and let the documentation section stand alone as the single place to discuss plantuml. What are your thoughts?

The readme needs an update to ensure that the version of plantuml is new enough to compile these.

From my recollection, the version bundled with ubuntu 18.04 is not capable of compiling these diagrams. For current ubuntu LTS, verison available is v8024, which looks to be from 2014/2015 time frame. https://packages.ubuntu.com/source/xenial/plantuml
Newer ubuntus contains versions from 2018... https://packages.ubuntu.com/source/focal/plantuml

See plantuml versions https://plantuml.com/changes

Signed-off-by: Morgan Bauer <mbauer@us.ibm.com>

**What this PR does / why we need it**:

I had difficulties earlier when I did an `apt-get` on ubuntu for plantuml.

I think there is still potential for people to be confused and not make it to the bottom of the README, especially with the parenthetical comment.

**Which issue(s) this PR fixes**:
None, I can file one.

Fixes #

**Special notes for your reviewer**:

Consider my alternative in the beginning of this text. 

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
No.