### PR TITLE
Faster docker builds be preloading go downloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,12 @@ linter: gotools build
 	@echo "LINT completed."
 
 gotools:
-	# install goimports if not present
+	# install go tools if not present
+	# (for faster docker-build, also replicte these commands
+	#  in 'utils/docker/base-dev/Dockerfile')
 	$(GO) install golang.org/x/tools/cmd/goimports
 	$(GO) install google.golang.org/protobuf/cmd/protoc-gen-go
-	GO111MODULE=off $(GO) get -u github.com/maxbrunsfeld/counterfeiter
+	GO111MODULE=off $(GO) get github.com/maxbrunsfeld/counterfeiter
 
 godeps: gotools
 	$(GO) mod download

--- a/utils/docker/base-dev/Dockerfile
+++ b/utils/docker/base-dev/Dockerfile
@@ -69,8 +69,9 @@ RUN GO_TAR=go${GO_VERSION}.linux-amd64.tar.gz \
   && mkdir -p /project
 ENV PATH=${GOPATH}/bin:${GOROOT}/bin:${PATH}
 #  Go tools we need
-RUN go get golang.org/x/tools/cmd/goimports
-
+RUN  go get golang.org/x/tools/cmd/goimports \
+  && go get google.golang.org/protobuf/cmd/protoc-gen-go \
+  && GO111MODULE=off go get github.com/maxbrunsfeld/counterfeiter
 
 # Install SGX SSL
 ENV SGX_SSL /opt/intel/sgxssl

--- a/utils/docker/dev_peer_cc-builder/Dockerfile
+++ b/utils/docker/dev_peer_cc-builder/Dockerfile
@@ -82,6 +82,10 @@ RUN git \
 # Notes:
 # - the -c submodule's are to prevent dragging in large but unneeded sub-sub-modules of pdo ...
 
+# Make sure we download common godeps once instead if separate times below
+RUN cd ${FPC_PATH} \
+ && make godeps
+
 
 # peer builder container (Ephemeral)
 #------------------------------------


### PR DESCRIPTION

**What this PR does / why we need it**:

Minimize network loads for docker-build. Primarily improves when your network is not the fastest ..

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
