### PR TITLE
Enable message encryption and chaincode request message consistency check

### DIFF
--- a/common/crypto/pdo-crypto-c-wrapper.cpp
+++ b/common/crypto/pdo-crypto-c-wrapper.cpp
@@ -62,6 +62,75 @@ err:
     return false;
 }
 
+bool pk_encrypt_message(uint8_t* public_key,
+        uint32_t public_key_len,
+        uint8_t* message,
+        uint32_t message_len,
+        uint8_t* encrypted_message,
+        uint32_t encrypted_message_len,
+        uint32_t* encrypted_message_actual_len)
+{
+    try
+    {
+        std::string pk_string((const char*)public_key, public_key_len);
+        ByteArray msg(message, message + message_len);
+        ByteArray encr_msg;
+
+        //deserialize public key
+        pdo::crypto::pkenc::PublicKey pk(pk_string);
+
+        //encrypt message
+        encr_msg = pk.EncryptMessage(msg);
+
+        COND2ERR(encrypted_message_len < encr_msg.size());
+        memcpy(encrypted_message, encr_msg.data(), encr_msg.size());
+        *encrypted_message_actual_len = encr_msg.size();
+    }
+    catch(const std::exception& e)
+    {
+        COND2LOGERR(true, e.what());
+    }
+
+    // encryption successful
+    return true;
+
+err:
+    return false;
+}
+
+bool decrypt_message(uint8_t* key,
+        uint32_t key_len,
+        uint8_t* encrypted_message,
+        uint32_t encrypted_message_len,
+        uint8_t* message,
+        uint32_t message_len,
+        uint32_t* message_actual_len)
+{
+    try
+    {
+        ByteArray ba_key(key, key + key_len);
+        ByteArray encr_msg(encrypted_message, encrypted_message + encrypted_message_len);
+        ByteArray msg;
+
+        //decrypt message
+        msg = pdo::crypto::skenc::DecryptMessage(ba_key, encr_msg);
+
+        COND2ERR(message_len < msg.size());
+        memcpy(message, msg.data(), msg.size());
+        *message_actual_len = msg.size();
+    }
+    catch(const std::exception& e)
+    {
+        COND2LOGERR(true, e.what());
+    }
+
+    //decryption successful
+    return true;
+
+err:
+    return false;
+}
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/common/crypto/pdo-crypto-c-wrapper.cpp
+++ b/common/crypto/pdo-crypto-c-wrapper.cpp
@@ -14,6 +14,10 @@
 extern "C" {
 #endif
 
+extern "C" const unsigned int SYM_KEY_LEN = pdo::crypto::constants::SYM_KEY_LEN;
+extern "C" const unsigned int RSA_PLAINTEXT_LEN = pdo::crypto::constants::RSA_PLAINTEXT_LEN;
+extern "C" const unsigned int RSA_KEY_SIZE = pdo::crypto::constants::RSA_KEY_SIZE;
+
 bool compute_hash(uint8_t* message,
     uint32_t message_len,
     uint8_t* hash,
@@ -82,7 +86,8 @@ bool pk_encrypt_message(uint8_t* public_key,
         //encrypt message
         encr_msg = pk.EncryptMessage(msg);
 
-        COND2ERR(encrypted_message_len < encr_msg.size());
+        LOG_DEBUG("encr msg size %d buffer len %d",  encr_msg.size(), encrypted_message_len);
+        COND2LOGERR(encrypted_message_len < encr_msg.size(), "buffer too small for encrypted msg");
         memcpy(encrypted_message, encr_msg.data(), encr_msg.size());
         *encrypted_message_actual_len = encr_msg.size();
     }

--- a/common/crypto/pdo-crypto-c-wrapper.h
+++ b/common/crypto/pdo-crypto-c-wrapper.h
@@ -10,6 +10,10 @@
 extern "C" {
 #endif
 
+extern const unsigned int SYM_KEY_LEN;
+extern const unsigned int RSA_PLAINTEXT_LEN;
+extern const unsigned int RSA_KEY_SIZE;
+
 bool compute_hash(uint8_t* message,
     uint32_t message_len,
     uint8_t* hash,

--- a/common/crypto/pdo-crypto-c-wrapper.h
+++ b/common/crypto/pdo-crypto-c-wrapper.h
@@ -16,7 +16,28 @@ bool compute_hash(uint8_t* message,
     uint32_t max_hash_len,
     uint32_t* actual_hash_len);
 
-bool verify_signature(uint8_t* public_key, uint32_t public_key_len, uint8_t* message, uint32_t message_len, uint8_t* signature, uint32_t signature_len);
+bool verify_signature(uint8_t* public_key,
+        uint32_t public_key_len,
+        uint8_t* message,
+        uint32_t message_len,
+        uint8_t* signature,
+        uint32_t signature_len);
+
+bool pk_encrypt_message(uint8_t* public_key,
+        uint32_t public_key_len,
+        uint8_t* message,
+        uint32_t message_len,
+        uint8_t* encrypted_message,
+        uint32_t encrypted_message_len,
+        uint32_t* encrypted_message_actual_len);
+
+bool decrypt_message(uint8_t* key,
+        uint32_t key_len,
+        uint8_t* encrypted_message,
+        uint32_t encrypted_message_len,
+        uint8_t* message,
+        uint32_t message_len,
+        uint32_t* message_actual_len);
 
 #ifdef __cplusplus
 }

--- a/common/enclave/cc_data.cpp
+++ b/common/enclave/cc_data.cpp
@@ -16,6 +16,7 @@
 #include "protos/fpc/fpc.pb.h"
 
 #include "attestation-api/attestation/attestation.h"
+#include "crypto.h"
 
 // ecc enclave global variable -- allocated dynamically
 cc_data* g_cc_data = NULL;
@@ -241,6 +242,31 @@ bool cc_data::sign_message(const ByteArray& message, ByteArray& signature) const
     bool b;
     CATCH(b, signature = signature_key_.SignMessage(message));
     COND2LOGERR(!b, "message signing failed");
+
+    return true;
+
+err:
+    return false;
+}
+
+bool cc_data::decrypt_cc_message(const ByteArray& encrypted_message, ByteArray& message) const
+{
+    bool b;
+    CATCH(b, message = cc_decryption_key_.DecryptMessage(encrypted_message));
+    COND2LOGERR(!b, "message decryption failed");
+
+    return true;
+
+err:
+    return false;
+}
+
+bool cc_data::encrypt_message(
+    const ByteArray key, const ByteArray& message, ByteArray& encrypted_message) const
+{
+    bool b;
+    CATCH(b, encrypted_message = pdo::crypto::skenc::EncryptMessage(key, message));
+    COND2LOGERR(!b, "message encryption failed");
 
     return true;
 

--- a/common/enclave/cc_data.h
+++ b/common/enclave/cc_data.h
@@ -45,6 +45,9 @@ public:
     ByteArray get_state_encryption_key();
     std::string get_enclave_id();
     bool sign_message(const ByteArray& message, ByteArray& signature) const;
+    bool decrypt_cc_message(const ByteArray& encrypted_message, ByteArray& message) const;
+    bool encrypt_message(
+        const ByteArray key, const ByteArray& message, ByteArray& encrypted_message) const;
 };
 
 extern cc_data* g_cc_data;

--- a/ecc_enclave/enclave/enclave.cpp
+++ b/ecc_enclave/enclave/enclave.cpp
@@ -115,8 +115,10 @@ int ecall_cc_invoke(const uint8_t* signed_proposal_proto_bytes,
         crm = {};
 
         {  // encrypt response
-            encrypted_response = pdo::crypto::skenc::EncryptMessage(return_encryption_key,
-                ByteArray(b64_response.c_str(), b64_response.c_str() + b64_response.length()));
+            b = g_cc_data->encrypt_message(return_encryption_key,
+                ByteArray(b64_response.c_str(), b64_response.c_str() + b64_response.length()),
+                encrypted_response);
+            COND2LOGERR(!b, "cannot encrypt message");
         }
 
         {  // fill encrypted response

--- a/internal/utils/proto.go
+++ b/internal/utils/proto.go
@@ -17,7 +17,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger-labs/fabric-private-chaincode/internal/protos"
+	"github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
 )
 
 func MarshallProto(msg proto.Message) string {
@@ -58,4 +61,94 @@ func ExtractEndpoint(credentials *protos.Credentials) (string, error) {
 	}
 
 	return attestedData.HostParams.PeerEndpoint, nil
+}
+
+func GetChaincodeRequestMessageFromSignedProposal(signedProposal *pb.SignedProposal) (crmProtoBytes []byte, e error) {
+	// This function is based on the `newChaincodeStub` in
+	// https://github.com/hyperledger/fabric-chaincode-go/blob/9b3ae92d8664f398fe9846561fafde44864d55e3/shim/stub.go
+	// In particular, it serves to
+	// * extract the arguments from the proposal,
+	// * check that exactly two arguments have been passed (i.e., the function name and crm)
+	// * return the (base-64 decoded) chaincode request message bytes
+
+	if signedProposal == nil {
+		return nil, fmt.Errorf("no signed proposal to parse")
+	}
+
+	var err error
+
+	proposal := &pb.Proposal{}
+	err = proto.Unmarshal(signedProposal.ProposalBytes, proposal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract Proposal from SignedProposal: %s", err)
+	}
+
+	// check for header
+	if len(proposal.GetHeader()) == 0 {
+		return nil, errors.New("failed to extract Proposal fields: proposal header is nil")
+	}
+
+	// extract header
+	hdr := &common.Header{}
+	if err := proto.Unmarshal(proposal.GetHeader(), hdr); err != nil {
+		return nil, fmt.Errorf("failed to extract proposal header: %s", err)
+	}
+
+	// validate channel header
+	chdr := &common.ChannelHeader{}
+	if err := proto.Unmarshal(hdr.ChannelHeader, chdr); err != nil {
+		return nil, fmt.Errorf("failed to extract channel header: %s", err)
+	}
+	validTypes := map[common.HeaderType]bool{
+		common.HeaderType_ENDORSER_TRANSACTION: true,
+	}
+	if !validTypes[common.HeaderType(chdr.GetType())] {
+		return nil, fmt.Errorf(
+			"invalid channel header type. Expected %s, received %s",
+			common.HeaderType_ENDORSER_TRANSACTION,
+			common.HeaderType(chdr.GetType()),
+		)
+	}
+
+	// extract args from proposal payload
+	payload := &pb.ChaincodeProposalPayload{}
+	if err := proto.Unmarshal(proposal.GetPayload(), payload); err != nil {
+		return nil, fmt.Errorf("failed to extract proposal payload: %s", err)
+	}
+	cppInput := payload.GetInput()
+	if cppInput == nil {
+		return nil, fmt.Errorf("failed to get chaincode proposal payload input")
+	}
+	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{}
+	err = proto.Unmarshal(cppInput, chaincodeInvocationSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal chaincodeInvocationSpec: %s", err)
+	}
+	chaincodeSpec := chaincodeInvocationSpec.GetChaincodeSpec()
+	if chaincodeSpec == nil {
+		return nil, fmt.Errorf("failed to get chaincode spec")
+	}
+	input := chaincodeSpec.GetInput()
+	if input == nil {
+		return nil, fmt.Errorf("failed to get chaincode spec input")
+	}
+	args := input.GetArgs()
+	if args == nil {
+		return nil, fmt.Errorf("failed to get chaincode spec input args")
+	}
+
+	// validate args
+	// there two args:
+	// 1. the function name (usually "__invoke") and
+	// 2. the b64-encoded chaincode request message bytes
+	if len(args) != 2 {
+		return nil, fmt.Errorf("unexpected args num %d instead of 2 (function + chaincode request message", len(args))
+	}
+
+	// Return the decoded second arg
+	chaincodeRequestMessageBytes, err := base64.StdEncoding.DecodeString(string(args[1]))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode chaincode request message")
+	}
+	return chaincodeRequestMessageBytes, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,16 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric-protos-go/common"
-	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
 )
 
@@ -86,94 +82,4 @@ func ValidateEndpoint(endpoint string) error {
 	}
 
 	return nil
-}
-
-func GetChaincodeRequestMessageFromSignedProposal(signedProposal *pb.SignedProposal) (crmProtoBytes []byte, e error) {
-	// This function is based on the `newChaincodeStub` in
-	// https://github.com/hyperledger/fabric-chaincode-go/blob/9b3ae92d8664f398fe9846561fafde44864d55e3/shim/stub.go
-	// In particular, it serves to
-	// * extract the arguments from the proposal,
-	// * check that exactly two arguments have been passed (i.e., the function name and crm)
-	// * return the (base-64 decoded) chaincode request message bytes
-
-	if signedProposal == nil {
-		return nil, fmt.Errorf("no signed proposal to parse")
-	}
-
-	var err error
-
-	proposal := &pb.Proposal{}
-	err = proto.Unmarshal(signedProposal.ProposalBytes, proposal)
-	if err != nil {
-		return nil, fmt.Errorf("failed to extract Proposal from SignedProposal: %s", err)
-	}
-
-	// check for header
-	if len(proposal.GetHeader()) == 0 {
-		return nil, errors.New("failed to extract Proposal fields: proposal header is nil")
-	}
-
-	// extract header
-	hdr := &common.Header{}
-	if err := proto.Unmarshal(proposal.GetHeader(), hdr); err != nil {
-		return nil, fmt.Errorf("failed to extract proposal header: %s", err)
-	}
-
-	// validate channel header
-	chdr := &common.ChannelHeader{}
-	if err := proto.Unmarshal(hdr.ChannelHeader, chdr); err != nil {
-		return nil, fmt.Errorf("failed to extract channel header: %s", err)
-	}
-	validTypes := map[common.HeaderType]bool{
-		common.HeaderType_ENDORSER_TRANSACTION: true,
-	}
-	if !validTypes[common.HeaderType(chdr.GetType())] {
-		return nil, fmt.Errorf(
-			"invalid channel header type. Expected %s, received %s",
-			common.HeaderType_ENDORSER_TRANSACTION,
-			common.HeaderType(chdr.GetType()),
-		)
-	}
-
-	// extract args from proposal payload
-	payload := &pb.ChaincodeProposalPayload{}
-	if err := proto.Unmarshal(proposal.GetPayload(), payload); err != nil {
-		return nil, fmt.Errorf("failed to extract proposal payload: %s", err)
-	}
-	cppInput := payload.GetInput()
-	if cppInput == nil {
-		return nil, fmt.Errorf("failed to get chaincode proposal payload input")
-	}
-	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{}
-	err = proto.Unmarshal(cppInput, chaincodeInvocationSpec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal chaincodeInvocationSpec: %s", err)
-	}
-	chaincodeSpec := chaincodeInvocationSpec.GetChaincodeSpec()
-	if chaincodeSpec == nil {
-		return nil, fmt.Errorf("failed to get chaincode spec")
-	}
-	input := chaincodeSpec.GetInput()
-	if input == nil {
-		return nil, fmt.Errorf("failed to get chaincode spec input")
-	}
-	args := input.GetArgs()
-	if args == nil {
-		return nil, fmt.Errorf("failed to get chaincode spec input args")
-	}
-
-	// validate args
-	// there two args:
-	// 1. the function name (usually "__invoke") and
-	// 2. the b64-encoded chaincode request message bytes
-	if len(args) != 2 {
-		return nil, fmt.Errorf("unexpected args num %d instead of 2 (function + chaincode request message", len(args))
-	}
-
-	// Return the decoded second arg
-	chaincodeRequestMessageBytes, err := base64.StdEncoding.DecodeString(string(args[1]))
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode chaincode request message")
-	}
-	return chaincodeRequestMessageBytes, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,12 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
 )
 
