### PR TITLE
Add missing makefile dependencies to patch & build fabric peer

### DIFF
--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -9,23 +9,29 @@ FABRIC_VERSION ?= 2.1.0
 FABRIC_VERSION_TAG =v$(FABRIC_VERSION)
 FABRIC_PEER_BIN = $(FABRIC_PATH)/build/bin/peer
 FABRIC_TLCC = $(FABRIC_PATH)/core/scc/tlcc
+TLCC_GO_SRC = ${TOP}/tlcc/*.go
+TLCC_ENCLAVE_DIR = ${TOP}/tlcc_enclave
+TLCC_ENCLAVE_LIB = ${TLCC_ENCLAVE_DIR}/_build/libtl.so
 
-FABRIC_CURRENT_TAG = $(shell cd $(FABRIC_PATH); git tag --points-at HEAD)
 FABRIC_PATCHED = $(FABRIC_PATH)/.fpc_patched
-FABRIC_TRACKED_CHANGES = $(shell cd $(FABRIC_PATH); git status -s | grep -v '\?')
 FABRIC_CURRENT_DIFF_COMMITS_CMD = git log $(FABRIC_VERSION_TAG)..HEAD --oneline
 
 build: native
 
 patch: $(FABRIC_PATCHED)
 
-$(FABRIC_PATCHED):
+$(FABRIC_PATCHED): *.patch $(FABRIC_PATH)/.git
+	# Note: .git dependency hopefully captures significant changes in fabric dir requiring repatch (and rebuild)
 	@echo "Patching Fabric ..."; \
-	if [ "$(FABRIC_CURRENT_TAG)" != "$(FABRIC_VERSION_TAG)" ]; then \
-		echo "Aborting! Tag on current HEAD ($(FABRIC_CURRENT_TAG)) does not match expected tag $(FABRIC_VERSION_TAG)!"; \
+	if [ -f $(FABRIC_PATCHED) ]; then \
+		echo "Need to re-apply patch, so try to undo patches first"; \
+		$(MAKE) clean-patch; \
+	fi; \
+	FABRIC_CURRENT_TAG=$$(cd "$(FABRIC_PATH)"; git tag --points-at HEAD) || exit 2; \
+	if [ "$${FABRIC_CURRENT_TAG}" != "$(FABRIC_VERSION_TAG)" ]; then \
+		echo "Aborting! Tag on current HEAD ($${FABRIC_CURRENT_TAG}) does not match expected tag $(FABRIC_VERSION_TAG)!"; \
 		exit 1; \
 	fi
- 
 	cd $(FABRIC_PATH) && \
 	git am $(FPC_PATH)/fabric/*.patch && \
 	$(FABRIC_CURRENT_DIFF_COMMITS_CMD) > $@
@@ -33,13 +39,15 @@ $(FABRIC_PATCHED):
 clean-patch:
 	# Note: for below to work with exit 0, this has to be a single shell command!
 	@echo "Cleaning Fabric patches ..."; \
-	if [ "$(FABRIC_CURRENT_TAG)" = "$(FABRIC_VERSION_TAG)" ]; then \
+	FABRIC_CURRENT_TAG=$$(cd "$(FABRIC_PATH)"; git tag --points-at HEAD) || exit 2; \
+	FABRIC_TRACKED_CHANGES=$$(cd "$(FABRIC_PATH)"; git status -s | grep -v '\?'); if [ $$? = 2 ]; then exit 3; fi; \
+	if [ "$${FABRIC_CURRENT_TAG}" = "$(FABRIC_VERSION_TAG)" ]; then \
 		echo "Nothing to do here ... it seems you haven't applied the patches yet"; \
 		exit 0; \
 	fi; \
-	if [ ! -z "$(FABRIC_TRACKED_CHANGES)" ]; then \
+	if [ ! -z "$${FABRIC_TRACKED_CHANGES}" ]; then \
 		echo "Aborting! It seems you have some changes in your repo:"; \
-		echo \\t$(FABRIC_TRACKED_CHANGES); \
+		echo \\t$${FABRIC_TRACKED_CHANGES}; \
 		echo "Please clean/stash your changes and try again."; \
 		exit 1; \
 	fi; \
@@ -67,9 +75,15 @@ clean-patch:
 $(FABRIC_TLCC):
 	ln -sfn $$(/bin/pwd)/../tlcc $(FABRIC_TLCC)
 
+$(TLCC_ENCLAVE_LIB):
+	${MAKE} -C ${TLCC_ENCLAVE_DIR} build
+
 peer: patch $(FABRIC_PEER_BIN)
 
-$(FABRIC_PEER_BIN): $(FABRIC_TLCC)
+$(FABRIC_PEER_BIN): $(FABRIC_TLCC) $(TLCC_GO_SRC) $(TLCC_ENCLAVE_LIB) $(FABRIC_PATCHED)
+	# Note: above does not have enough dependencies to trigger a rebuild if (recursively) 
+	# any TLCC and dependent code changes. however, it should at least make sure it will
+	# build properly if tlcc enclave is not yet built ..
 	cd $(FABRIC_PATH) && \
 	GO_TAGS=pluginsenabled $(MAKE) peer
 


### PR DESCRIPTION
**What this PR does / why we need it**:

PR title says it all ..

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #354

**Special notes for your reviewer**:

To test do calling `make peer` in `fabric` while doing various combinations of touching the patch-files and/or changing tag/branch in fabric in patched or unpatched state and it should always cause (exactly once) a re-patch and a peer build.

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:

Nope