### PR TITLE
Logic fix in ercc-vscc

### DIFF
--- a/fabric/bin/peer.sh
+++ b/fabric/bin/peer.sh
@@ -370,8 +370,8 @@ handle_channel_join() {
     try $RUN ${FABRIC_BIN_DIR}/peer lifecycle chaincode querycommitted --channelID ${CHAN_ID}
     para
     sleep 3
-    say "call chaincode invoke..."
-    try $RUN ${FABRIC_BIN_DIR}/peer chaincode invoke -n ${ERCC_ID} -c '{"function":"getSPID","args":[]}' -C ${CHAN_ID}
+    say "call chaincode query ..."
+    try $RUN ${FABRIC_BIN_DIR}/peer chaincode query -n ${ERCC_ID} -c '{"function":"getSPID","args":[]}' -C ${CHAN_ID}
     sleep 3
 
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CONTRIBUTING.md
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

This commit fixes the logic of ercc-vscc. In the current implementation
the validation logic of ercc-vscc treated all transactions as
registerEnclave transactions triggered through ecc by an cc2cc
invocation. However, when ercc is called directly for instance by
calling getSPID, the resulting transaction validation will fail.

ercc-vscc now used utils.MrEnclaveStateKey instead of package local
const.

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
No issue created for this 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