@@ -82,4 +86,94 @@ func ValidateEndpoint(endpoint string) error {
 	}
 
 	return nil
+}
+
+func GetChaincodeRequestMessageFromSignedProposal(signedProposal *pb.SignedProposal) (crmProtoBytes []byte, e error) {
+	// This function is based on the `newChaincodeStub` in
+	// https://github.com/hyperledger/fabric-chaincode-go/blob/9b3ae92d8664f398fe9846561fafde44864d55e3/shim/stub.go
+	// In particular, it serves to
+	// * extract the arguments from the proposal,
+	// * check that exactly two arguments have been passed (i.e., the function name and crm)
+	// * return the (base-64 decoded) chaincode request message bytes
+
+	if signedProposal == nil {
+		return nil, fmt.Errorf("no signed proposal to parse")
+	}
+
+	var err error
+
+	proposal := &pb.Proposal{}
+	err = proto.Unmarshal(signedProposal.ProposalBytes, proposal)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract Proposal from SignedProposal: %s", err)
+	}
+
+	// check for header
+	if len(proposal.GetHeader()) == 0 {
+		return nil, errors.New("failed to extract Proposal fields: proposal header is nil")
+	}
+
+	// extract header
+	hdr := &common.Header{}
+	if err := proto.Unmarshal(proposal.GetHeader(), hdr); err != nil {
+		return nil, fmt.Errorf("failed to extract proposal header: %s", err)
+	}
+
+	// validate channel header
+	chdr := &common.ChannelHeader{}
+	if err := proto.Unmarshal(hdr.ChannelHeader, chdr); err != nil {
+		return nil, fmt.Errorf("failed to extract channel header: %s", err)
+	}
+	validTypes := map[common.HeaderType]bool{
+		common.HeaderType_ENDORSER_TRANSACTION: true,
+	}
+	if !validTypes[common.HeaderType(chdr.GetType())] {
+		return nil, fmt.Errorf(
+			"invalid channel header type. Expected %s, received %s",
+			common.HeaderType_ENDORSER_TRANSACTION,
+			common.HeaderType(chdr.GetType()),
+		)
+	}
+
+	// extract args from proposal payload
+	payload := &pb.ChaincodeProposalPayload{}
+	if err := proto.Unmarshal(proposal.GetPayload(), payload); err != nil {
+		return nil, fmt.Errorf("failed to extract proposal payload: %s", err)
+	}
+	cppInput := payload.GetInput()
+	if cppInput == nil {
+		return nil, fmt.Errorf("failed to get chaincode proposal payload input")
+	}
+	chaincodeInvocationSpec := &pb.ChaincodeInvocationSpec{}
+	err = proto.Unmarshal(cppInput, chaincodeInvocationSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal chaincodeInvocationSpec: %s", err)
+	}
+	chaincodeSpec := chaincodeInvocationSpec.GetChaincodeSpec()
+	if chaincodeSpec == nil {
+		return nil, fmt.Errorf("failed to get chaincode spec")
+	}
+	input := chaincodeSpec.GetInput()
+	if input == nil {
+		return nil, fmt.Errorf("failed to get chaincode spec input")
+	}
+	args := input.GetArgs()
+	if args == nil {
+		return nil, fmt.Errorf("failed to get chaincode spec input args")
+	}
+
+	// validate args
+	// there two args:
+	// 1. the function name (usually "__invoke") and
+	// 2. the b64-encoded chaincode request message bytes
+	if len(args) != 2 {
+		return nil, fmt.Errorf("unexpected args num %d instead of 2 (function + chaincode request message", len(args))
+	}
+
+	// Return the decoded second arg
+	chaincodeRequestMessageBytes, err := base64.StdEncoding.DecodeString(string(args[1]))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode chaincode request message")
+	}
+	return chaincodeRequestMessageBytes, nil
 }

