### PR TITLE
Bump nanopb to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Make sure that you have the following required dependencies installed:
 
 * Protocol Buffers
     - Protocol Buffers 3.0.x needed for the Intel SGX SDK
-    - Protocol Buffers 3.11.x or higher and [Nanopb](http://github.com/nanopb/nanopb) 0.3.9.2
+    - Protocol Buffers 3.11.x or higher and [Nanopb](http://github.com/nanopb/nanopb) 0.4.1
 
 * SGX PSW & SDK v2.10 for [Linux](https://01.org/intel-software-guard-extensions/downloads)
   (alternatively, you could also install it from the [source](https://github.com/intel/linux-sgx)
@@ -327,7 +327,7 @@ For more detailed information consult the official nanopb documentation http://g
     $ export NANOPB_PATH=/path-to/install/nanopb/
     $ git clone https://github.com/nanopb/nanopb.git ${NANOPB_PATH}
     $ cd ${NANOPB_PATH}
-    $ git checkout nanopb-0.3.9.2
+    $ git checkout nanopb-0.4.1
     $ cd generator/proto && make
 
 Make sure that you set `$NANOPB_PATH` as it is needed to build Fabric Private Chaincode.

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -21,7 +21,7 @@ FROM hyperledger/fabric-private-chaincode-base-rt:${FPC_VERSION} as common
 
 # config/build params
 ARG GO_VERSION=1.14.4
-ARG NANOPB_VERSION=0.3.9.2
+ARG NANOPB_VERSION=0.4.1
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 ARG APT_ADD_PKGS=


### PR DESCRIPTION
**What this PR does / why we need it**:

This bumps nanopb to 0.4.1 so we get the improved runtime from 0.4 as well as additional support for Any and alike.  

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->

**Special notes for your reviewer**:
- public API as used do not change, so code should work as is. There is now a way that you can generate the code directly (rather than as a protoc plugin) but doesn't seem worth changing it.
- 0.4 now also has [good docu](https://jpa.kapsi.fi/nanopb/docs/index.html)
- to update, you only would have to do `cd $NANOPB_PATH; git checkout nanopb-0.4.1` in your nanopb directory.  To be safe, you also might want to do a `git clean -dfx;  (cd generator/proto/; make)` to make sure everything is freshly built
- note this is _not_ the latest version of nanopb. There is a version 0.4.2. However, this version switches to use explicitly python3 and that fails.  If you use the python2 version (e.g., by changing `protoc-gen-nanopb` to `protoc-gen-nanopb-py2` in `tlcc_enclave/generate_protos.sh` it would also work.  
  The reason for the failure might to be that we do require an upstream version of protoc but do not update `python3-protobuf` to a new version a correspondingly new version That said, we also do  also not update `python-protobuf` to a new version and when i run the nanopb tests with protoc 3.11 (as `env PATH=$NANOPB_PATH/generator:$PATH scons PROTOC=/usr/local/proto3/bin/protoc`) i don't get the same error as we face for FPC ; I do though get some OOM on a 16G RAM machine which i didn't get when i run it with the standard protoc from ubuntu but even in the latter case it also seems to use essentially all memory and so i might just have gotten lucky. 
  Also note that the error we get with FPC seems not to depend on particular protoc version downloaded from github: i got the same error not only with 3.11 but also with 3.13.0, 3.9.2, 3.8.1 with 3.6.1.

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
