### PR TITLE
Make sure switching SGX_MODE work with just a "make clean"

### DIFF
--- a/common/crypto/Makefile
+++ b/common/crypto/Makefile
@@ -25,4 +25,6 @@ test: build
 	$(MAKE) -C $(BUILD_DIR) test
 
 clean:
+	-$(MAKE) -C $(BUILD_DIR) clean 
+	# above makes sure any build-artifacts in source, like ias-certificate.cpp, also get cleaned
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
**What this PR does / why we need it**:

A `make clean` didn't clean up some SGX_MODE-sensitive build artifacts which resulted in strange crypto test failures when switching from SIM to HW.  This small patch should fix that ..

**Which issue(s) this PR fixes**:

This should fix the problem Marcus was facing when testing PR #419 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
