### PR TITLE
Add nil check to PEM block parsing result

### DIFF
--- a/plugins/ercc-vscc/ercc_validation_logic.go
+++ b/plugins/ercc-vscc/ercc_validation_logic.go
@@ -140,6 +140,10 @@ func (t *VSCCERCC) checkAttestation(respPayload *peer.ChaincodeAction) error {
 		// transform INTEL pk to DER format
 		block, _ := pem.Decode([]byte(attestation.IntelPubPEM))
 
+		if block == nil {
+			return fmt.Errorf("public key resides in a malformed PEM block")
+		}
+
 		// transform sig-pk from attestation report to DER format
 		verificationPK, err := x509.ParsePKIXPublicKey(block.Bytes)
 		if err != nil {


### PR DESCRIPTION
When parsing a PEM block you need to check if the result
is nil, which happens in case the block is not a valid PEM.

Signed-off-by: yacovm <yacovm@il.ibm.com>
