### PR TITLE
Convert all log to flogger

### DIFF
--- a/client_sdk/go/fpc/attestation/transformation.go
+++ b/client_sdk/go/fpc/attestation/transformation.go
@@ -9,18 +9,20 @@ package attestation
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/protos"
+	"github.com/hyperledger/fabric/common/flogging"
 )
+
+var logger = flogging.MustGetLogger("fpc-client-attest")
 
 func ToEvidence(credentials *protos.Credentials) (*protos.Credentials, error) {
 
-	log.Printf("Perform attestation to evidence transformation\n")
+	logger.Debugf("Perform attestation to evidence transformation")
 
 	fpcPath := os.Getenv("FPC_PATH")
 	if fpcPath == "" {

--- a/client_sdk/go/fpc/attestation/transformation_test.go
+++ b/client_sdk/go/fpc/attestation/transformation_test.go
@@ -8,7 +8,6 @@ SPDX-License-Identifier: Apache-2.0
 package attestation
 
 import (
-	"log"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/protos"
@@ -22,10 +21,10 @@ func Test(t *testing.T) {
 	credentials.Attestation = []byte(`{"attestation_type":"simulated","attestation":"MA=="}`)
 	credentials, err = ToEvidence(credentials)
 	if err != nil {
-		log.Fatalf("conversion failed: %v", err)
+		logger.Fatalf("conversion failed: %v", err)
 	}
 	expected := `{"attestation_type":"simulated","evidence":"MA=="}`
 	if expected != string(credentials.Evidence) {
-		log.Fatalf("conversion provided '%v' rather than expected '%v'", string(credentials.Evidence), expected)
+		logger.Fatalf("conversion provided '%v' rather than expected '%v'", string(credentials.Evidence), expected)
 	}
 }

--- a/client_sdk/go/fpc/contract.go
+++ b/client_sdk/go/fpc/contract.go
@@ -10,7 +10,6 @@ package fpc
 import (
 	"encoding/base64"
 	"encoding/json"
-	"log"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/client_sdk/go/fpc/crypto"
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/utils"
@@ -160,7 +159,7 @@ func (c *contractState) evaluateTransaction(args ...string) ([]byte, error) {
 		return nil, err
 	}
 
-	log.Printf("calling __invoke!\n")
+	logger.Debugf("calling __invoke!")
 	return txn.Evaluate(args...)
 }
 
@@ -178,7 +177,7 @@ func (c *contractState) SubmitTransaction(name string, args ...string) ([]byte, 
 	// call __invoke
 	encryptedResponse, err := c.evaluateTransaction(encryptedRequest)
 
-	log.Printf("calling __endorse!\n")
+	logger.Debugf("calling __endorse!")
 	_, err = c.contract.SubmitTransaction("__endorse", base64.StdEncoding.EncodeToString(encryptedResponse))
 	if err != nil {
 		return nil, err

--- a/client_sdk/go/fpc/crypto/crypto.go
+++ b/client_sdk/go/fpc/crypto/crypto.go
@@ -9,12 +9,14 @@ package crypto
 
 import (
 	"encoding/base64"
-	"log"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/protos"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/common/flogging"
 	"google.golang.org/protobuf/proto"
 )
+
+var logger = flogging.MustGetLogger("fpc-client-crypto")
 
 func encrypt(input []byte, encryptionKey []byte) ([]byte, error) {
 	return input, nil
@@ -89,7 +91,7 @@ func (e *EncryptionContextImpl) Conceal(function string, args []string) (string,
 		Input:               &peer.ChaincodeInput{Args: bytes},
 		ReturnEncryptionKey: e.resultEncryptionKey,
 	}
-	log.Printf("prepping chaincode params: %s\n", ccRequest)
+	logger.Debugf("prepping chaincode params: %s", ccRequest)
 
 	serializedCcRequest, err := proto.Marshal(ccRequest)
 	if err != nil {

--- a/client_sdk/go/fpc/logging.go
+++ b/client_sdk/go/fpc/logging.go
@@ -1,0 +1,14 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+Copyright 2020 Intel Corporation
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fpc
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+)
+
+var logger = flogging.MustGetLogger("fpc-client-sdk")

--- a/client_sdk/go/fpc/management.go
+++ b/client_sdk/go/fpc/management.go
@@ -10,7 +10,6 @@ package fpc
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/client_sdk/go/fpc/attestation"
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/protos"
@@ -74,7 +73,7 @@ func (c *managementState) InitEnclave(peerEndpoint string, attestationParams ...
 		AttestationParams: protoutil.MarshalOrPanic(&pbatt.AttestationParameters{Parameters: serializedJSONParams}),
 	}
 
-	log.Printf("calling __initEnclave\n")
+	logger.Debugf("calling __initEnclave")
 	credentialsBytes, err := txn.Evaluate(utils.MarshallProto(initMsg))
 	if err != nil {
 		return fmt.Errorf("evaluation error: %s", err)
@@ -86,7 +85,7 @@ func (c *managementState) InitEnclave(peerEndpoint string, attestationParams ...
 		return fmt.Errorf("evaluation error: %s", err)
 	}
 
-	log.Printf("calling registerEnclave\n")
+	logger.Debugf("calling registerEnclave")
 	_, err = c.ercc.SubmitTransaction("registerEnclave", convertedCredentials)
 	if err != nil {
 		return err
@@ -97,7 +96,7 @@ func (c *managementState) InitEnclave(peerEndpoint string, attestationParams ...
 
 // perform attestation evidence transformation
 func ConvertCredentials(credentialsOnlyAttestation string) (credentialsWithEvidence string, err error) {
-	log.Printf("Received Credential: '%s'", credentialsOnlyAttestation)
+	logger.Debugf("Received Credential: '%s'", credentialsOnlyAttestation)
 	credentials, err := utils.UnmarshalCredentials(credentialsOnlyAttestation)
 	if err != nil {
 		return "", fmt.Errorf("cannot decode credentials: %s", err)
@@ -108,6 +107,6 @@ func ConvertCredentials(credentialsOnlyAttestation string) (credentialsWithEvide
 		return "", err
 	}
 	credentialsOnlyAttestation = utils.MarshallProto(credentials)
-	log.Printf("Converted to Credential: '%s'", credentialsOnlyAttestation)
+	logger.Debugf("Converted to Credential: '%s'", credentialsOnlyAttestation)
 	return credentialsOnlyAttestation, nil
 }

--- a/ecc_mock/main.go
+++ b/ecc_mock/main.go
@@ -8,17 +8,19 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/ecc_mock/chaincode"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/hyperledger/fabric/common/flogging"
 )
 
 type serverConfig struct {
 	CCID    string
 	Address string
 }
+
+var logger = flogging.MustGetLogger("ecc")
 
 func main() {
 
@@ -44,9 +46,9 @@ func main() {
 		},
 	}
 
-	log.Printf("starting fpc chaincode (%s)\n", config.CCID)
+	logger.Infof("starting fpc chaincode (%s)", config.CCID)
 
 	if err := server.Start(); err != nil {
-		log.Panicf("error starting fpc chaincode: %s", err)
+		logger.Panicf("error starting fpc chaincode: %s", err)
 	}
 }

--- a/ercc/main.go
+++ b/ercc/main.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
-	"log"
 	"os"
 
 	"github.com/hyperledger-labs/fabric-private-chaincode/ercc/attestation"
@@ -15,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/utils"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+	"github.com/hyperledger/fabric/common/flogging"
 )
 
 type serverConfig struct {
@@ -22,7 +22,13 @@ type serverConfig struct {
 	Address string
 }
 
+var logger = flogging.MustGetLogger("ercc")
+
 func main() {
+
+	// we can control logging via FABRIC_LOGGING_SPEC, the default is FABRIC_LOGGING_SPEC=INFO
+	// For more fine grained logging we could also use different log level for loggers.
+	// For example: FABRIC_LOGGING_SPEC=ecc=DEBUG:ecc_enclave=ERROR
 
 	c := &registry.Contract{}
 	c.Verifier = attestation.NewVerifier()
@@ -31,7 +37,7 @@ func main() {
 
 	ercc, err := contractapi.NewChaincode(c)
 	if err != nil {
-		log.Panicf("error create enclave registry chaincode: %s", err)
+		logger.Panicf("error create enclave registry chaincode: %s", err)
 	}
 
 	ccid := os.Getenv("CHAINCODE_PKG_ID")
@@ -53,20 +59,20 @@ func main() {
 			},
 		}
 
-		log.Printf("starting enclave registry (%s)\n", config.CCID)
+		logger.Infof("starting enclave registry (%s)", config.CCID)
 
 		if err := server.Start(); err != nil {
-			log.Panicf("error starting enclave registry chaincode: %s", err)
+			logger.Panicf("error starting enclave registry chaincode: %s", err)
 		}
 	} else if len(ccid) == 0 && len(addr) == 0 {
 		// start the chaincode in the traditional way
 
-		log.Printf("starting enclave registry\n")
+		logger.Info("starting enclave registry")
 		if err := ercc.Start(); err != nil {
-			log.Panicf("Error starting registry chaincode: %v", err)
+			logger.Panicf("Error starting registry chaincode: %v", err)
 		}
 	} else {
-		log.Panicf("invalid input parameters")
+		logger.Panicf("invalid input parameters")
 	}
 
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Converted all uses of "log" to "flogging" so we have consistent logging across the board and also logging control via `FABRIC_LOGGIN_SPEC` ...

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Was straight-forward conversion. Did also usually convert `log.Print` to `logger.Debug`, which maybe in some cases could have been also handled as Info.  Note as `management.go` and `contract.go` share the name space (and hence can only have one logger variable) i solomonically solved it by putting `logger` var into a separate file `logging.go` :-)

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
