### PR TITLE
update nanopb 0.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Make sure that you have the following required dependencies installed:
 
 * Protocol Buffers
     - Protocol Buffers 3.0.x needed for the Intel SGX SDK
-    - Protocol Buffers 3.11.x or higher and [Nanopb](http://github.com/nanopb/nanopb) 0.4.1
+    - Protocol Buffers 3.11.x or higher and [Nanopb](http://github.com/nanopb/nanopb) 0.4.3
 
 * SGX PSW & SDK v2.10 for [Linux](https://01.org/intel-software-guard-extensions/downloads)
   (alternatively, you could also install it from the [source](https://github.com/intel/linux-sgx)
@@ -328,7 +328,7 @@ For more detailed information consult the official nanopb documentation http://g
     $ export NANOPB_PATH=/path-to/install/nanopb/
     $ git clone https://github.com/nanopb/nanopb.git ${NANOPB_PATH}
     $ cd ${NANOPB_PATH}
-    $ git checkout nanopb-0.4.1
+    $ git checkout nanopb-0.4.3
     $ cd generator/proto && make
 
 Make sure that you set `$NANOPB_PATH` as it is needed to build Fabric Private Chaincode.

--- a/protos/generate_protos.sh
+++ b/protos/generate_protos.sh
@@ -47,7 +47,7 @@ mkdir -p $FABRIC_BUILD_DIR
 GO_BUILD_DIR=${FPC_PATH}/internal/protos
 mkdir -p $GO_BUILD_DIR
 
-PROTOC_OPTS="--plugin=protoc-gen-nanopb=$NANOPB_PATH/generator/protoc-gen-nanopb"
+PROTOC_OPTS="--plugin=protoc-gen-nanopb=$NANOPB_PATH/generator/protoc-gen-nanopb-py2"
 
 # compile google protos
 $PROTOC_CMD "$PROTOC_OPTS" --proto_path=${PROTOS_DIR} --nanopb_out=$BUILD_DIR ${PROTOS_DIR}/google/protobuf/*.proto

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -21,7 +21,7 @@ FROM hyperledger/fabric-private-chaincode-base-rt:${FPC_VERSION} as common
 
 # config/build params
 ARG GO_VERSION=1.15.4
-ARG NANOPB_VERSION=0.4.1
+ARG NANOPB_VERSION=0.4.3
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 ARG APT_ADD_PKGS=


### PR DESCRIPTION
**What this PR does / why we need it**:

nanopb 0.4.3 fixes the issue in 0.4.2 which prevented us to go to (then) latest version in PR #436, fixes numerous bugs, brings some performance optimization and, for the C++ fans among us, provides `Better support C++ types in generated structs (#577)`
For more info see [CHANGELOG](https://github.com/nanopb/nanopb/blob/master/CHANGELOG.txt)
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

To test you will have to update your nanopb setup:
```
cd  $NANOPB_PATH
git fetch --all --prune
git checkout nanopb-0.4.3
cd generator/proto
rm -f nanopb_pb2.py*
make
```
and then also make sure that do `make clean`, at least in 'protos' dir ..

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**: