### PR TITLE
Make fabric patch optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,20 +385,18 @@ unzip protoc-3.11.4-linux-x86_64.zip -d /usr/local/proto3
 export PROTOC_CMD=/usr/local/proto3/bin/protoc
 ```
 
-#### Prepare Fabric
+#### Hyperledger Fabric
 
-Fabric Private Chaincode support requires to re-build the Fabric peer.
-
-Checkout Fabric 2.3.0 release using the following commands:
+Our project fetches the latest supported Fabric binaries during the build process automatically.
+However, if you want to use your own Fabric binaries, please checkout Fabric 2.3.0 release using the following commands:
 ```bash
-export FABRIC_PATH=${GOPATH}/src/github.com/hyperledger/fabric
+export FABRIC_PATH=$GOPATH/src/github.com/hyperledger/fabric
 git clone https://github.com/hyperledger/fabric.git $FABRIC_PATH
 cd $FABRIC_PATH; git checkout tags/v2.3.0
 ```
 
 Note that Fabric Private Chaincode may not work with the Fabric `main` branch.
 Therefore make sure you use the Fabric `v2.3.0` tag.
-This is important as our build script applies some patches to the fabric peer to enable FPC support.
 Make sure the source of Fabric is in your `$GOPATH`.
 
 ### Build Fabric Private Chaincode

--- a/config.mk
+++ b/config.mk
@@ -78,6 +78,12 @@ export FPC_PATH=$(abspath $(TOP))
 # re-defined to point to the FPC path as seen by the docker daemon
 export DOCKERD_FPC_PATH ?= $(FPC_PATH)
 
+# For testing Fabric binaries are needed; you can customize these via the following
+# env variable. By default we fetch the binaries into $(FPC_PATH)/fabric/_internal/bin
+export FABRIC_BIN_DIR ?= $(FPC_PATH)/fabric/_internal/bin
+# In case you want to your custom fabric bins, just point to your fabric path
+# export FABRIC_BIN_DIR ?= $(FABRIC_PATH)/build/bin
+
 # Additional SGX related settings
 #--------------------------------------------------
 export SGX_CREDENTIALS_PATH ?= $(FPC_PATH)/config/ias

--- a/config.mk
+++ b/config.mk
@@ -78,11 +78,10 @@ export FPC_PATH=$(abspath $(TOP))
 # re-defined to point to the FPC path as seen by the docker daemon
 export DOCKERD_FPC_PATH ?= $(FPC_PATH)
 
-# For testing Fabric binaries are needed; you can customize these via the following
+# Fabric binaries are needed for testing; you can customize these via the following
 # env variable. By default we fetch the binaries into $(FPC_PATH)/fabric/_internal/bin
+# In case you want to use your custom fabric bins, for instance: $(FABRIC_PATH)/build/bin
 export FABRIC_BIN_DIR ?= $(FPC_PATH)/fabric/_internal/bin
-# In case you want to your custom fabric bins, just point to your fabric path
-# export FABRIC_BIN_DIR ?= $(FABRIC_PATH)/build/bin
 
 # Additional SGX related settings
 #--------------------------------------------------

--- a/fabric/.gitignore
+++ b/fabric/.gitignore
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+_internal/*

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -11,8 +11,24 @@ FABRIC_PEER_BIN = $(FABRIC_PATH)/build/bin/peer
 FABRIC_PATCHED = $(FABRIC_PATH)/.fpc_patched
 FABRIC_CURRENT_DIFF_COMMITS_CMD = git log $(FABRIC_VERSION_TAG)..HEAD --oneline
 
-build: native
+FABS = _internal
+FABS_FETCHED = $(FABS)/.fetched
 
+build: fetch
+
+fetch: $(FABS_FETCHED)
+
+$(FABS_FETCHED):
+	mkdir -p $(FABS) && cd $(FABS) \
+	&& curl -sSL https://bit.ly/2ysbOFE | bash -s -- $(FABRIC_VERSION) 1.4.9 -s -d \
+	&& touch .fetched
+
+
+# this target applies all fabric patches in the patches folder;
+# these patches are not required for FPC but may be helpful for 
+# developers testing (e.g., residing behind a proxy environment)
+#
+# optional target
 patch: $(FABRIC_PATCHED)
 
 $(FABRIC_PATCHED): patches/*.patch $(FABRIC_PATH)/.git
@@ -76,14 +92,20 @@ $(FABRIC_PEER_BIN): $(FABRIC_PATCHED)
 	cd $(FABRIC_PATH) && \
         $(MAKE) peer
 
+# this target builds custom fabric binaries in the provided FABRIC_PATH
+# 
+# optional target
 native: peer
 	cd $(FABRIC_PATH) && \
 	$(MAKE) -j orderer cryptogen configtxgen
 
-clean: clean-native clean-patch
+clean: clean-fetched
 
 clean-peer:
 	rm -rf $(FABRIC_PEER_BIN)
 
 clean-native:
 	rm -rf $(FABRIC_PATH)/build/bin/
+
+clean-fetched:
+	rm -rf $(FABS)

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -99,7 +99,9 @@ native: peer
 	cd $(FABRIC_PATH) && \
 	$(MAKE) -j orderer cryptogen configtxgen
 
-clean: clean-fetched
+clean:
+
+clobber: clean-fetched
 
 clean-peer:
 	rm -rf $(FABRIC_PEER_BIN)

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -13,7 +13,7 @@ make
 ```
 
 # Build custom Fabric binaries
