### PR TITLE
Fix broken dev apt add pkg

### DIFF
--- a/utils/docker/Makefile
+++ b/utils/docker/Makefile
@@ -70,7 +70,7 @@ DOCKER_DEV_BUILD_OPTS += $(shell git config user.name >/dev/null && echo --build
 DOCKER_DEV_BUILD_OPTS += $(shell git config user.email >/dev/null && echo --build-arg GIT_USER_EMAIL=\'$$(git config user.email)\')
 # - allow additional custom apt pkgs for 'dev' container based on DOCKER_DEV_IMAGE_APT_ADD_PKGS
 ifdef DOCKER_DEV_IMAGE_APT_ADD_PKGS
-	DOCKER_DEV_BUILD_OPTS += --build-arg APT_ADD_DEV_PKGS=$(DOCKER_DEV_IMAGE_APT_ADD_PKGS)
+	DOCKER_DEV_BUILD_OPTS += --build-arg APT_DEV_ADD_PKGS=$(DOCKER_DEV_IMAGE_APT_ADD_PKGS)
 endif
 
 

--- a/utils/docker/dev_peer_cc-builder/Dockerfile
+++ b/utils/docker/dev_peer_cc-builder/Dockerfile
@@ -20,7 +20,7 @@
 #  - git user's email:          GIT_USER_EMAIL
 #  - sgxmode:                   SGX_MODE
 #  - sgx attestation mode:      FPC_ATTESTATION_TYPE
-#  - additional dev apt pkgs:   APT_ADD_DEV_PKGS
+#  - additional dev apt pkgs:   APT_DEV_ADD_PKGS
 
 # Note on SGX_MODE:
 # In a docker build environment, we build but cannot _run_ with SGX_MODE=HW!.
@@ -181,6 +181,7 @@ FROM common as dev
 # import global vars
 ARG FPC_REL_PATH
 ARG SGX_MODE
+ARG APT_DEV_ADD_PKGS
 
 ENV SGX_MODE=${SGX_MODE}
 


### PR DESCRIPTION
A naming inconsistency and missing ARG caused not installing any
additional packages as set with DOCKER_DEV_IMAGE_APT_ADD_PKGS in
config.override.mk

Signed-off-by: bur <bur@zurich.ibm.com>
