### PR TITLE
Set MRENCLAVE as version in Chaincode Definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ Make sure that you have the following required dependencies installed:
 
 * Clang-format 6.x or higher
 
+* jq
+* hex (for ubuntu, found in package basez)
+
 * A recent version of [PlantUML](http://plantuml.com/), including Graphviz, for building documentation. See [Documentation](#Documentation) for our recommendations on installing. The version available in common package repositories may be out of date.
 
 #### Intel SGX SDK and SSL

--- a/common/enclave/generate_mrenclave.sh
+++ b/common/enclave/generate_mrenclave.sh
@@ -12,18 +12,18 @@ build_dir=$1
 enclave_dir=$2
 
 hex_out_name=enclave_hash.hex
-base64_out_name=mrenclave
+hex_string_out_name=mrenclave
 tmp_name=tmp_enc_hash
 go_name=mrenclave.go
 
 cd $build_dir
 sgx_sign gendata -enclave enclave.so -config $enclave_dir/enclave.config.xml -out $tmp_name
 dd if=$tmp_name bs=1 skip=188 of=$hex_out_name count=32
-base64 $hex_out_name > $base64_out_name
+hex $hex_out_name > $hex_string_out_name
 rm $hex_out_name
 rm $tmp_name
 echo "Enclave hash extracted."
-cat $base64_out_name
+cat $hex_string_out_name
 
 echo "Create go file"
 cat > $go_name << EOF
@@ -36,6 +36,6 @@ cat > $go_name << EOF
 package enclave
 
 // MrEnclave contains hash of enclave code
-const MrEnclave = "$(cat $base64_out_name)"
+const MrEnclave = "$(cat $hex_string_out_name)"
 EOF
 

--- a/docs/design/fabric-v2+/fpc-management.md
+++ b/docs/design/fabric-v2+/fpc-management.md
@@ -20,7 +20,7 @@ This commands has a new option `--lang fpc-c` to specify the FPC chaincode type.
 #### Approveformyorg
 
 This command has the following requirements *when it is used for FPC chaincodes*:
-* `--version <base64-encoded MRENCLAVE>`, the version of the FPC chaincode must contain a string that represent the identity of the enclave. This is the same identity which the trusted hardware computes and attests to. The string can be conveniently found in the `mrenclave` output file of the `generate_mrenclave.sh` script.
+* `--version <MRENCLAVE as hexadecimal string>`, the version of the FPC chaincode must contain a string that represent the identity of the enclave. This is the same identity which the trusted hardware computes and attests to. The string can be conveniently found in the `mrenclave` output file of the `generate_mrenclave.sh` script.
 * `--signature-policy string`, the endorsement policy must be a valid FPC endorsement policy.
 FPC currently supports only a single enclave as endorser, running at a designated peer. See more details below in the [FPC Endorsement Policies](#fpc-endorsement-policies) section.
 * `--endorsement-plugin string`, this flag is not supported in FPC.

--- a/ercc/attestation/verifier.go
+++ b/ercc/attestation/verifier.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -106,7 +107,7 @@ func QuoteFromAttestationReport(report IASAttestationReport) (EnclaveQuote, erro
 // Verifier interface
 type Verifier interface {
 	VerifyAttestationReport(verificationPubKey interface{}, report IASAttestationReport) (bool, error)
-	CheckMrEnclave(mrEnclaveBase64 string, report IASAttestationReport) (bool, error)
+	CheckMrEnclave(mrEnclaveHexString string, report IASAttestationReport) (bool, error)
 	CheckEnclavePkHash(pkBytes []byte, report IASAttestationReport) (bool, error)
 }
 
@@ -165,14 +166,14 @@ func (v *VerifierImpl) VerifyAttestationReport(verificationPubKey interface{}, r
 }
 
 // CheckMrEnclave returns true if mrenclave in attestation report matches the expected value. Expected value input as base64.
-func (v *VerifierImpl) CheckMrEnclave(mrEnclaveBase64 string, report IASAttestationReport) (bool, error) {
+func (v *VerifierImpl) CheckMrEnclave(mrEnclaveHexString string, report IASAttestationReport) (bool, error) {
 
 	quote, err := QuoteFromAttestationReport(report)
 	if err != nil {
 		return false, err
 	}
 
-	mrenclave, err := base64.StdEncoding.DecodeString(mrEnclaveBase64)
+	mrenclave, err := hex.DecodeString(mrEnclaveHexString)
 	if err != nil {
 		return false, err
 	}

--- a/examples/README.md
+++ b/examples/README.md
@@ -318,13 +318,12 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_utils.sh
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
-CC_ID=helloworld_test
-CC_EP="OR('SampleOrg.member')"
-
 #this is the path that will be used for the docker build of the chaincode enclave
-ENCLAVE_SO_PATH=examples/helloworld/_build/lib/
+CC_PATH=${FPC_TOP_DIR}/examples/helloworld/_build/lib/
 
-CC_VERS=0
+CC_ID=helloworld_test
+CC_VER="$(cat ${CC_PATH}/mrenclave)"
+CC_EP="OR('SampleOrg.member')"
 ```
 
 ### Launch Fabric network
@@ -360,9 +359,9 @@ With the variables set and `common_ledger.sh` executed, usage of `peer.sh` is as
 
 In the next step, the FPC chaincode must be approved by the organizations on the channel by agreeing on the chaincode definition.
 ```
-    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
-    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
-    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
 ```
 
 To complete the installation, we need to create an enclave that runs the FPC Chaincode.
@@ -378,8 +377,8 @@ helloworld_test() {
     say "- do hello world"
 
     # install helloworld  chaincode
-    # input:  CC_ID:chaincode name; CC_VERS:chaincode version;
-    #         ENCLAVE_SO_PATH:path to build artifacts
+    # input:  CC_ID:chaincode name; CC_VER:chaincode version;
+    #         CC_PATH:path to build artifacts
     say "- install helloworld chaincode"
     PKG=/tmp/${CC_ID}.tar.gz
     try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label ${CC_ID} --path ${CC_PATH} ${PKG}
@@ -387,9 +386,9 @@ helloworld_test() {
 
     PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: ${CC_ID}/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
 
-    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
-    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
-    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
 
     # create an FPC Chaincode enclave
     try ${PEER_CMD} lifecycle chaincode createenclave --name ${CC_ID}
@@ -419,20 +418,19 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_utils.sh
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
-CC_ID=helloworld_test
-CC_EP="OR('SampleOrg.member')"
-
 #this is the path that will be used for the docker build of the chaincode enclave
-CC_PATH=examples/helloworld/_build/lib/
+CC_PATH=${FPC_TOP_DIR}/examples/helloworld/_build/lib/
 
-CC_VERS=0
+CC_ID=helloworld_test
+CC_VER="$(cat ${CC_PATH}/mrenclave)"
+CC_EP="OR('SampleOrg.member')"
 
 helloworld_test() {
     say "- do hello world"
 
     # install helloworld  chaincode
-    # input:  CC_ID:chaincode name; CC_VERS:chaincode version;
-    #         ENCLAVE_SO_PATH:path to build artifacts
+    # input:  CC_ID:chaincode name; CC_VER:chaincode version;
+    #         CC_PATH:path to build artifacts
     say "- install helloworld chaincode"
     PKG=/tmp/${CC_ID}.tar.gz
     try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label ${CC_ID} --path ${CC_PATH} ${PKG}
@@ -440,9 +438,9 @@ helloworld_test() {
 
     PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: ${CC_ID}/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
 
-    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
-    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
-    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VERS} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name ${CC_ID} --version ${CC_VER} --signature-policy ${CC_EP}
 
     # create an FPC Chaincode enclave
     try ${PEER_CMD} lifecycle chaincode createenclave --name ${CC_ID}

--- a/integration/auction_test.sh
+++ b/integration/auction_test.sh
@@ -16,7 +16,7 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 CC_ID=auction_test
 CC_PATH=${FPC_TOP_DIR}/examples/auction/_build/lib/
 CC_LANG=fpc-c
-CC_VER=0
+CC_VER="$(cat ${CC_PATH}/mrenclave)"
 CC_EP="OR('SampleOrg.member')" # note that we use .member as NodeOUs is disabled with the crypto material used in the integration tests.
 
 num_rounds=3

--- a/integration/deployment_test.sh
+++ b/integration/deployment_test.sh
@@ -16,29 +16,31 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 . ${FABRIC_SCRIPTDIR}/lib/common_utils.sh
 . ${FABRIC_SCRIPTDIR}/lib/common_ledger.sh
 
-CC_VERS=0
 CC_EP="OR('SampleOrg.member')" # note that we use .member as NodeOUs is disabled with the crypto material used in the integration tests.
 FAILURES=0
 
 run_test() {
 
     # install examples/auction
+    CC_PATH=${FPC_TOP_DIR}/examples/auction/_build/lib/
+    CC_VER="$(cat ${CC_PATH}/mrenclave)"
     PKG=/tmp/auction_test.tar.gz
-    try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label auction_test --path ${FPC_TOP_DIR}/examples/auction/_build/lib/ ${PKG}
+
+    try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label auction_test --path ${CC_PATH} ${PKG}
     try ${PEER_CMD} lifecycle chaincode install ${PKG}
     PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: auction_test/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
 
     # first call negated as it fails due to specification of validation plugin
-    try_fail ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name auction_test --version ${CC_VERS} --signature-policy ${CC_EP} -E mock-escc -V ecc-vscc
-    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name auction_test --version ${CC_VERS} --signature-policy ${CC_EP}
+    try_fail ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name auction_test --version ${CC_VER} --signature-policy ${CC_EP} -E mock-escc -V ecc-vscc
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name auction_test --version ${CC_VER} --signature-policy ${CC_EP}
 
     # first call negated as it fails due to specification of validation plugin
-    try_fail ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name auction_test --version ${CC_VERS} --signature-policy ${CC_EP} -E mock-escc -V ecc-vscc
-    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name auction_test --version ${CC_VERS} --signature-policy ${CC_EP}
+    try_fail ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name auction_test --version ${CC_VER} --signature-policy ${CC_EP} -E mock-escc -V ecc-vscc
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name auction_test --version ${CC_VER} --signature-policy ${CC_EP}
 
     # first call negated as it fails due to specification of validation plugin
-    try_fail ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name auction_test --version ${CC_VERS} --signature-policy ${CC_EP} -E mock-escc -V ecc-vscc
-    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name auction_test --version ${CC_VERS} --signature-policy ${CC_EP}
+    try_fail ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name auction_test --version ${CC_VER} --signature-policy ${CC_EP} -E mock-escc -V ecc-vscc
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name auction_test --version ${CC_VER} --signature-policy ${CC_EP}
 
     #first call negated as it fails
     try_fail ${PEER_CMD} lifecycle chaincode createenclave --name wrong-cc-id
@@ -49,9 +51,9 @@ run_test() {
     try ${PEER_CMD} lifecycle chaincode package --lang golang --label marbles02 --path github.com/hyperledger/fabric-samples/chaincode/marbles02/go ${PKG}
     try ${PEER_CMD} lifecycle chaincode install ${PKG}
     PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: marbles02/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
-    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name marbles02 --version ${CC_VERS}
-    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name marbles02 --version ${CC_VERS}
-    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name marbles02 --version ${CC_VERS}
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name marbles02 --version 0
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name marbles02 --version 0
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name marbles02 --version 0
 
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n auction_test -c '{"Args":["init", "MyAuctionHouse"]}' --waitForEvent
     check_result "OK"
@@ -62,22 +64,25 @@ run_test() {
     try_r ${PEER_CMD} chaincode invoke -o ${ORDERER_ADDR} -C ${CHAN_ID} -n marbles02 -c '{"Args":["initMarble","marble1","blue","35","tom"]}' --waitForEvent
 
     # install examples/echo
-    PKG=/tmp/auction_test.tar.gz
+    CC_PATH=${FPC_TOP_DIR}/examples/echo/_build/lib/
+    CC_VER="$(cat ${CC_PATH}/mrenclave)"
+    PKG=/tmp/echo_test.tar.gz
+
     try ${PEER_CMD} lifecycle chaincode package --lang fpc-c --label echo_test --path ${FPC_TOP_DIR}/examples/echo/_build/lib ${PKG}
     try ${PEER_CMD} lifecycle chaincode install ${PKG}
     PKG_ID=$(${PEER_CMD} lifecycle chaincode queryinstalled | awk "/Package ID: echo_test/{print}" | sed -n 's/^Package ID: //; s/, Label:.*$//;p')
 
     # first call negated as it fails due to specification of validation plugin
-    try_fail ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name echo_test --version ${CC_VERS} -E mock-escc -V ecc-vscc
-    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name echo_test --version ${CC_VERS}
+    try_fail ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name echo_test --version ${CC_VER} -E mock-escc -V ecc-vscc
+    try ${PEER_CMD} lifecycle chaincode approveformyorg -C ${CHAN_ID} --package-id ${PKG_ID} --name echo_test --version ${CC_VER}
 
     # first call negated as it fails due to specification of validation plugin
-    try_fail ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name echo_test --version ${CC_VERS} -E mock-escc -V ecc-vscc
-    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name echo_test --version ${CC_VERS}
+    try_fail ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name echo_test --version ${CC_VER} -E mock-escc -V ecc-vscc
+    try ${PEER_CMD} lifecycle chaincode checkcommitreadiness -C ${CHAN_ID} --name echo_test --version ${CC_VER}
 
     # first call negated as it fails due to specification of validation plugin
-    try_fail ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name echo_test --version ${CC_VERS} -E mock-escc -V ecc-vscc
-    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name echo_test --version ${CC_VERS}
+    try_fail ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name echo_test --version ${CC_VER} -E mock-escc -V ecc-vscc
+    try ${PEER_CMD} lifecycle chaincode commit -C ${CHAN_ID} --name echo_test --version ${CC_VER}
 
     #first call negated as it fails
     try_fail ${PEER_CMD} lifecycle chaincode createenclave --name wrong-cc-id

--- a/integration/echo_test.sh
+++ b/integration/echo_test.sh
@@ -16,7 +16,7 @@ FABRIC_SCRIPTDIR="${FPC_TOP_DIR}/fabric/bin/"
 CC_ID=echo_test
 CC_PATH=${FPC_TOP_DIR}/examples/echo/_build/lib/
 CC_LANG=fpc-c
-CC_VER=0
+CC_VER="$(cat ${CC_PATH}/mrenclave)"
 CC_EP="OR('SampleOrg.member')" # note that we use .member as NodeOUs is disabled with the crypto material used in the integration tests.
 
 num_rounds=10

--- a/utils/docker/base/Dockerfile
+++ b/utils/docker/base/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
     cmake \
     vim \
     unzip \
+    basez \
  && apt-get -y -q upgrade \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CONTRIBUTING.md
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

* Update integration tests and hello world example
* Change MRENCLAVE from base64 to hex string
* Update mgnt API

Signed-off-by: bur <bur@zurich.ibm.com>
**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #387 and finishes #358

**Special notes for your reviewer**:

make sure you have apt package `basez` (for /usr/bin/hex) installed ...

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
