### PR TITLE
shim support for channelid and mspid

### DIFF
--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -150,11 +150,9 @@ func get_channel_id(channel_id *C.char, max_channel_id_len C.uint32_t, ctx unsaf
 
 //export get_msp_id
 func get_msp_id(msp_id *C.char, max_msp_id_len C.uint32_t, ctx unsafe.Pointer) {
-	//stubs := registry.Get(*(*int)(ctx))
-	//mspIdStr, err := cid.GetMSPID(stubs.shimStub)
 	mspIdStr, err := shim.GetMSPID()
 	if err != nil {
-		logger.Infof("CORE_PEER_LOCALMSPID env var not set, returning empty mspid")
+		logger.Infof("Error while calling shim.GetMSPID, returning empty mspid. err %s", err)
 		mspIdStr = ""
 	}
 	if len(mspIdStr) > int(max_msp_id_len) {

--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -138,6 +138,31 @@ var _logger = func(in string) {
 	logger.Info(in)
 }
 
+//export get_channel_id
+func get_channel_id(channel_id *C.char, max_channel_id_len C.uint32_t, ctx unsafe.Pointer) {
+    stubs := registry.Get(*(*int)(ctx))
+    channelIdStr := stubs.shimStub.GetChannelID()
+    if len(channelIdStr) > int(max_channel_id_len) {
+        panic(fmt.Sprintf("error: insufficient buffer (len=%d) for channel id string (len=%d)", len(channelIdStr), int(max_channel_id_len)))
+    }
+    C._cpy_str(channel_id, channelIdStr, max_channel_id_len)
+}
+
+//export get_msp_id
+func get_msp_id(msp_id *C.char, max_msp_id_len C.uint32_t, ctx unsafe.Pointer) {
+    //stubs := registry.Get(*(*int)(ctx))
+    //mspIdStr, err := cid.GetMSPID(stubs.shimStub)
+    mspIdStr, err := shim.GetMSPID()
+    if err != nil {
+        logger.Infof("CORE_PEER_LOCALMSPID env var not set, returning empty mspid")
+        mspIdStr = ""
+    }
+    if len(mspIdStr) > int(max_msp_id_len) {
+        panic(fmt.Sprintf("error: insufficient buffer (len=%d) for channel id string (len=%d)", len(mspIdStr), int(max_msp_id_len)))
+    }
+    C._cpy_str(msp_id, mspIdStr, max_msp_id_len)
+}
+
 //export get_creator_name
 func get_creator_name(msp_id *C.char, max_msp_id_len C.uint32_t, dn *C.char, max_dn_len C.uint32_t, ctx unsafe.Pointer) {
 	stubs := registry.Get(*(*int)(ctx))

--- a/ecc/enclave/enclave_stub.go
+++ b/ecc/enclave/enclave_stub.go
@@ -140,27 +140,27 @@ var _logger = func(in string) {
 
 //export get_channel_id
 func get_channel_id(channel_id *C.char, max_channel_id_len C.uint32_t, ctx unsafe.Pointer) {
-    stubs := registry.Get(*(*int)(ctx))
-    channelIdStr := stubs.shimStub.GetChannelID()
-    if len(channelIdStr) > int(max_channel_id_len) {
-        panic(fmt.Sprintf("error: insufficient buffer (len=%d) for channel id string (len=%d)", len(channelIdStr), int(max_channel_id_len)))
-    }
-    C._cpy_str(channel_id, channelIdStr, max_channel_id_len)
+	stubs := registry.Get(*(*int)(ctx))
+	channelIdStr := stubs.shimStub.GetChannelID()
+	if len(channelIdStr) > int(max_channel_id_len) {
+		panic(fmt.Sprintf("error: insufficient buffer (len=%d) for channel id string (len=%d)", len(channelIdStr), int(max_channel_id_len)))
+	}
+	C._cpy_str(channel_id, channelIdStr, max_channel_id_len)
 }
 
 //export get_msp_id
 func get_msp_id(msp_id *C.char, max_msp_id_len C.uint32_t, ctx unsafe.Pointer) {
-    //stubs := registry.Get(*(*int)(ctx))
-    //mspIdStr, err := cid.GetMSPID(stubs.shimStub)
-    mspIdStr, err := shim.GetMSPID()
-    if err != nil {
-        logger.Infof("CORE_PEER_LOCALMSPID env var not set, returning empty mspid")
-        mspIdStr = ""
-    }
-    if len(mspIdStr) > int(max_msp_id_len) {
-        panic(fmt.Sprintf("error: insufficient buffer (len=%d) for channel id string (len=%d)", len(mspIdStr), int(max_msp_id_len)))
-    }
-    C._cpy_str(msp_id, mspIdStr, max_msp_id_len)
+	//stubs := registry.Get(*(*int)(ctx))
+	//mspIdStr, err := cid.GetMSPID(stubs.shimStub)
+	mspIdStr, err := shim.GetMSPID()
+	if err != nil {
+		logger.Infof("CORE_PEER_LOCALMSPID env var not set, returning empty mspid")
+		mspIdStr = ""
+	}
+	if len(mspIdStr) > int(max_msp_id_len) {
+		panic(fmt.Sprintf("error: insufficient buffer (len=%d) for channel id string (len=%d)", len(mspIdStr), int(max_msp_id_len)))
+	}
+	C._cpy_str(msp_id, mspIdStr, max_msp_id_len)
 }
 
 //export get_creator_name

--- a/ecc_enclave/enclave/CMakeLists.txt
+++ b/ecc_enclave/enclave/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCE_FILES
     enclave.cpp
     enclave_t.c
     shim.cpp
+    shim_internals.cpp
     ${COMMON_SOURCE_DIR}/enclave/common.cpp
     ${COMMON_SOURCE_DIR}/base64/base64.cpp
     ${COMMON_SOURCE_DIR}/utils.c

--- a/ecc_enclave/enclave/enclave.cpp
+++ b/ecc_enclave/enclave/enclave.cpp
@@ -249,6 +249,16 @@ int ecall_cc_invoke(const char* encoded_args,
     ctx.u_shim_ctx = u_shim_ctx;
     ctx.encoded_args = encoded_args;
 
+    {
+        int max_length = 1024;
+        char channel_id[max_length];
+        char mspid[max_length];
+        get_channel_id(channel_id, max_length, &ctx);
+        get_msp_id(mspid, max_length, &ctx);
+        LOG_DEBUG("(unverified) channel id: %s\n", channel_id);
+        LOG_DEBUG("(unverified) msp id: %s\n", mspid);
+    }
+
     // call chaincode invoke logic: creates output and response
     // output, response <- F(args, input)
     int ret;

--- a/ecc_enclave/enclave/enclave.edl
+++ b/ecc_enclave/enclave/enclave.edl
@@ -29,6 +29,14 @@ enclave {
                 [out, size=max_dn_len] char *dn, uint32_t max_dn_len,
                 [user_check] void *u_shim_ctx);
 
+        void ocall_get_channel_id(
+                [out, size=max_channel_id_len] char *channel_id, uint32_t max_channel_id_len,
+                [user_check] void *u_shim_ctx);
+
+        void ocall_get_msp_id(
+                [out, size=max_msp_id_len] char *msp_id, uint32_t max_msp_id_len,
+                [user_check] void *u_shim_ctx);
+
         void ocall_get_state(
                 [in, string] const char *key,
                 [out, size=max_val_len] uint8_t *val, uint32_t max_val_len, [out] uint32_t *val_len,

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -39,22 +39,14 @@ void get_creator_name(
 
 void get_channel_id(char* channel_id, uint32_t max_channel_id_len, shim_ctx_ptr_t ctx)
 {
-    if (max_channel_id_len > 0)
-    {
-        channel_id[0] = '\0';
-        ocall_get_channel_id(channel_id, max_channel_id_len, ctx->u_shim_ctx);
-        channel_id[max_channel_id_len - 1] = '\0';
-    }
+    memset(channel_id, 0, max_channel_id_len);
+    internal_get_channel_id(channel_id, max_channel_id_len, ctx);
 }
 
 void get_msp_id(char* msp_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx)
 {
-    if (max_msp_id_len > 0)
-    {
-        msp_id[0] = '\0';
-        ocall_get_msp_id(msp_id, max_msp_id_len, ctx->u_shim_ctx);
-        msp_id[max_msp_id_len - 1] = '\0';
-    }
+    memset(msp_id, 0, max_msp_id_len);
+    internal_get_msp_id(msp_id, max_msp_id_len, ctx);
 }
 
 void get_state(

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -37,6 +37,16 @@ void get_creator_name(
     ocall_get_creator_name(msp_id, max_msp_id_len, dn, max_dn_len, ctx->u_shim_ctx);
 }
 
+void get_channel_id(char* channel_id, uint32_t max_channel_id_len, shim_ctx_ptr_t ctx)
+{
+    ocall_get_channel_id(channel_id, max_channel_id_len, ctx->u_shim_ctx);
+}
+
+void get_msp_id(char* msp_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx)
+{
+    ocall_get_msp_id(msp_id, max_msp_id_len, ctx->u_shim_ctx);
+}
+
 void get_state(
     const char* key, uint8_t* val, uint32_t max_val_len, uint32_t* val_len, shim_ctx_ptr_t ctx)
 {
@@ -253,6 +263,11 @@ void get_public_state_by_partial_composite_key(
 int get_string_args(std::vector<std::string>& argss, shim_ctx_ptr_t ctx)
 {
     JSON_Value* root = json_parse_string(ctx->json_args);
+    if(root == NULL)
+    {
+        LOG_ERROR("Shim: Cannot parse json");
+        return -1;
+    }
     if (json_value_get_type(root) != JSONArray)
     {
         LOG_ERROR("Shim: Cannot parse args '%s'", ctx->json_args);
@@ -272,6 +287,11 @@ int get_func_and_params(
     std::string& func_name, std::vector<std::string>& params, shim_ctx_ptr_t ctx)
 {
     JSON_Value* root = json_parse_string(ctx->json_args);
+    if(root == NULL)
+    {
+        LOG_ERROR("Shim: Cannot parse json");
+        return -1;
+    }
     if (json_value_get_type(root) != JSONArray)
     {
         LOG_ERROR("Shim: Cannot parse args '%s'", ctx->json_args);

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -39,12 +39,22 @@ void get_creator_name(
 
 void get_channel_id(char* channel_id, uint32_t max_channel_id_len, shim_ctx_ptr_t ctx)
 {
-    ocall_get_channel_id(channel_id, max_channel_id_len, ctx->u_shim_ctx);
+    if (max_channel_id_len > 0)
+    {
+        channel_id[0] = '\0';
+        ocall_get_channel_id(channel_id, max_channel_id_len, ctx->u_shim_ctx);
+        channel_id[max_channel_id_len - 1] = '\0';
+    }
 }
 
 void get_msp_id(char* msp_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx)
 {
-    ocall_get_msp_id(msp_id, max_msp_id_len, ctx->u_shim_ctx);
+    if (max_msp_id_len > 0)
+    {
+        msp_id[0] = '\0';
+        ocall_get_msp_id(msp_id, max_msp_id_len, ctx->u_shim_ctx);
+        msp_id[max_msp_id_len - 1] = '\0';
+    }
 }
 
 void get_state(

--- a/ecc_enclave/enclave/shim.cpp
+++ b/ecc_enclave/enclave/shim.cpp
@@ -263,7 +263,7 @@ void get_public_state_by_partial_composite_key(
 int get_string_args(std::vector<std::string>& argss, shim_ctx_ptr_t ctx)
 {
     JSON_Value* root = json_parse_string(ctx->json_args);
-    if(root == NULL)
+    if (root == NULL)
     {
         LOG_ERROR("Shim: Cannot parse json");
         return -1;
@@ -287,7 +287,7 @@ int get_func_and_params(
     std::string& func_name, std::vector<std::string>& params, shim_ctx_ptr_t ctx)
 {
     JSON_Value* root = json_parse_string(ctx->json_args);
-    if(root == NULL)
+    if (root == NULL)
     {
         LOG_ERROR("Shim: Cannot parse json");
         return -1;

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -227,6 +227,22 @@ void get_creator_name(char* msp_id,  // MSP id of organization to which transact
 // upgrade it according to what highlighted in note-3.
 extern int get_random_bytes(uint8_t* buffer, size_t length);
 
+// get_channel_id
+// --------------
+// returns the channel id string.
+// The channel id might be truncated if the buffer size is not large enough.
+void get_channel_id(char* channel_id,
+    uint32_t max_msp_id_len,
+    shim_ctx_ptr_t ctx);
+
+// get_msp_id
+// --------------
+// returns the msp id string.
+// The msp id might be truncated if the buffer size is not large enough.
+void get_msp_id(char* msp_id,
+    uint32_t max_msp_id_len,
+    shim_ctx_ptr_t ctx);
+
 // logging
 //-------------------------------------------------
 void log_critical(const char* format, ...);

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -149,14 +149,6 @@ int get_func_and_params(
 // transaction APIs
 //-------------------------------------------------
 
-// - getChannelID
-// // TOD0 (possible extensions): might be useful to support and should be easy?
-// //     If this is just the name, would it be useful also to have a variant which
-// //     has the unique id ("content-addressable"/genesis-block-hash)?
-// void get_channel_id(char* channel_id,
-//     uint32_t max_channel_id_len,
-//     shim_ctx_ptr_t ctx);
-
 // - TxID
 // // TODO (possible extensions): at least coming from a Sawtooth/PDO perspective,
 // //   i would think access to this info might be important for cross-cc transactions?

--- a/ecc_enclave/enclave/shim.h
+++ b/ecc_enclave/enclave/shim.h
@@ -231,17 +231,13 @@ extern int get_random_bytes(uint8_t* buffer, size_t length);
 // --------------
 // returns the channel id string.
 // The channel id might be truncated if the buffer size is not large enough.
-void get_channel_id(char* channel_id,
-    uint32_t max_msp_id_len,
-    shim_ctx_ptr_t ctx);
+void get_channel_id(char* channel_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx);
 
 // get_msp_id
 // --------------
 // returns the msp id string.
 // The msp id might be truncated if the buffer size is not large enough.
-void get_msp_id(char* msp_id,
-    uint32_t max_msp_id_len,
-    shim_ctx_ptr_t ctx);
+void get_msp_id(char* msp_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx);
 
 // logging
 //-------------------------------------------------

--- a/ecc_enclave/enclave/shim_internals.cpp
+++ b/ecc_enclave/enclave/shim_internals.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "shim_internals.h"
+#include "enclave_t.h"  // for ocalls
+#include "logging.h"    // for LOG_*
+
+/******************************************************************************
+ * The channel id is set once, and then maintained fixed for consistency.
+ * The value is meant to be either provided by the Fabric shim on enclave
+ * creation, or set after unsealing the chaincode parameters.
+ * In both cases, the value is not verified. The verification is performed
+ * by the Enclave Registry when the chaincode/enclave parameters are registered.
+ *****************************************************************************/
+
+static char g_channel_id[MAX_CHANNEL_ID_LENGTH];
+static uint32_t g_channel_id_length;
+static bool g_channel_id_set = false;
+
+bool internal_set_channel_id(char* channel_id, uint32_t channel_id_length)
+{
+    if (g_channel_id_set)
+    {
+        LOG_ERROR("channel id already set");
+        return false;
+    }
+
+    if (channel_id_length + 1 > MAX_CHANNEL_ID_LENGTH)
+    {
+        LOG_ERROR("channel id %s (length %u) too long", channel_id_length);
+        return false;
+    }
+
+    strncpy(g_channel_id, channel_id, channel_id_length);
+    g_channel_id_length = channel_id_length;
+    g_channel_id[g_channel_id_length + 1] = '\0';
+    g_channel_id_set = true;
+    return true;
+}
+
+bool internal_get_channel_id(char* channel_id, uint32_t max_channel_id_len, shim_ctx_ptr_t ctx)
+{
+    if (!g_channel_id_set)
+    {
+        // get channel id
+        char local_channel_id[MAX_CHANNEL_ID_LENGTH];
+        ocall_get_channel_id(local_channel_id, MAX_CHANNEL_ID_LENGTH, ctx->u_shim_ctx);
+        // make sure string is null terminated
+        local_channel_id[MAX_CHANNEL_ID_LENGTH - 1] = '\0';
+        // set internal channel id
+        if (!internal_set_channel_id(local_channel_id, strlen(local_channel_id)))
+        {
+            return false;
+        }
+    }
+
+    // channel id is set
+
+    if (max_channel_id_len < g_channel_id_length + 1)
+    {
+        LOG_ERROR("input channel id buffer length is insufficient");
+        return false;
+    }
+
+    strncpy(channel_id, g_channel_id, g_channel_id_length);
+    channel_id[g_channel_id_length + 1] = '\0';
+    return true;
+}
+
+/******************************************************************************
+ * The msp id is set once, and then maintained fixed for consistency.
+ * The value is meant to be either provided by the Fabric shim on enclave
+ * creation, or set after unsealing the chaincode parameters.
+ * In both cases, the value is not verified. The verification is performed
+ * by the Enclave Registry when the chaincode/enclave parameters are registered.
+ *****************************************************************************/
+
+static char g_msp_id[MAX_MSP_ID_LENGTH];
+static uint32_t g_msp_id_length;
+static bool g_msp_id_set = false;
+
+bool internal_set_msp_id(char* msp_id, uint32_t msp_id_length)
+{
+    if (g_msp_id_set)
+    {
+        LOG_ERROR("msp id already set");
+        return false;
+    }
+
+    if (msp_id_length + 1 > MAX_CHANNEL_ID_LENGTH)
+    {
+        LOG_ERROR("msp id %s (length %u) too long", msp_id_length);
+        return false;
+    }
+
+    strncpy(g_msp_id, msp_id, msp_id_length);
+    g_msp_id_length = msp_id_length;
+    g_msp_id[g_msp_id_length + 1] = '\0';
+    g_msp_id_set = true;
+    return true;
+}
+
+bool internal_get_msp_id(char* msp_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx)
+{
+    if (!g_msp_id_set)
+    {
+        // get msp id
+        char local_msp_id[MAX_CHANNEL_ID_LENGTH];
+        ocall_get_msp_id(local_msp_id, MAX_CHANNEL_ID_LENGTH, ctx->u_shim_ctx);
+        // make sure string is null terminated
+        local_msp_id[MAX_CHANNEL_ID_LENGTH - 1] = '\0';
+        // set internal msp id
+        if (!internal_set_msp_id(local_msp_id, strlen(local_msp_id)))
+        {
+            return false;
+        }
+    }
+
+    // msp id is set
+
+    if (max_msp_id_len < g_msp_id_length + 1)
+    {
+        LOG_ERROR("input msp id buffer length is insufficient");
+        return false;
+    }
+
+    strncpy(msp_id, g_msp_id, g_msp_id_length);
+    msp_id[g_msp_id_length + 1] = '\0';
+    return true;
+}

--- a/ecc_enclave/enclave/shim_internals.h
+++ b/ecc_enclave/enclave/shim_internals.h
@@ -10,6 +10,10 @@
 #include <map>
 #include <set>
 #include <string>
+#include "shim.h"  // for shim_ctx_ptr_t
+
+#define MAX_CHANNEL_ID_LENGTH 1024
+#define MAX_MSP_ID_LENGTH 1024
 
 // read/writeset
 typedef std::map<std::string, std::string> write_set_t;
@@ -24,3 +28,9 @@ typedef struct t_shim_ctx
     const char* encoded_args;  // args as passed from client-side shim, potentially encrypted
     const char* json_args;     // clear-text args from client-side shim
 } t_shim_ctx_t;
+
+bool internal_set_channel_id(char* channel_id, uint32_t channel_id_length);
+bool internal_get_channel_id(char* channel_id, uint32_t max_channel_id_len, shim_ctx_ptr_t ctx);
+
+bool internal_set_msp_id(char* msp_id, uint32_t msp_id_length);
+bool internal_get_msp_id(char* msp_id, uint32_t max_msp_id_len, shim_ctx_ptr_t ctx);

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -7,8 +7,8 @@
 
 #include "sgxcclib.h"
 #include "common-sgxcclib.h"  //CHECK_SGX_ERROR_AND_RETURN_ON_ERROR macro
-#include "sgx_attestation_type.h"
 #include "enclave_u.h"
+#include "sgx_attestation_type.h"
 
 #include <stdbool.h>
 #include <string.h>
@@ -25,12 +25,10 @@ extern void get_creator_name(
     const char* msp_id, uint32_t max_msp_id_len, const char* dn, uint32_t max_dn_len, void* ctx);
 
 // - channel id
-extern void get_channel_id(
-    const char* channel_id, uint32_t max_channel_id_len, void* ctx);
+extern void get_channel_id(const char* channel_id, uint32_t max_channel_id_len, void* ctx);
 
 // - msp id
-extern void get_msp_id(
-    const char* msp_id, uint32_t max_msp_id_len, void* ctx);
+extern void get_msp_id(const char* msp_id, uint32_t max_msp_id_len, void* ctx);
 
 // - for accessing ledger kvs
 extern void get_state(const char* key,
@@ -84,14 +82,12 @@ void ocall_get_creator_name(
     get_creator_name(msp_id, max_msp_id_len, dn, max_dn_len, ctx);
 }
 
-void ocall_get_channel_id(
-    char* channel_id, uint32_t max_channel_id_len, void* ctx)
+void ocall_get_channel_id(char* channel_id, uint32_t max_channel_id_len, void* ctx)
 {
     get_channel_id(channel_id, max_channel_id_len, ctx);
 }
 
-void ocall_get_msp_id(
-    char* msp_id, uint32_t max_msp_id_len, void* ctx)
+void ocall_get_msp_id(char* msp_id, uint32_t max_msp_id_len, void* ctx)
 {
     get_msp_id(msp_id, max_msp_id_len, ctx);
 }
@@ -126,4 +122,3 @@ void ocall_print_string(const char* str)
 {
     golog(str);
 }
-

--- a/ecc_enclave/sgxcclib/sgxcclib.c
+++ b/ecc_enclave/sgxcclib/sgxcclib.c
@@ -7,15 +7,13 @@
 
 #include "sgxcclib.h"
 #include "common-sgxcclib.h"  //CHECK_SGX_ERROR_AND_RETURN_ON_ERROR macro
+#include "sgx_attestation_type.h"
 #include "enclave_u.h"
 
 #include <stdbool.h>
 #include <string.h>
 
-// for RA:
 #include "sgx_quote.h"
-#include "sgx_report.h"
-#include "sgx_uae_service.h"
 
 #include "sgx_urts.h"
 
@@ -25,6 +23,14 @@ extern void LOG_ERROR(const char* fmt, ...);
 // - creator access
 extern void get_creator_name(
     const char* msp_id, uint32_t max_msp_id_len, const char* dn, uint32_t max_dn_len, void* ctx);
+
+// - channel id
+extern void get_channel_id(
+    const char* channel_id, uint32_t max_channel_id_len, void* ctx);
+
+// - msp id
+extern void get_msp_id(
+    const char* msp_id, uint32_t max_msp_id_len, void* ctx);
 
 // - for accessing ledger kvs
 extern void get_state(const char* key,
@@ -78,6 +84,18 @@ void ocall_get_creator_name(
     get_creator_name(msp_id, max_msp_id_len, dn, max_dn_len, ctx);
 }
 
+void ocall_get_channel_id(
+    char* channel_id, uint32_t max_channel_id_len, void* ctx)
+{
+    get_channel_id(channel_id, max_channel_id_len, ctx);
+}
+
+void ocall_get_msp_id(
+    char* msp_id, uint32_t max_msp_id_len, void* ctx)
+{
+    get_msp_id(msp_id, max_msp_id_len, ctx);
+}
+
 void ocall_get_state(const char* key,
     uint8_t* val,
     uint32_t max_val_len,
@@ -108,3 +126,4 @@ void ocall_print_string(const char* str)
 {
     golog(str);
 }
+


### PR DESCRIPTION
This PR enables the chaincode enclave to retrieve (untrusted) values related to channel id and msp id. These will be needed at enclave creation time for populating the cc parameters structure -- related code will be pushed later.
It partially addresses #404 .  