### PR TITLE
Replace explicit list of maintainers but group (team)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # FPC Maintainers
-*       @mbrandenburger @bvavala @g2flyer @jordy24 @MHBauer
+*       @hyperledger-labs/fabric-private-chaincode-committers


### PR DESCRIPTION
As discussed today, the PR which changes from explict CODEOWNERS to the github group, presumably then also replacing the group as choosen reviewers for PRs ....