### PR TITLE
Make fabric-samples work again and easier to use

### DIFF
--- a/ecc_mock/Makefile
+++ b/ecc_mock/Makefile
@@ -8,8 +8,12 @@ include $(TOP)/build.mk
 
 build: ecc
 
-ecc: main.go
+ecc: ecc_dependencies
 	$(GO) build $(GOTAGS) -o ecc main.go
+
+ecc_dependencies:
+	# hard to list explicitly, so just leave empty target,
+	# which forces ecc to always be built
 
 test: build
 	$(GO) test $(GOTAGS) -v ./...
@@ -18,5 +22,5 @@ clean:
 	$(GO) clean
 	$(RM) ecc
 
-docker:
+docker: ecc
 	${DOCKER} build --no-cache -t fpc/ecc .

--- a/ecc_mock/chaincode/ecc.go
+++ b/ecc_mock/chaincode/ecc.go
@@ -23,7 +23,7 @@ var logger = flogging.MustGetLogger("ecc")
 
 // EnclaveChaincode struct
 type EnclaveChaincode struct {
-	enclave enclave.StubInterface
+	enclave enclave.MockEnclave
 }
 
 // Init sets the chaincode state to "init"

--- a/ercc/Makefile
+++ b/ercc/Makefile
@@ -8,11 +8,15 @@ include $(TOP)/build.mk
 
 build: ercc
 
-ercc:
+ercc: ercc_dependencies
 	# ERCC's binary is created here.
 	# The binary is then referenced by the fpc-peer cli, inserted in the ERCC package,
 	# and eventually run by the external launcher.
 	$(GO) build $(GOTAGS) -o ercc main.go
+
+ercc_dependencies:
+	# hard to list explicitly, so just leave empty target,
+	# which forces ecc to always be built
 
 test: build
 	$(GO) test $(GOTAGS) -v ./...

--- a/ercc/attestation/logging_cgo.go
+++ b/ercc/attestation/logging_cgo.go
@@ -1,0 +1,18 @@
+/*
+   Copyright 2019 Intel Corporation
+   Copyright IBM Corp. All Rights Reserved.
+
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package attestation
+
+// extern void golog(char*);
+//
+// int golog_cgo_wrapper(const char* str)
+// {
+//      golog((char*)str);
+//      return 1;
+// }
+//
+import "C"

--- a/ercc/attestation/logging_go.go
+++ b/ercc/attestation/logging_go.go
@@ -1,0 +1,34 @@
+/*
+   Copyright 2019 Intel Corporation
+   Copyright IBM Corp. All Rights Reserved.
+
+   SPDX-License-Identifier: Apache-2.0
+*/
+
+package attestation
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+)
+
+// #cgo CFLAGS: -I${SRCDIR}/../../common/logging/untrusted
+// #include "logging.h"
+//
+// extern int golog_cgo_wrapper(const char* str);
+//
+import "C"
+
+var logger = flogging.MustGetLogger("cgo")
+
+func init() {
+	logger.Info("Initializing logger")
+	r := C.logging_set_callback(C.log_callback_f(C.golog_cgo_wrapper))
+	if r == false {
+		panic("error initializing logging for cgo")
+	}
+}
+
+//export golog
+func golog(str *C.char) {
+	logger.Infof("%s", C.GoString(str))
+}

