### PR TITLE
Add missing FPC v1.0-rc1 to release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Additional google documents provide details on FPC 1.0:
 
 ## Releases
 
+- [v1.0-rc1 - Feburary 5, 2021](https://github.com/hyperledger-labs/fabric-private-chaincode/tree/v1.0-rc1)
+
 - [Tech Preview - July 2, 2020](https://github.com/hyperledger-labs/fabric-private-chaincode/tree/concept-release-2.0)
 
 - [Concept Release - March 2, 2020](https://github.com/hyperledger-labs/fabric-private-chaincode/tree/concept-release-1.0)
@@ -405,9 +407,10 @@ git clone https://github.com/hyperledger/fabric.git $FABRIC_PATH
 cd $FABRIC_PATH; git checkout tags/v2.3.0
 ```
 
-Note that Fabric Private Chaincode currently does not work with the Fabric `master` branch, therefore make sure you use the Fabric
-`v2.3.0` tag. This is important as our build script applies some patches
-to the fabric peer to enable FPC support. Make sure the source of Fabric is in your `$GOPATH`.
+Note that Fabric Private Chaincode may not work with the Fabric `master` branch.
+Therefore make sure you use the Fabric `v2.3.0` tag.
+This is important as our build script applies some patches to the fabric peer to enable FPC support.
+Make sure the source of Fabric is in your `$GOPATH`.
 
 ### Build Fabric Private Chaincode
 

--- a/client_sdk/go/doc.go
+++ b/client_sdk/go/doc.go
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 //
 // Usage samples
 //
-// samples/main.go: Illustrates the use of the FPC Client SDK. The application can be used with the our test-network.
+// samples/main.go: Illustrates the use of the FPC Client SDK. The application can be used with our test-network.
 // Reference: https://github.com/hyperledger-labs/fabric-private-chaincode/tree/master/integration/test-network
 //
 package fpcclientsdk

--- a/docs/design/fabric-v2+/interfaces.md
+++ b/docs/design/fabric-v2+/interfaces.md
@@ -79,7 +79,7 @@ namespaces/exported/<chaincode_id>/<enclave_id> -> SignedExportMessage
 ```
 
 This key scheme is design with the goal in mind to reduce the write conflicts for concurrent enclave registrations.
-ERCC state can accessed and modified by the [lifecycle ledger shim](https://github.com/hyperledger/fabric/blob/master/core/chaincode/lifecycle/ledger_shim.go) or the normal [go-chaincode shim](https://github.com/hyperledger/fabric/blob/master/vendor/github.com/hyperledger/fabric-chaincode-go/shim/stub.go). Here an example:
+ERCC state can be accessed and modified by the [lifecycle ledger shim](https://github.com/hyperledger/fabric/blob/master/core/chaincode/lifecycle/ledger_shim.go) or the normal [go-chaincode shim](https://github.com/hyperledger/fabric/blob/master/vendor/github.com/hyperledger/fabric-chaincode-go/shim/stub.go). Here an example:
 ```go
 // returns the chaincode encryption key for AuctionChaincode1
 k := fmt.Sprintf("namespaces/chaincode_ek/%s", "AuctionChaincode1")


### PR DESCRIPTION
This ports some changes from the FPC v1.0-rc1 release into master; in
particular, it adds FPC v1.0-rc1 to the release section of the main readme and
fixes some types.

Signed-off-by: bur <bur@zurich.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CONTRIBUTING.md
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/master/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