-
+The following assumes that the `FABRIC_PATH` environment variable contains the path to Fabric's source code.
 ```bash
 cd $FPC_PATH/fabric
 make native
@@ -21,7 +21,7 @@ make native
 
 Note that this applies all fabric code patches residing in `patches`.
 This is optional and not required in order to use FPC.
-
+To clean the native build, type `cd $FPC_PATH/fabric; make clean-native`.
 ## Common errors
 
 ### Wrong Fabric version

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -3,7 +3,7 @@ Licensed under Creative Commons Attribution 4.0 International License
 https://creativecommons.org/licenses/by/4.0/
 --->
 
-# Build Fabric with FPC support
+# Fetch default Fabric binaries
 
 Run the following command:
 
@@ -11,6 +11,16 @@ Run the following command:
 cd $FPC_PATH/fabric
 make
 ```
+
+# Build custom Fabric binaries
+
+```bash
+cd $FPC_PATH/fabric
+make native
+```
+
+Note that this applies all fabric code patches residing in `patches`.
+This is optional and not required in order to use FPC.
 
 ## Common errors
 

--- a/fabric/bin/lib/common_ledger.sh
+++ b/fabric/bin/lib/common_ledger.sh
@@ -12,7 +12,7 @@
 [ -d "${FPC_PATH}" ] || (echo "FPC_PATH not properly defined in '${FPC_PATH}'"; exit 1; )
 
 : ${FABRIC_PATH:="${FPC_PATH}/../../hyperledger/fabric/"}
-: ${FABRIC_BIN_DIR:="${FABRIC_PATH}/build/bin"}
+: ${FABRIC_BIN_DIR:="${FPC_PATH}/fabric/_internal/bin"}
 : ${FABRIC_UTIL_BIN_DIR:="${FPC_PATH}/utils/fabric"}
 
 FABRIC_SCRIPTDIR="${FPC_PATH}/fabric/bin/"

--- a/utils/docker/dev_peer_cc-builder/Dockerfile
+++ b/utils/docker/dev_peer_cc-builder/Dockerfile
@@ -116,7 +116,7 @@ ARG SGX_MODE
 # note these envs are _not_ inhereted from above as we start from base-rt !
 ARG FABRIC_PATH=${GOPATH}/${FABRIC_REL_PATH}
 ARG FPC_PATH=${GOPATH}/${FPC_REL_PATH}
-ARG FABRIC_BIN_DIR=${FABRIC_PATH}/build/bin
+ARG FABRIC_BIN_DIR=${FPC_PATH}/fabric/_internal/bin
 ARG FPC_CMDS=${FPC_PATH}/fabric/bin
 
 ENV FABRIC_PATH=${FABRIC_PATH}


### PR DESCRIPTION
- Update readme and remove statements telling the reader to patch fabric
- Remove fabric patch from default build path; patch targets are still available for custom use;
- Docker dev image still checkouts fabric repo
- By default fabric binaries are fetched into `fabric/_internal` and set in `config.mk`

Signed-off-by: Marcus brandenburger <bur@zurich.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our code of conduct and contributor guidelines: 
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/main/CONTRIBUTING.md
     https://github.com/hyperledger-labs/fabric-private-chaincode/blob/main/CODE_OF_CONDUCT.md
   In particular pay attention to the git workflows
      https://docs.google.com/document/d/1sR7YV3pSYN3NEFiW-2fUqtpsJeJrpC0EWUVtEm0Blcg/edit#heading=h.kwcug3pkefak
2. Fill out below sections.
3. Label the PR with the label of any component this PR touches.
4. ALso don't forget to sign your comments before submitting. 
   Github will complain if there is no DCO but it's easier if we don't have to hunt you down to fix that :-)

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
  list existing bug, feature and/or work-item which this PR addresses.
  You might also consider creating an issue first for the PR.
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing changes and/or breaks backward compatability?**:
<!--
  If no, you can delete this section
  If yes, describe what changes and/or what breaks ..
-->
```
