### PR TITLE
Let generate_protos.sh immediately fail on error

### DIFF
--- a/tlcc_enclave/generate_protos.sh
+++ b/tlcc_enclave/generate_protos.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# set -eux
+set -e
 
 if [[ -z "${NANOPB_PATH}"  ]]; then
     echo "Error: NANOPB_PATH not set"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CONTRIBUTING.md
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

Helps the user to detect protobuf. issues earlier. 

By adding set -e to the protobuf generator script, we
let the script immediately exit and thus make will fail. Without this
fix the `make protos` may run though without an error but building tlcc
enclave will fail.



**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #336 

**Special notes for your reviewer**:

Using docker dev images you can test this by running:
cd tlcc_enclave
make clean
make
// should work nicely ....

unset PROTOC_CMD
make clean
make
// protos target should fail

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