--- a/ercc/attestation/verifier.go
+++ b/ercc/attestation/verifier.go
@@ -37,7 +37,7 @@ func (v *VerifierImpl) VerifyEvidence(evidenceBytes, expectedStatementBytes []by
 
 	expectedMrEnclaveBytes := []byte(expectedMrEnclave)
 	expectedMrEnclavePtr := C.CBytes(expectedMrEnclaveBytes)
-	defer C.free(expectedStatementPtr)
+	defer C.free(expectedMrEnclavePtr)
 	expectedMrEnclaveLen := len(expectedMrEnclaveBytes)
 
 	if !C.verify_evidence(

--- a/ercc/registry/registry.go
+++ b/ercc/registry/registry.go
@@ -168,6 +168,7 @@ func (rs *Contract) RegisterEnclave(ctx contractapi.TransactionContextInterface,
 		return errors.Wrap(err, "invalid attested data message")
 	}
 
+	log.Printf("- verifying attested data (%v) against evidence (%s)", attestedData, credentials.Evidence)
 	if err := checkAttestedData(ctx, rs.Verifier, rs.IEvaluator, &attestedData, &credentials); err != nil {
 		return err
 	}

--- a/integration/test-network/0001-Add-network.sh-cmd-enabling-docker-compose-commands.patch
+++ b/integration/test-network/0001-Add-network.sh-cmd-enabling-docker-compose-commands.patch
@@ -1,0 +1,121 @@
+From ef15370e72ca8a8414ca7e64679ace1923d558f8 Mon Sep 17 00:00:00 2001
+From: michael steiner <michael.steiner@intel.com>
+Date: Mon, 30 Nov 2020 16:09:57 -0800
+Subject: [PATCH] Add network.sh cmd enabling docker-compose commands
+
+* much facilitates debugging and alike
+
+Signed-off-by: michael steiner <michael.steiner@intel.com>
+---
+ test-network/network.sh     | 21 +++++++++++++++++++++
+ test-network/scriptUtils.sh | 20 ++++++++++++++++++++
+ 2 files changed, 41 insertions(+)
+
+diff --git a/test-network/network.sh b/test-network/network.sh
+index 4cb19dd..05d3b5f 100755
+--- a/test-network/network.sh
++++ b/test-network/network.sh
+@@ -289,6 +289,16 @@ function networkUp() {
+   fi
+ }
+ 
++function dockerComposeCommand() {
++
++  if [ "$CRYPTO" == "Certificate Authorities" ]; then
++      IMAGE_TAG=${CA_IMAGETAG} docker-compose -f $COMPOSE_FILE_CA -f $COMPOSE_FILE_CA_ORG3 "${ARGS[@]}"
++  else
++      IMAGE_TAG=${IMAGETAG}    docker-compose -f ${COMPOSE_FILE_BASE} -f ${COMPOSE_FILE_COUCH} -f $COMPOSE_FILE_COUCH_ORG3 -f $COMPOSE_FILE_ORG3 "${ARGS[@]}"
++  fi
++}
++
++
+ ## call the script to join create the channel and join the peers of org1 and org2
+ function createChannel() {
+ 
+@@ -381,6 +391,8 @@ COMPOSE_FILE_CA=docker/docker-compose-ca.yaml
+ COMPOSE_FILE_COUCH_ORG3=addOrg3/docker/docker-compose-couch-org3.yaml
+ # use this as the default docker-compose yaml definition for org3
+ COMPOSE_FILE_ORG3=addOrg3/docker/docker-compose-org3.yaml
++# use this as the certificate authorities docker-compose yaml definition for org3
++COMPOSE_FILE_CA_ORG3=addOrg3/docker/docker-compose-ca-org3.yaml
+ #
+ # use go as the default language for chaincode
+ CC_SRC_LANGUAGE="go"
+@@ -487,6 +499,11 @@ while [[ $# -ge 1 ]] ; do
+     VERBOSE=true
+     shift
+     ;;
++  -- )
++    shift
++    ARGS=( "$@" )
++    break 2
++    ;;
+   * )
+     errorln "Unknown flag: $key"
+     printHelp
+@@ -509,6 +526,8 @@ if [ "$MODE" == "up" ]; then
+ elif [ "$MODE" == "createChannel" ]; then
+   infoln "Creating channel '${CHANNEL_NAME}'."
+   infoln "If network is not up, starting nodes with CLI timeout of '${MAX_RETRY}' tries and CLI delay of '${CLI_DELAY}' seconds and using database '${DATABASE} ${CRYPTO_MODE}"
++elif [ "$MODE" == "dc-command" ]; then
++  infoln "docker-compose command execution"
+ elif [ "$MODE" == "down" ]; then
+   infoln "Stopping network"
+ elif [ "$MODE" == "restart" ]; then
+@@ -526,6 +545,8 @@ elif [ "${MODE}" == "createChannel" ]; then
+   createChannel
+ elif [ "${MODE}" == "deployCC" ]; then
+   deployCC
++elif [ "${MODE}" == "dc-command" ]; then
++  dockerComposeCommand
+ elif [ "${MODE}" == "down" ]; then
+   networkDown
+ else
+diff --git a/test-network/scriptUtils.sh b/test-network/scriptUtils.sh
+index 043d33f..1c20e2c 100755
+--- a/test-network/scriptUtils.sh
++++ b/test-network/scriptUtils.sh
+@@ -71,6 +71,19 @@ function printHelp() {
+     println " Examples:"
+     println "   network.sh deployCC -ccn basic -ccl javascript"
+     println "   network.sh deployCC -ccn mychaincode -ccp ./user/mychaincode -ccv 1 -ccl javascript"
++  elif [ "$USAGE" == "dc-command" ]; then
++    println "Usage: "
++    println "  network.sh \033[0;32mdc-command\033[0m [Flags]"
++    println "    -- <args> - pass following arguments to docker-compose"
++    println "    -ca - run command for CA docker-compose network (instead of network for orderer and peers)"
++    println "    -i <imagetag> - Docker image tag of Fabric to deploy (defaults to \"latest\")"
++    println "    -cai <ca_imagetag> - Docker image tag of Fabric CA to deploy (defaults to \"${CA_IMAGETAG}\")"
++    println
++    println "    -h - Print this message"
++    println
++    println " Examples:"
++    println "   network.sh dc-command -- logs -f orderer.example.com"
++    println "   network.sh dc-command -ca -- ps"
+   else
+     println "Usage: "
+     println "  network.sh <Mode> [Flags]"
+@@ -80,6 +93,7 @@ function printHelp() {
+     println "      \033[0;32mcreateChannel\033[0m - Create and join a channel after the network is created"
+     println "      \033[0;32mdeployCC\033[0m - Deploy a chaincode to a channel (defaults to asset-transfer-basic)"
+     println "      \033[0;32mdown\033[0m - Bring down the network"
++    println "      \033[0;32mdc-command\033[0m - Run docker-compose commands, e.g., for logging"
+     println
+     println "    Flags:"
+     println "    Used with \033[0;32mnetwork.sh up\033[0m, \033[0;32mnetwork.sh createChannel\033[0m:"
+@@ -103,6 +117,12 @@ function printHelp() {
+     println "    -cccg <collection-config>  - (Optional) File path to private data collections configuration file"
+     println "    -cci <fcn name>  - (Optional) Name of chaincode initialization function. When a function is provided, the execution of init will be requested and the function will be invoked."
+     println
++    println "    Used with \033[0;32mnetwork.sh dc-command\033[0m"
++    println "    -- <args> - pass following arguments to docker-compose"
++    println "    -ca - run command for CA docker-compose network (instead of network for orderer and peers)"
++    println "    -i <imagetag> - Docker image tag of Fabric to deploy (defaults to \"latest\")"
++    println "    -cai <ca_imagetag> - Docker image tag of Fabric CA to deploy (defaults to \"${CA_IMAGETAG}\")"
++    println
+     println "    -h - Print this message"
+     println
+     println " Possible Mode and flag combinations"
+-- 
+2.29.2
+

--- a/integration/test-network/README.md
+++ b/integration/test-network/README.md
@@ -18,11 +18,11 @@ make && make docker
 
 ## Prepare network
 
-Go to `$FPC_PATH/integration/fabric-samples` and follow the [instructions](https://hyperledger-fabric.readthedocs.io/en/latest/install.html) to get the fabric binaries and docker images.
+Setup fabric sample network, binaries and docker images (this follow the [instructions](https://hyperledger-fabric.readthedocs.io/en/latest/install.html)).
 
 ```bash
 cd $FPC_PATH/integration/test-network/fabric-samples
-curl -sSL https://bit.ly/2ysbOFE | bash -s -- -s
+curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.2.0 1.4.9 -s
 ```
  
 ```bash
@@ -33,7 +33,7 @@ cd $FPC_PATH/integration/test-network
 Start network:
 ```bash
 cd $FPC_PATH/integration/test-network/fabric-samples/test-network
-./network.sh up createChannel -c mychannel -ca
+./network.sh up createChannel -c mychannel -ca -cai 1.4.9 -i 2.2.0
 ```
 
 Install FPC components:
@@ -45,7 +45,8 @@ cd $FPC_PATH/integration/test-network
 
 Start FPC container
 ```bash
-docker-compose up
+cd $FPC_PATH/integration/test-network
+docker-compose up -d
 ```
 
 Run test program
@@ -57,6 +58,9 @@ make
 
 Shutdown network
 ```bash
+cd $FPC_PATH/integration/test-network
+docker-compose down
 cd $FPC_PATH/integration/test-network/fabric-samples
 ./network.sh down
+rm -f ${FPC_PATH}/client_sdk/go/test/wallet/appUser.id
 ```

--- a/integration/test-network/setup.sh
+++ b/integration/test-network/setup.sh
@@ -25,7 +25,18 @@ backup() {
 
 FABRIC_SAMPLES=${FPC_PATH}/integration/test-network/fabric-samples/
 
-#cd ${FABRIC_SAMPLES} && curl -sSL https://bit.ly/2ysbOFE | bash -s -- -s
+if [ ! -d "${FABRIC_SAMPLES}/bin" ]; then
+  echo "Error: environment not properly setup, see README.md"
+  #cd ${FABRIC_SAMPLES} && curl -sSL https://bit.ly/2ysbOFE | bash -s -- -s
+fi
+
+# patch fabric-sample
+
+# - network script (for more meaningful debugging options)
+(cd ${FABRIC_SAMPLES} && git am --3way ../*.patch)
+
+
+# - config and docker-compose files (for fpc lite enablement)
 
 CORE_PATH=${FABRIC_SAMPLES}/config/core.yaml
 DOCKER_PATH=${FABRIC_SAMPLES}/test-network/docker/docker-compose-test-net.yaml
@@ -38,9 +49,9 @@ backup ${CORE_PATH}
 
 yq m -i -a=append ${CORE_PATH} core_ext.yaml
 
-peers=("peer0.org1.example.com" "peer0.org2.example.com")
-
 backup ${DOCKER_PATH}
+
+peers=("peer0.org1.example.com" "peer0.org2.example.com")
 
 # Also there is another issue with this approach here. When working completely inside the FPC dev-container,
 # the volume mounts won't work. The reason is that the docker daemon provided by the host cannot parse volume paths.


### PR DESCRIPTION
test-networks test do not work in master. This is PR fixes some obvious issues, updates docu and also adds a patch to the test-network network.sh which makes it easy to look at peer logs and alike.   It should also display now logs from cgo.

PS: it's strange, in a simple test program, the `puts` used in cgo does display info on stdout, but not for `ercc` where puts output is simply swallowed and you have to explicitly set the output callback to something else.  
BTW: given that we used flogging so far, why are we using now "log"? Would be nice to be somewhat consistent ....