### PR TITLE
Make epid linkable creds also working with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ We currently support both `linkable` and `unlinkable` signatures for the attesta
 The type of attestation used is selected based on the `FPC_ATTESTATION_TYPE` environment variable:
 `epid_unlinkable` for unlinkable or `epid_linkable` for linkable signatures. If you
 do not define that environment variable, the chosen attestation method is `epid_unlinkable`.
+If you are changing the type, please perform a rebuild with `make clean all`.
 Note that a mismatch between your IAS credentials and the linkable setting
 will result in an (HTTP) error '400' visible in the log-files when the
 code tries to verify the attestation. (Another cause for such error '400'
@@ -459,14 +460,9 @@ export SGX_MODE=SIM
 # SGX simulation mode
 export SGX_MODE=HW
 
-# The attestation type is ignored when SGX_MODE=SIM is set.
-
-# IAS attestation (unlinkable)
-export FPC_ATTESTATION_TYPE=epid_unlinkable
-
-# IAS attestation (linkable)
+# IAS attestation (epid_linkable or epid_unlinkable)
+# Note: The attestation type is ignored when SGX_MODE=SIM is set.
 export FPC_ATTESTATION_TYPE=epid_linkable
-
 ```
 ##### Clang-format
 

--- a/build.mk
+++ b/build.mk
@@ -7,6 +7,12 @@ include $(TOP)/config.mk
 # optionlly allow local overriding defaults
 -include $(TOP)/config.override.mk
 
+# define composites only here and not in config.mk so we can override parts in config.override.mk
+DOCKER := DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) $(DOCKER_CMD) $(DOCKERFLAGS)
+GO := $(GO_CMD) $(GOFLAGS)
+
+
+
 .PHONY: all
 all: build test checks # keep checks last as license test is brittle ...
 

--- a/cmake/ConfigSGX.cmake
+++ b/cmake/ConfigSGX.cmake
@@ -1,4 +1,5 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +32,19 @@ set(SGX_SSL "$ENV{SGX_SSL}")
 if("${SGX_SSL} " STREQUAL " ")
     message(FATAL_ERROR "SGX_SSL: undefined environment variable")
 endif()
+
+SET(FPC_ATTESTATION_TYPE "$ENV{FPC_ATTESTATION_TYPE}")
+IF("${FPC_ATTESTATION_TYPE} " STREQUAL " ")
+    message(FATAL_ERROR "FPC_ATTESTATION_TYPE: undefined environment variable")
+ELSE()
+    IF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_linkable ")
+        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_LINKABLE")
+    ELSEIF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_unlinkable ")
+        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
+    ELSE()
+        message(FATAL_ERROR "if set, FPC_ATTESTATION_TYPE must be 'epid_linkable' or 'epid_unlinkable'")
+    ENDIF()
+ENDIF()
 
 set(SGX_COMMON_CFLAGS -m64)
 set(SGX_LIBRARY_PATH ${SGX_SDK}/lib64)

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,7 @@
 # Go related settings
 #--------------------------------------------------
 GOFLAGS :=
-GO := go $(GOFLAGS)
+GO_CMD := go
 
 
 # Docker related settings
@@ -22,7 +22,7 @@ export DOCKER_BUILDKIT ?= 0
 # as a more robust 0. If you prefer the benefits of buildkit,
 # override default in your `config.override.mk`
 DOCKERFLAGS :=
-DOCKER := DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker $(DOCKERFLAGS)
+DOCKER_CMD := docker
 # Note:
 # - to get quiet docker builds, you can define in config.override.mk
 #   DOCKER_QUIET_BUILD=1
@@ -40,7 +40,11 @@ DOCKER := DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker $(DOCKERFLAGS)
 
 # SGX related settings
 #--------------------------------------------------
+# (Note: vars are exported as env variables as we also need them in various scripts)
+# alternatives for SGX_MODE: SIM or HW
 export SGX_MODE ?= SIM
+# alternatives for FPC_ATTESTATION_TYPE: epid_linkable or epid_unlinkable
+export FPC_ATTESTATION_TYPE ?= epid_unlinkable
 export SGX_BUILD ?= PRERELEASE
 export SGX_SSL ?= /opt/intel/sgxssl
 export SGX_SDK ?= /opt/intel/sgxsdk

--- a/ecc/Dockerfile.boilerplate-ecc
+++ b/ecc/Dockerfile.boilerplate-ecc
@@ -1,14 +1,20 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# Description:
+#   Sets up the template of a docker environment to run FPC chaincode, just missing the chaincode's enclave.so*
+#
+#  Configuration (build) paramaters (for defaults, see below section with ARGs)
+#  - fpc image version:         FPC_VERSION
+#  - sgxmode:                   SGX_MODE
+#  - sgx attestation mode:      FPC_ATTESTATION_TYPE
+#  - additional dev apt pkgs:   APT_ADD_DEV_PKGS
 
 ARG FPC_VERSION=latest
 
 FROM hyperledger/fabric-private-chaincode-ccenv:${FPC_VERSION}
-
-ARG CC_NAME="ecc"
-ARG CC_PATH="/usr/local/bin"
-ARG CC_LIB_PATH=${CC_PATH}"/enclave/lib"
 
 ARG SGX_MODE
 ENV SGX_MODE=${SGX_MODE}
@@ -16,6 +22,13 @@ ENV SGX_MODE=${SGX_MODE}
 # define here a env which makes it easy recognizable which mode
 # the container is. No default, though, as we do not control
 # the build and rely on a proper value provided from outside.
+ARG FPC_ATTESTATION_TYPE
+ENV FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}
+
+
+ARG CC_NAME="ecc"
+ARG CC_PATH="/usr/local/bin"
+ARG CC_LIB_PATH=${CC_PATH}"/enclave/lib"
 
 
 RUN mkdir -p ${CC_LIB_PATH}

--- a/ecc/Dockerfile.fpc-app
+++ b/ecc/Dockerfile.fpc-app
@@ -1,6 +1,15 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# Description:
+#   Docker image for a particular fpc chaincode
+#
+#  Configuration (build) paramaters (for defaults, see below section with ARGs)
+#  - extension identifying sgx mode and attestation type:       BOILERPLATE_EXTENSION
+#  - fpc image version:                                         FPC_VERSION
+#  - path to directory containing chaincode's enclave.so:       enclave_so_path
 
 ARG BOILERPLATE_EXTENSION
 ARG FPC_VERSION=latest
@@ -8,6 +17,8 @@ ARG FPC_VERSION=latest
 FROM hyperledger/fabric-private-chaincode-boilerplate-ecc${BOILERPLATE_EXTENSION}:${FPC_VERSION}
 
 ARG enclave_so_path
+
+
 ARG CC_PATH="/usr/local/bin"
 ARG CC_LIB_PATH=${CC_PATH}"/enclave/lib"
 

--- a/ecc/Makefile
+++ b/ecc/Makefile
@@ -13,8 +13,8 @@ PEER_ID ?=jdoe
 DOCKER_CONTAINER_ID?=$$(docker ps | grep -- ${NET_ID}-${PEER_ID}-$(CC_NAME)- | awk '{print $$1;}')
 # the following are the required docker build parameters
 DOCKER_IMAGE ?= $$(docker images | grep -- ${NET_ID}-${PEER_ID}-$(CC_NAME)- | awk '{print $$1;}')
-BOILERPLATE_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)
-DOCKER_BOILERPLATE_ECC_IMAGE ?= hyperledger/$(PROJECT_NAME)-boilerplate-ecc$(BOILERPLATE_EXTENSION)
+HW_ATTEST_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then if [ "${FPC_ATTESTATION_TYPE}" = "epid_linkable" ]; then echo "-hw-lnk"; elif [ "${FPC_ATTESTATION_TYPE}" = "epid_unlinkable" ]; then echo "-hw-ulnk"; else echo "incorrect FPC_ATTESTATION_TYPE"; exit 1; fi; fi)
+DOCKER_BOILERPLATE_ECC_IMAGE ?= hyperledger/$(PROJECT_NAME)-boilerplate-ecc${HW_ATTEST_EXTENSION}
 DOCKER_ENCLAVE_SO_PATH ?= $(ENCLAVE_SO_PATH)
 
 all: build
@@ -72,6 +72,7 @@ DOCKER_BUILD_OPTS += --build-arg FPC_VERSION=$(FPC_VERSION)
 docker-boilerplate-ecc: ecc
 	$(DOCKER) build $(DOCKER_BUILD_OPTS) -t $(DOCKER_BOILERPLATE_ECC_IMAGE) -f Dockerfile.boilerplate-ecc\
 		--build-arg SGX_MODE=$(SGX_MODE)\
+                --build-arg FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}\
 		..
 	$(DOCKER) tag $(DOCKER_BOILERPLATE_ECC_IMAGE) $(DOCKER_BOILERPLATE_ECC_IMAGE):${FPC_VERSION}
 

--- a/ecc_enclave/sgxcclib/CMakeVariables.txt
+++ b/ecc_enclave/sgxcclib/CMakeVariables.txt
@@ -2,18 +2,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SET(FPC_ATTESTATION_TYPE "$ENV{FPC_ATTESTATION_TYPE}")
-
-IF("$ENV{FPC_ATTESTATION_TYPE} " STREQUAL " ")
-    #default attestation flag is "epid_unlinkable"
-    SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
-ELSE()
-    IF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_linkable ")
-        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_LINKABLE")
-    ELSEIF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_unlinkable ")
-        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
-    ELSE()
-        message(FATAL_ERROR "if set, FPC_ATTESTATION_TYPE must be 'epid_linkable' or 'epid_unlinkable'")
-    ENDIF()
-ENDIF()
-

--- a/tlcc_enclave/test/CMakeLists.txt
+++ b/tlcc_enclave/test/CMakeLists.txt
@@ -1,18 +1,6 @@
-SET(FPC_ATTESTATION_TYPE "$ENV{FPC_ATTESTATION_TYPE}")
-
-IF("$ENV{FPC_ATTESTATION_TYPE} " STREQUAL " ")
-    #default attestation flag is "epid_unlinkable"
-    SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
-ELSE()
-    IF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_linkable ")
-        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_LINKABLE")
-    ELSEIF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_unlinkable ")
-        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
-    ELSE()
-        message(FATAL_ERROR "if set, FPC_ATTESTATION_TYPE must be 'epid_linkable' or 'epid_unlinkable'")
-    ENDIF()
-ENDIF()
-message(WARNING "TLCC attestation type derived from ECC -- TLCC does not use remote attestation")
+# Copyright 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
 
 set(SOURCE_FILES
     test.c

--- a/tlcc_enclave/trusted_ledger/CMakeLists.txt
+++ b/tlcc_enclave/trusted_ledger/CMakeLists.txt
@@ -1,18 +1,6 @@
-SET(FPC_ATTESTATION_TYPE "$ENV{FPC_ATTESTATION_TYPE}")
-
-IF("$ENV{FPC_ATTESTATION_TYPE} " STREQUAL " ")
-    #default attestation flag is "epid_unlinkable"
-    SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
-ELSE()
-    IF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_linkable ")
-        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_LINKABLE")
-    ELSEIF("${FPC_ATTESTATION_TYPE} " STREQUAL "epid_unlinkable ")
-        SET(SGX_ATTESTATION_FLAG "-DUSE_EPID_UNLINKABLE")
-    ELSE()
-        message(FATAL_ERROR "if set, FPC_ATTESTATION_TYPE must be 'epid_linkable' or 'epid_unlinkable'")
-    ENDIF()
-ENDIF()
-message(WARNING "TLCC attestation type derived from ECC -- TLCC does not use remote attestation")
+# Copyright 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
 
 set(SOURCE_FILES
     trusted_ledger.c

--- a/utils/docker-compose/network-config/docker-compose-sgx-hw.yml
+++ b/utils/docker-compose/network-config/docker-compose-sgx-hw.yml
@@ -10,7 +10,7 @@ services:
   peer0.org1.example.com:
   # ideally we would extend the definition of 'peer-base:' but alas docker-compose
   # doesn't propagate this to services which 'extend' from peer-base :-(
-    image: hyperledger/fabric-peer-fpc-hw:${FPC_VERSION}
+    image: hyperledger/fabric-peer-fpc${HW_ATTEST_EXTENSION}:${FPC_VERSION}
     # build:
     #   args:
     #     SGX_MODE: HW

--- a/utils/docker-compose/scripts/lib/common.sh
+++ b/utils/docker-compose/scripts/lib/common.sh
@@ -17,6 +17,7 @@ if [ -z ${DOCKERD_FPC_PATH+x} ]; then export DOCKERD_FPC_PATH=${FPC_PATH}; fi
 # SGX mode: make sure it is set so we consistently use the same value also when we call make
 # Note: make might define in config*.mk its own value without necessarily it being an env variable
 export SGX_MODE=${SGX_MODE:=SIM}
+export HW_ATTEST_EXTENSION=$(if [ "${SGX_MODE}" = "HW" ]; then if [ "${FPC_ATTESTATION_TYPE}" = "epid_linkable" ]; then echo "-hw-lnk"; elif [ "${FPC_ATTESTATION_TYPE}" = "epid_unlinkable" ]; then echo "-hw-ulnk"; else echo "incorrect FPC_ATTESTATION_TYPE"; exit 1; fi; fi)
 
 # Variables which we allow the caller override ..
 export FABRIC_VERSION=${FABRIC_VERSION:=2.2.0}

--- a/utils/docker-compose/scripts/start.sh
+++ b/utils/docker-compose/scripts/start.sh
@@ -16,7 +16,7 @@ export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && p
 #
 if [[ ! $USE_FPC = false ]]; then
     # - existance of FPC peer
-    FPC_PEER_NAME="hyperledger/fabric-peer-fpc$(if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi):${FPC_VERSION}" 
+    FPC_PEER_NAME="hyperledger/fabric-peer-fpc${HW_ATTEST_EXTENSION}:${FPC_VERSION}"
     if [ -z "$(docker images -q ${FPC_PEER_NAME})" ]; then
 	echo "FPC peer container image '${FPC_PEER_NAME}' does not exist, try to build it ..."
 	# if it doesn't exist, build it: note this can take quite some time!!
@@ -25,7 +25,7 @@ if [[ ! $USE_FPC = false ]]; then
 	popd
     fi
     # - existance of boilerplate
-    BOILERPLATE_NAME="hyperledger/fabric-private-chaincode-boilerplate-ecc$(if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi):${FPC_VERSION}"
+    BOILERPLATE_NAME="hyperledger/fabric-private-chaincode-boilerplate-ecc${HW_ATTEST_EXTENSION}:${FPC_VERSION}"
     if [ -z "$(docker images -q ${BOILERPLATE_NAME})" ]; then
 	echo "FPC boilerplate container image '${BOILERPLATE_NAME}' does not exist, try to build it ..."
 	pushd "${FPC_PATH}/" || die "can't go to fpc-sdk and boilerplate build location"
@@ -61,6 +61,7 @@ export \\
  FABRIC_VERSION="${FABRIC_VERSION}"\\
  PEER_CMD="${PEER_CMD}"\\
  FPC_CONFIG="${FPC_CONFIG}"\\
+ HW_ATTEST_EXTENSION=${HW_ATTEST_EXTENSION}"\\
  CHANNEL_NAME="${CHANNEL_NAME}"\\
  DOCKER_COMPOSE="${DOCKER_COMPOSE}"
 

--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -1,4 +1,4 @@
-
+# Copyright 2019 Intel Corporation
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -7,6 +7,8 @@ TOP = ../..
 include $(TOP)/build.mk
 
 HW_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then echo "-hw"; fi)
+HW_ATTEST_EXTENSION=$(shell if [ "${SGX_MODE}" = "HW" ]; then if [ "${FPC_ATTESTATION_TYPE}" = "epid_linkable" ]; then echo "-hw-lnk"; elif [ "${FPC_ATTESTATION_TYPE}" = "epid_unlinkable" ]; then echo "-hw-ulnk"; else echo "incorrect FPC_ATTESTATION_TYPE"; exit 1; fi; fi)
+
 
 # Names and namespaces
 # ------------------
@@ -18,7 +20,7 @@ FPC_DOCKER_BASE_RT_NAME = $(FPC_DOCKER_NAMESPACE)-base-rt
 FPC_DOCKER_BASE_DEV_NAME = $(FPC_DOCKER_NAMESPACE)-base-dev
 
 FPC_DOCKER_PEER_NAMESPACE := hyperledger/fabric-peer-fpc
-FPC_DOCKER_PEER_NAME = $(FPC_DOCKER_PEER_NAMESPACE)$(HW_EXTENSION)
+FPC_DOCKER_PEER_NAME = $(FPC_DOCKER_PEER_NAMESPACE)$(HW_ATTEST_EXTENSION)
 
 DOCKER_DEV_CONTAINER_NAME = fpc-development-${FPC_VERSION}
 
@@ -188,6 +190,7 @@ peer: base-dev
          --build-arg FPC_REPO_URL=file:///tmp/cloned-local-fpc-git-repo\
          --build-arg FPC_REPO_BRANCH_TAG_OR_COMMIT=$$(git rev-parse HEAD)\
          --build-arg SGX_MODE=${SGX_MODE}\
+         --build-arg FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}\
          . )
 	$(DOCKER) tag $(FPC_DOCKER_PEER_NAME) $(FPC_DOCKER_PEER_NAME):${FPC_VERSION}
 
@@ -200,6 +203,7 @@ dev: base-dev
          --build-arg FPC_REPO_URL=file:///tmp/cloned-local-fpc-git-repo\
          --build-arg FPC_REPO_BRANCH_TAG_OR_COMMIT=$$(git rev-parse HEAD)\
          --build-arg SGX_MODE=${SGX_MODE}\
+         --build-arg FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}\
          . )
 	$(DOCKER) tag $(FPC_DOCKER_DEV_NAME) $(FPC_DOCKER_DEV_NAME):${FPC_VERSION}
 
@@ -212,6 +216,7 @@ cc-builder: base-dev
          --build-arg FPC_REPO_URL=file:///tmp/cloned-local-fpc-git-repo\
          --build-arg FPC_REPO_BRANCH_TAG_OR_COMMIT=$$(git rev-parse HEAD)\
          --build-arg SGX_MODE=${SGX_MODE}\
+         --build-arg FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}\
          . )
 	$(DOCKER) tag $(FPC_DOCKER_CC_BUILDER_NAME) $(FPC_DOCKER_CC_BUILDER_NAME):${FPC_VERSION}
 

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -1,17 +1,18 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
 # Description:
 #   Builds the environment with all prerequistes needed to _build_ SGX-enabled apps as needed in FPC
 #
-#  Configuration (build) paramaters
-#  - fpc image version:		FPC_VERSION (default: latest)
-#  - go version:		GO_VERSION (default: 1.14.4)
-#  - nanopb version:		NANOPB_VERSION (default: 0.3.9.2)
-#  - openssl version: 		OPENSSL (default: 1.1.1g)
-#  - sgxssl version: 		SGXSSL  (default: 2.10_1.1.1g)
-#  - additional apt pkgs:	APT_ADD_PKGS (default: )
+#  Configuration (build) paramaters (for defaults, see below section with ARGs)
+#  - fpc image version:         FPC_VERSION
+#  - go version:                GO_VERSION
+#  - nanopb version:            NANOPB_VERSION
+#  - openssl version:           OPENSSL
+#  - sgxssl version:            SGXSSL
+#  - additional apt pkgs:       APT_ADD_PKGS
 
 
 ARG FPC_VERSION=latest

--- a/utils/docker/base-rt/Dockerfile
+++ b/utils/docker/base-rt/Dockerfile
@@ -1,16 +1,17 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
 # Description:
 #   Builds the environment with all prerequistes needed to _run_ (but not necessarily build) SGX-enabled apps as needed in FPC
 #
-#  Configuration (build) paramaters
-#  - ubuntu version to use: 	UBUNTU_VERSION (default: 18.04)
-#  - ubuntu name to use: 	UBUNTU_VERSION (default: bionic)
-#  - sgx sdk/psw version:	SGX (default: 2.10)
-#  - protobuf version:		PROTO_VERSION (default: 3.11.4)
-#  - additional apt pkgs:	APT_ADD_PKGS (default: )
+#  Configuration (build) paramaters (for defaults, see below section with ARGs)
+#  - ubuntu version to use:     UBUNTU_VERSION
+#  - ubuntu name to use:        UBUNTU_VERSION
+#  - sgx sdk/psw version:       SGX
+#  - protobuf version:          PROTO_VERSION
+#  - additional apt pkgs:       APT_ADD_PKGS
 
 # config/build params (part 1)
 ARG UBUNTU_VERSION=18.04

--- a/utils/docker/ccenv/Dockerfile
+++ b/utils/docker/ccenv/Dockerfile
@@ -1,6 +1,13 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# Description:
+#   Sets up the basic environment to run fpc cc in docker
+#
+#  Configuration (build) paramaters (for defaults, see below section with ARGs)
+#  - fpc image version:		FPC_VERSION
 
 ARG FPC_VERSION=latest
 

--- a/utils/docker/dev_peer_cc-builder/Dockerfile
+++ b/utils/docker/dev_peer_cc-builder/Dockerfile
@@ -1,31 +1,38 @@
 # Copyright IBM Corp. All Rights Reserved.
+# Copyright 2020 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
 # Description:
-#   Sets up fabric/fpc source environment and builds various derivatives in different stages
+#   Sets up fabric/fpc source environment and builds, in different stages, three different
+#   containers
+#   - peer: a container with an fpc-enhanced fabric peer
+#   - cc-builder: an environment to build fpc chaincode enclave.so
+#   - dev: a fpc-enabled interactive development environment
 #
-#  Configuration (build) paramaters
-#  - fpc image version:		FPC_VERSION (default: latest)
-#  - fabric repo:  		FABRIC_REPO (default: https://github.com/hyperledger/fabric.git)
-#  - fabric branch: 		FABRIC_VERSION (default: 2.2.0)
-#  - fpc repo:		 	FPC_REPO_URL (default: https://github.com/hyperledger-labs/fabric-private-chaincode.git)
-#  - fpc branch/tag/commit	FPC_REPO_BRANCH_TAG_OR_COMMIT (default: master)
-#  - git user:			GIT_USER_NAME (default: tester)
-#  - git user's email:		GIT_USER_EMAIL (default: tester@fpc)
-#  - sgxmode: 			SGX_MODE (default: SIM)
-#  - additional dev apt pkgs:	APT_ADD_DEV_PKGS (default: )
+#  Configuration (build) paramaters (for defaults, see below section with ARGs)
+#  - fpc image version:         FPC_VERSION
+#  - fabric repo:               FABRIC_REPO
+#  - fabric branch:             FABRIC_VERSION
+#  - fpc repo:                  FPC_REPO_URL
+#  - fpc branch/tag/commit      FPC_REPO_BRANCH_TAG_OR_COMMIT
+#  - git user:                  GIT_USER_NAME
+#  - git user's email:          GIT_USER_EMAIL
+#  - sgxmode:                   SGX_MODE
+#  - sgx attestation mode:      FPC_ATTESTATION_TYPE
+#  - additional dev apt pkgs:   APT_ADD_DEV_PKGS
 
 # Note on SGX_MODE:
 # In a docker build environment, we build but cannot _run_ with SGX_MODE=HW!.
 # Moreoever, libraries like sgxssl are be agnostic to the mode in which they are built and
-# can be used in both modes. Hence, even when we define glabally SGX_MODE to be HW, 
+# can be used in both modes. Hence, even when we define glabally SGX_MODE to be HW,
 # we can still build _and test_ them by locally/temporarily defining SGX_MODE to SIM
 # as we do below for sgxssl ...
 
 # global config params
 ARG FPC_VERSION=latest
 ARG SGX_MODE=SIM
+ARG FPC_ATTESTATION_TYPE
 ARG APT_DEV_ADD_PKGS=
 
 # global constants
@@ -85,6 +92,8 @@ FROM common as peer-builder
 # import global vars
 ARG SGX_MODE
 ENV SGX_MODE=${SGX_MODE}
+ARG FPC_ATTESTATION_TYPE
+ENV FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}
 
 # Build FPC peer including plugins and tlcc support
 RUN cd ${FPC_PATH} \
@@ -102,6 +111,7 @@ FROM hyperledger/fabric-private-chaincode-base-rt:${FPC_VERSION} as peer
 ARG FABRIC_REL_PATH
 ARG FPC_REL_PATH
 ARG SGX_MODE
+ARG FPC_ATTESTATION_TYPE
 
 # local vars
 # note these envs are _not_ inhereted from above as we start from base-rt !
@@ -115,6 +125,7 @@ ENV FABRIC_BIN_DIR=${FABRIC_BIN_DIR}
 ENV FPC_PATH=${FPC_PATH}
 ENV FPC_CMDS=${FPC_CMDS}
 ENV SGX_MODE=${SGX_MODE}
+ENV FPC_ATTESTATION_TYPE=${FPC_ATTESTATION_TYPE}
 
 RUN apt-get update \
   && apt-get install -y -q \
@@ -151,6 +162,11 @@ FROM common as cc-builder
 # import global vars
 ARG SGX_MODE
 ENV SGX_MODE=${SGX_MODE}
+# Note: Only the untrusted part of the SDK depends on FPC_ATTESTATION_TYPE; the trusted parts
+#  compiled into `enclave.so`, the output of a running cc-builder, do not. So it does not
+#  matter which way the SDK is built regarding attestation and we do not have to "specialize"
+#  for FPC_ATTESTATION_TYPE as we do for `peer`.  But as properties of `enclave.so` depend
+#  on SGX_MODE, we do have to specialize for that ...
 
 WORKDIR ${FPC_PATH}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Subject says it all, see also #426.

**Which issue(s) this PR fixes**:

Closes #426

**Special notes for your reviewer**:

A few notes:
- removed the definition of the default of `FPC_ATTESTATION_TYPE` and moved it to `config.mk` so this tweakable has some docu and a default definition at a central place in the code.
- as this was really part of SGX config, i also consolidated the cmake handling in `cmake/ConfigSGX.cmake`
- as peer and boilerplate images are "tainted" with `FPC_ATTESTATION_TYPE`, i correspondingly reflect that also in the image name ...

_PS: As Bruno correctly points out in #431, the compiled-in attestation-type is in a way the wrong approach and if we are going to do what #431 proposes, then this PR would become obsolete (and the docker-changes would have to be reverted).  So somewhat debatable whether it is worth merging this PR? That said, the bug can lead to confusion, the PR is here and reverting it as part of #431 should be easy?_

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:

Different docker image name is the only user-facing visible change (except that it should now also work with linkable creds ;-)) and it should be backwards compatible ...