--- a/protos/fpc.options
+++ b/protos/fpc.options
@@ -7,6 +7,7 @@ fpc.ChaincodeRequestMessage.encrypted_request type:FT_POINTER
 fpc.FPCKVSet.read_value_hashes type:FT_POINTER
 
 fpc.ChaincodeResponseMessage.encrypted_response type:FT_POINTER
+fpc.ChaincodeResponseMessage.chaincode_request_message_hash type:FT_POINTER
 fpc.ChaincodeResponseMessage.enclave_id type:FT_POINTER
 
 fpc.SignedChaincodeResponseMessage.chaincode_response_message type:FT_POINTER

--- a/protos/fpc/fpc.proto
+++ b/protos/fpc/fpc.proto
@@ -126,8 +126,13 @@ message ChaincodeResponseMessage {
     // signed proposal for this request
     protos.SignedProposal proposal = 3;
 
+    // hash of the proposal's input request
+    // this field is required because input request is passed alongside the proposal
+    // and not extracted from it; validation chaincode will check for consistency
+    bytes chaincode_request_message_hash = 4;
+
     // identity for public key used to sign
-    string enclave_id = 4;
+    string enclave_id = 5;
 }
 
 message SignedChaincodeResponseMessage {


### PR DESCRIPTION
(self-explanatory)

This PR addresses #504 (consistency check), part of #486 (message encryption), and maintains the limitations described in #478 (message size).

Also, see comment below, closes #412, and #486 can be moved to next release